### PR TITLE
Fix release action and E2E on pre-created EKS

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -103,7 +103,7 @@ jobs:
           export CLUSTER_TYPE=${{ matrix.cluster-type }}
           tests/e2e-kubernetes/run.sh
       - name: Promote image for release branch
-        if: ${{ startsWith(github.ref_name, 'release') }}
+        if: ${{ startsWith(github.ref_name, 'release') && matrix.cluster-type == 'eksctl' }}
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |

--- a/tests/e2e-kubernetes/helm.sh
+++ b/tests/e2e-kubernetes/helm.sh
@@ -46,7 +46,7 @@ function helm_install_driver() {
     --set image.repository=${REPOSITORY} \
     --set image.tag=${TAG} \
     --set image.pullPolicy=Always \
-    --set node.serviceAccount.create=false \
+    --set node.serviceAccount.create=true \
     --kubeconfig ${KUBECONFIG}
   $KUBECTL_BIN rollout status daemonset s3-csi-node -n kube-system --timeout=60s --kubeconfig $KUBECONFIG
   $KUBECTL_BIN get pods -A --kubeconfig $KUBECONFIG


### PR DESCRIPTION
*Description of changes:*
- we need to promote image on release only once (there are 2 workflows - eks and kops, choosing eks)
- we need to create SA since it does not yet exist on an empty cluster 
___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
