### PR TITLE
Run unit tests as root in Github actions

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,4 +24,4 @@ jobs:
       run: make bin
 
     - name: Test
-      run: make test
+      run: sudo make test

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,4 +24,5 @@ jobs:
       run: make bin
 
     - name: Test
+      # Run tests as root as we require it for systemd tests
       run: sudo make test


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Run unit tests as root as part of the CI. Previously, some tests weren't running because they had an ['is running as root' check](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/8938019603/job/24551349632?pr=193#step:8:78).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
