### PR TITLE
Allow GH actions to cut release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
*Description of changes:*
* Allow GH actions to cut release, was missing [permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
