### PR TITLE
Added new yaml manifest to Deployment kind that can scale pods using same PV

### DIFF
--- a/examples/kubernetes/static_provisioning/README.md
+++ b/examples/kubernetes/static_provisioning/README.md
@@ -6,7 +6,7 @@ This example shows how to make a static provisioned Mountpoint for S3 persistent
 - `non_root.yaml` - same as above, but the pod is spawned as non-root (uid `1000`, gid `2000`)
 - `s3_express_specify_az.yaml` - same as above, but this uses a [S3 Express One Zone](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-one-zone.html) directory bucket and shows how to specify the availability zone (AZ) of the [persistent volume](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) to co-locate the pods with the bucket for lower latency access
 - `multiple_buckets_one_pod.yaml` - same as above, with multiple buckets mounted in one pod. Note: when mounting multiple buckets in the same pod, the `volumeHandle` must be unique as specified in the [CSI documentation](https://kubernetes.io/docs/concepts/storage/volumes/#csi).
-
+- `multiple_pods_one_pv.yaml` - same as above, with multiple pods mounting the same persistent volume, in Deployment kind, that can be used to scale pods, using HPA or other method to create more replicas
 ## Configure
 ### Edit [Persistent Volume](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/examples/kubernetes/static_provisioning/static_provisioning.yaml)
 > Note: This example assumes your S3 bucket has already been created. If you need to create a bucket, follow the [S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html) for a general purpose bucket or the [S3 Express One Zone documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-create.html) for a directory bucket.

--- a/examples/kubernetes/static_provisioning/multiple_pods_one_pv.yaml
+++ b/examples/kubernetes/static_provisioning/multiple_pods_one_pv.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: s3-pv
+spec:
+  capacity:
+    storage: 1200Gi # ignored, required
+  accessModes:
+    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  mountOptions:
+    - allow-delete
+    - region us-east-1
+  csi:
+    driver: s3.csi.aws.com # required
+    volumeHandle: s3-csi-driver-volume
+    volumeAttributes:
+      bucketName: s3-csi-bucket-name
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-claim
+spec:
+  accessModes:
+    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # required for static provisioning
+  resources:
+    requests:
+      storage: 1200Gi # ignored, required
+  volumeName: s3-pv
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s3-app
+  labels:
+    app: s3-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: s3-app
+  template:
+    metadata:
+      labels:
+        app: s3-app
+    spec:
+      containers:
+      - name: s3-app
+        image: centos
+        command: ["/bin/sh"]
+        args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
+        volumeMounts:
+        - name: persistent-storage
+          mountPath: /data
+        ports:
+        - containerPort: 80
+      volumes:
+      - name: persistent-storage
+        persistentVolumeClaim:
+          claimName: s3-claim


### PR DESCRIPTION

*Issue #145 

- Added new yaml manifest to deploy a Deployment kind object, that creates a set of pod replicas using same PV to get access to bucket, allowing it to scale up and in your pods.
- Added this description into REAME file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

thanks