### PR TITLE
Use IAM roles from github variables

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::239424963615:role/S3CSIDriverE2ETestsRole
+          role-to-assume: ${{ secrets.TEST_IAM_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
@@ -77,7 +77,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::239424963615:role/S3CSIDriverE2ETestsRole
+          role-to-assume: ${{ secrets.TEST_IAM_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
       - name: Install tools
         run: |
@@ -160,7 +160,7 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@master
       with:
-        role-to-assume: arn:aws:iam::239424963615:role/S3CSIDriverE2ETestsRole
+        role-to-assume: ${{ secrets.TEST_IAM_ROLE }}
         aws-region: ${{ env.AWS_REGION }}
     - name: Login to Amazon ECR
       id: login-ecr

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,6 @@ env:
   COMMIT_ID: ${{ github.sha }}
   GIT_TAG: ${{ github.ref_name }}
   IMAGE_NAME: "s3-csi-driver"
-  ARS_REGISTRY: "211164257204.dkr.ecr.us-west-2.amazonaws.com/eks/aws-s3-csi-driver"
   PUBLIC_REGISTRY: "public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver"
 jobs:
   build:
@@ -38,7 +37,7 @@ jobs:
       - name: Configure AWS Credentials from Test acccount
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::239424963615:role/S3CSIDriverE2ETestsRole
+          role-to-assume: ${{ secrets.TEST_IAM_ROLE }}
           aws-region: ${{ env.AWS_SRC_REGION }}
       - name: Login to Amazon ECR test
         id: login-ecr-test
@@ -46,7 +45,7 @@ jobs:
       - name: Configure AWS Credentials from Prod account
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::211164257204:role/S3CSIDriverPrivateImagePublisherRole
+          role-to-assume: ${{ secrets.PROD_IAM_IMAGE_ROLE }}
           aws-region: ${{ env.AWS_DEST_REGION }}
       - name: Login to Amazon ECR prod
         id: login-ecr-prod
@@ -57,8 +56,10 @@ jobs:
         with:
           registry-type: public
       - name: Promote image
+        env:
+          ARS_REGISTRY: ${{ secrets.ARS_REGISTRY }}
         run: |
-          crane copy ${{ steps.login-ecr-test.outputs.registry }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_ID }} ${{ env.ARS_REGISTRY }}:${{ env.GIT_TAG }}
+          crane copy ${{ steps.login-ecr-test.outputs.registry }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_ID }} ${ARS_REGISTRY}:${{ env.GIT_TAG }}
           crane copy ${{ steps.login-ecr-test.outputs.registry }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_ID }} ${{ env.PUBLIC_REGISTRY }}:${{ env.GIT_TAG }}
       - name: Create Release
         id: create-release

--- a/tests/e2e-kubernetes/README.md
+++ b/tests/e2e-kubernetes/README.md
@@ -1,6 +1,6 @@
 
 # Usage
-> To recreate EKS cluster used in CI (run locally using CI's AWS account): `ACTION=create_cluster AWS_REGION=us-east-1 CLUSTER_TYPE=eksctl CI_ROLE_ARN=arn:aws:iam::239424963615:role/S3CSIDriverE2ETestsRole tests/e2e-kubernetes/scripts/run.sh`
+> To recreate EKS cluster used in CI (run locally using CI's AWS account): `ACTION=create_cluster AWS_REGION=us-east-1 CLUSTER_TYPE=eksctl CI_ROLE_ARN=<TEST_IAM_ROLE> tests/e2e-kubernetes/scripts/run.sh`
 
 All of the following commands are expected to be executed from repo root:
 


### PR DESCRIPTION
*Description of changes:*
CI IAM roles are renamed and defined in github variables now
___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
