### PR TITLE
Add SELinux options for Bottlerocket

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -46,6 +46,14 @@ spec:
       initContainers:
         - name: install-mountpoint
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          {{- with .Values.node.seLinuxOptions }}
+          securityContext:
+            seLinuxOptions:
+              user: {{ .user }}
+              type: {{ .type }}
+              role: {{ .role }}
+              level: {{ .level }}
+          {{- end }}
           imagePullPolicy: IfNotPresent
           command:
             - "/bin/install-mp"
@@ -58,6 +66,14 @@ spec:
       containers:
         - name: s3-plugin
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          {{- with .Values.node.seLinuxOptions }}
+          securityContext:
+            seLinuxOptions:
+              user: {{ .user }}
+              type: {{ .type }}
+              role: {{ .role }}
+              level: {{ .level }}
+          {{- end }}
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -13,8 +13,11 @@ node:
   kubeletPath: /var/lib/kubelet
   mountpointInstallPath: /opt/mountpoint-s3-csi/bin/ # should end with "/"
   logLevel: 4
-  containerSecurityContext:
-    privileged: true
+  seLinuxOptions:
+    user: system_u
+    type: super_t
+    role: system_r
+    level: s0
   serviceAccount:
     # Specifies whether a service account should be created
     create: true

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -28,6 +28,12 @@ spec:
           tolerationSeconds: 300
       initContainers:
         - name: install-mountpoint
+          securityContext:
+            seLinuxOptions:
+              user: system_u
+              type: super_t
+              role: system_r
+              level: s0
           image: csi-driver
           imagePullPolicy: IfNotPresent
           command:
@@ -42,6 +48,11 @@ spec:
         - name: s3-plugin
           securityContext:
             privileged: false
+            seLinuxOptions:
+              user: system_u
+              type: super_t
+              role: system_r
+              level: s0
           image: csi-driver
           imagePullPolicy: IfNotPresent
           args:

--- a/examples/kubernetes/static_provisioning/static_provisioning.yaml
+++ b/examples/kubernetes/static_provisioning/static_provisioning.yaml
@@ -14,7 +14,7 @@ spec:
     driver: s3.csi.aws.com # required
     volumeHandle: s3-csi-driver-volume
     volumeAttributes:
-      bucketName: s3-csi-driver
+      bucketName: s3-csi-driver-test-jjk
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/examples/kubernetes/static_provisioning/static_provisioning.yaml
+++ b/examples/kubernetes/static_provisioning/static_provisioning.yaml
@@ -14,7 +14,7 @@ spec:
     driver: s3.csi.aws.com # required
     volumeHandle: s3-csi-driver-volume
     volumeAttributes:
-      bucketName: s3-csi-driver-test-jjk
+      bucketName: s3-csi-driver
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
*Issue #, if available:* #86

*Description of changes:* Add support for Bottlerocket OS. New versions of Bottlerocket are adding SELinux policies and directories to support installing the CSI driver and this PR adds SELinux labels to the containers to work with these changes. The install and node driver containers must run with the `super_t` SELinux user. The Bottlerocket policies are configured such that the installed files will automatically get the correct labels applied, so it turns out there is no relabeling required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
