### PR TITLE
Promote image for release branch

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release-**" ]
   pull_request:
     branches: [ "main" ]
 
@@ -72,11 +72,11 @@ jobs:
           tests/e2e-kubernetes/install.sh
       - name: Run E2E Tests
         run: make e2e E2E_KUBECONFIG=${{ env.KUBECONFIG }} E2E_COMMIT_ID=${{ env.COMMIT_ID }}
-      - name: Promote image
-        if: ${{ github.ref_name == 'main' }}
+      - name: Promote image for release branch
+        if: ${{ startsWith(github.ref_name, 'release') }}
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          export NEW_IMAGE_NAME=${REGISTRY}:${{ env.PROMOTED_IMAGE_NAME }}:${{ env.COMMIT_ID }}
-          docker tag ${REGISTRY}:${{ env.TMP_IMAGE_NAME }}:${{ env.COMMIT_ID }} ${NEW_IMAGE_NAME}
+          export NEW_IMAGE_NAME=${REGISTRY}/${{ env.PROMOTED_IMAGE_NAME }}:${{ env.COMMIT_ID }}
+          docker tag ${REGISTRY}/${{ env.TMP_IMAGE_NAME }}:${{ env.COMMIT_ID }} ${NEW_IMAGE_NAME}
           docker push ${NEW_IMAGE_NAME}


### PR DESCRIPTION
*Description of changes:*
- fix typo in image name: https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/6705204738/job/18219153887
- existing aws drivers create [branch](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/branches) for every new release, we should do the same (this allows adding changes to an old release, when the main branch has moved forward)

Updated runbook: https://quip-amazon.com/7vhWAjnsa5ax/Runbook-S3-CSI-Driver-Release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
