### PR TITLE
Fix unit test workflow when running from forks

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -7,8 +7,7 @@ on:
     branches: [ "main", "feature/*" ]
 
 permissions:
-  id-token: write
-  contents: read
+  pull-requests: write
 
 jobs:
   build:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -3,8 +3,12 @@ name: Unit tests
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  pull_request_target:
+    branches: [ "main", "feature/*" ]
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   build:
@@ -44,7 +48,7 @@ jobs:
         path: cover.html
 
     - name: Comment test coverage
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request_target' }}
       uses: actions/github-script@v7
       env:
         TOTAL_COVERAGE: ${{ steps.go-test-coverage.outputs.total-coverage }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request_target:
-    branches: [ "main", "feature/*" ]
+    branches: [ "main" ]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* https://github.com/awslabs/mountpoint-s3-csi-driver/pull/199 has it's unit test workflow fail due to being created from a forked repository. This is due to `pull_request` having reduced permissions given when running from forked repositories. Using `pull_request_target` runs from the context of the fork, and still allows us to post comments to the PR. The unit test workflow doesn't make use of any AWS resources, so this is a trivial change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
