### PR TITLE
Changing helm chart for EKS addon

### DIFF
--- a/charts/aws-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-s3-csi-driver/templates/node.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
       containers:
         - name: s3-plugin
-          image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)


### PR DESCRIPTION
*Description of changes:*
* quick change to helm chart to get `containerRegistry` (used after onboarding to ARS)