### PR TITLE
Remove mountpoint stripping, hostPID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,6 @@ RUN MP_ARCH=`echo ${TARGETARCH} | sed s/amd64/x86_64/` && \
     gpg --verify mount-s3-${MOUNTPOINT_VERSION}-$MP_ARCH.tar.gz.asc && \
     mkdir -p /mountpoint-s3 && \
     tar -xvzf mount-s3-${MOUNTPOINT_VERSION}-$MP_ARCH.tar.gz -C /mountpoint-s3 && \
-    # strip debugging information to reduce binary size
-    strip --strip-debug /mountpoint-s3/bin/mount-s3 && \
     # set rpath for dynamic library loading
     patchelf --set-rpath '$ORIGIN' /mountpoint-s3/bin/mount-s3
 

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -19,7 +19,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      hostPID: true
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
       priorityClassName: system-node-critical
       tolerations:


### PR DESCRIPTION
Do not strip the mountpoint binary of debugging symbols. This can help aid in debugging of issues. Also remove hostPID from the helm chart, which is no longer needed after the removal of nsenter commands.
