### PR TITLE
Skip controller sanity tests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -25,4 +25,4 @@ jobs:
       run: make bin
 
     - name: Test
-      run: go test -v -race ./pkg/...
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ bin:
 .PHONY: test
 test:
 	go test -v -race ./pkg/...
-	go test -v ./tests/sanity/...
+	# skipping controller test cases because we don't implement controller for static provisioning, this is a known limitation of sanity testing package: https://github.com/kubernetes-csi/csi-test/issues/214
+	go test -v ./tests/sanity/... -ginkgo.skip="ControllerGetCapabilities" -ginkgo.skip="ValidateVolumeCapabilities"
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
- Controller is optional (we do not implement / deploy it): https://kubernetes-csi.github.io/docs/developing.html?highlight=controller#capabilities
- Issue with sanity tests is known, probably its worth contributing to upstream, but also this'll become irrelevant once we develop dynamic provisioning

**Issues:** https://sim.amazon.com/issues/S3GATAT-2014
___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
