### PR TITLE
Replace HOST_TOKEN_DIR environment variable by HOST_PLUGIN_DIR

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -91,8 +91,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: HOST_TOKEN_DIR
-              value: {{ trimSuffix "/" .Values.node.kubeletPath }}/plugins/s3.csi.aws.com/
             - name: HOST_PLUGIN_DIR
               value: {{ trimSuffix "/" .Values.node.kubeletPath }}/plugins/s3.csi.aws.com/
             {{- with .Values.awsAccessSecret }}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -91,6 +91,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: HOST_TOKEN_DIR
+              value: {{ trimSuffix "/" .Values.node.kubeletPath }}/plugins/s3.csi.aws.com/
             - name: HOST_PLUGIN_DIR
               value: {{ trimSuffix "/" .Values.node.kubeletPath }}/plugins/s3.csi.aws.com/
             {{- with .Values.awsAccessSecret }}

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -9,7 +9,6 @@ image:
   tag: "v1.4.0"
 
 node:
-  resources: {}
   kubeletPath: /var/lib/kubelet
   mountpointInstallPath: /opt/mountpoint-s3-csi/bin/ # should end with "/"
   logLevel: 4

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -32,9 +32,9 @@ import (
 )
 
 const (
-	hostTokenDirEnv = "HOST_TOKEN_DIR"
-	fstype          = "unused"
-	bucketName      = "bucketName"
+	hostPluginDirEnv = "HOST_PLUGIN_DIR"
+	fstype           = "unused"
+	bucketName       = "bucketName"
 )
 
 var (
@@ -110,12 +110,12 @@ func (ns *S3NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 	}
 
 	klog.V(4).Infof("NodePublishVolume: mounting %s at %s with options %v", bucket, target, mountpointArgs)
-	hostTokenDir := os.Getenv(hostTokenDirEnv)
-	if hostTokenDir == "" {
+	hostPluginDir := os.Getenv(hostPluginDirEnv)
+	if hostPluginDir == "" {
 		// set the default in case the env variable isn't found
-		hostTokenDir = "/var/lib/kubelet/plugins/s3.csi.aws.com/"
+		hostPluginDir = "/var/lib/kubelet/plugins/s3.csi.aws.com/"
 	}
-	hostTokenPath := path.Join(hostTokenDir, "token")
+	hostTokenPath := path.Join(hostPluginDir, "token")
 	credentials := &MountCredentials{
 		AccessKeyID:     os.Getenv(keyIdEnv),
 		SecretAccessKey: os.Getenv(accessKeyEnv),


### PR DESCRIPTION
*Description of changes:*

* Remove duplicated empty node.resources values.
* The Helm chart and Kubernetes manifest are set up to use HOST_PLUGIN_DIR, but the mountpoint-s3-csi-driver utilizes HOST_TOKEN_DIR. Since HOST_PLUGIN_DIR and HOST_TOKEN_DIR serve the same purpose, we are replacing HOST_TOKEN_DIR with HOST_PLUGIN_DIR to standardize the configuration.

Tested in onPrem K8S lab (with IRSA), deployed with [K0S](https://github.com/k0sproject/k0s).