### PR TITLE
Fix transient timeout error in sanity tests

### DIFF
--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
@@ -40,5 +41,7 @@ func (d *Driver) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCa
 }
 
 func (d *Driver) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	return &csi.ProbeResponse{}, nil
+	return &csi.ProbeResponse{
+		Ready: wrapperspb.Bool(true),
+	}, nil
 }


### PR DESCRIPTION
*Description of changes:*
Waiting for driver server to become up before running tests. This will fix frequent [test failures](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/6666860321/job/18119219896?pr=17#step:6:64) in CI.

*Testing:*
CI's error is reproducible by adding `time.Sleep(5 * time.Second)` before driver [start up](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/tests/sanity/sanity_test.go#L46).

___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
