### PR TITLE
Missing node.serviceAccount.annotations in values.yaml

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -22,6 +22,9 @@ node:
     # Specifies whether a service account should be created
     create: true
     name: s3-csi-driver-sa
+    annotations:
+      ## Specify the SA's role ARN
+      # "eks.amazonaws.com/role-arn": ""
   nodeSelector: {}
   resources:
     requests:

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -22,9 +22,9 @@ node:
     # Specifies whether a service account should be created
     create: true
     name: s3-csi-driver-sa
-    annotations:
-      ## Specify the SA's role ARN. Otherwise the the driver will be "Forbidden" from accessing s3 buckets
-      "eks.amazonaws.com/role-arn": ""
+    # Specify the SA's role ARN if running in EKS. Otherwise, the the driver will be "Forbidden" from accessing s3 buckets
+    # annotations:
+      # "eks.amazonaws.com/role-arn": ""
   nodeSelector: {}
   resources:
     requests:

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -23,8 +23,8 @@ node:
     create: true
     name: s3-csi-driver-sa
     annotations:
-      ## Specify the SA's role ARN
-      # "eks.amazonaws.com/role-arn": ""
+      ## Specify the SA's role ARN. Otherwise the the driver will be "Forbidden" from accessing s3 buckets
+      "eks.amazonaws.com/role-arn": ""
   nodeSelector: {}
   resources:
     requests:

--- a/docs/install.md
+++ b/docs/install.md
@@ -114,6 +114,14 @@ helm upgrade --install aws-mountpoint-s3-csi-driver \
     aws-mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
 ```
 
+> [!NOTE]
+> For EKS users, you need to pass your Role ARN here if you're using IAM roles for service accounts:
+> 
+> $ helm upgrade --install aws-mountpoint-s3-csi-driver \
+>    --namespace kube-system \
+>    --set node.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::account:role/csi-driver-role-name" \
+>    aws-mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver 
+
 Review the [configuration values](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/charts/aws-mountpoint-s3-csi-driver/values.yaml) for the Helm chart.
 
 #### Once the driver has been deployed, verify the pods are running:

--- a/docs/install.md
+++ b/docs/install.md
@@ -117,10 +117,12 @@ helm upgrade --install aws-mountpoint-s3-csi-driver \
 > [!NOTE]
 > For EKS users, you need to pass your Role ARN here if you're using IAM roles for service accounts:
 > 
+> ```bash
 > $ helm upgrade --install aws-mountpoint-s3-csi-driver \
 >    --namespace kube-system \
 >    --set node.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::account:role/csi-driver-role-name" \
 >    aws-mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver 
+> ```
 
 Review the [configuration values](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/charts/aws-mountpoint-s3-csi-driver/values.yaml) for the Helm chart.
 


### PR DESCRIPTION
*Issue #, if available:*
564
*Description of changes:*
Added a default annotation for the SA.
ref.: https://github.com/awslabs/mountpoint-s3-csi-driver/issues/173#issuecomment-2209120237

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
