### PR TITLE
Add prefix to static_provisioning example

### DIFF
--- a/examples/kubernetes/static_provisioning/static_provisioning.yaml
+++ b/examples/kubernetes/static_provisioning/static_provisioning.yaml
@@ -10,6 +10,7 @@ spec:
   mountOptions:
     - allow-delete
     - region us-west-2
+    - prefix some-s3-prefix/
   csi:
     driver: s3.csi.aws.com # required
     volumeHandle: s3-csi-driver-volume


### PR DESCRIPTION
*Issue #, if available:* #198

*Description of changes:*

This change simply adds a prefix to the main static provisioning example. We did not have an example to share in #198. The prefix doesn't need to already exist.

Tested by deploying the PV and example pod (replacing bucket name), getting a shell in the pod and touching a file named `using-s3-csi-with-prefix-arg.txt`, and checking files are created as expected.

```
❯ aws s3 ls --recursive s3://DOC-EXAMPLE-BUCKET/
2024-05-15 14:16:34         26 some-s3-prefix/Wed May 15 13:16:32 UTC 2024.txt
2024-05-15 14:21:55          0 some-s3-prefix/using-s3-csi-with-prefix-arg.txt
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
