### PR TITLE
Move Linux specific code for Pts to `pts_linux.go`

### DIFF
--- a/pkg/system/pts.go
+++ b/pkg/system/pts.go
@@ -2,12 +2,7 @@
 package system
 
 import (
-	"fmt"
 	"io"
-	"os"
-	"unsafe"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -18,48 +13,4 @@ const (
 // Interface for creating new private terminal session. See man pts(4)
 type Pts interface {
 	NewPts() (io.ReadCloser, int, error)
-}
-
-// Real os implementation of the Pts interface
-type OsPts struct{}
-
-func NewOsPts() Pts {
-	return &OsPts{}
-}
-
-// Create a new pseudo terminal (pts). Returns a ReaderCloser for the master device and a pts number
-func (p *OsPts) NewPts() (io.ReadCloser, int, error) {
-	ptmxPath := os.Getenv(PtmxPathEnv)
-	if ptmxPath == "" {
-		ptmxPath = DefaultPtmxPath
-	}
-	ptsMaster, err := os.Open(ptmxPath)
-	if err != nil {
-		return nil, 0, fmt.Errorf("Failed to open tty: %w", err)
-	}
-	success := false
-	defer func() {
-		if !success {
-			ptsMaster.Close()
-		}
-	}()
-	// grantpt ioctl to allow mount-s3 process access to the pts
-	var n uintptr // dummy int for ioctl
-	if err = unix.IoctlSetInt(int(ptsMaster.Fd()), unix.TIOCGPTN, int(uintptr(unsafe.Pointer(&n)))); err != nil {
-		return nil, 0, fmt.Errorf("Failed grantpt: %w", err)
-	}
-	n = 0
-	// unlockpt ioctl
-	err = unix.IoctlSetInt(int(ptsMaster.Fd()), unix.TIOCSPTLCK, int(uintptr(unsafe.Pointer(&n))))
-	if err != nil {
-		return nil, 0, fmt.Errorf("Failed unlockpt: %w", err)
-	}
-	// ptsname ioctl to get pts path for systemd
-	ptsN, err := unix.IoctlGetInt(int(ptsMaster.Fd()), unix.TIOCGPTN)
-	if err != nil {
-		return nil, 0, fmt.Errorf("Failed to get ptsname: %w", err)
-	}
-
-	success = true
-	return ptsMaster, ptsN, err
 }

--- a/pkg/system/pts_darwin.go
+++ b/pkg/system/pts_darwin.go
@@ -1,0 +1,8 @@
+package system
+
+// OsPts is the mock Darwin implementation of the Pts interface.
+type OsPts struct{}
+
+func NewOsPts() Pts {
+	panic("not supported on darwin")
+}

--- a/pkg/system/pts_linux.go
+++ b/pkg/system/pts_linux.go
@@ -1,0 +1,54 @@
+package system
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// OsPts is the Linux implementation of the Pts interface.
+type OsPts struct{}
+
+func NewOsPts() Pts {
+	return &OsPts{}
+}
+
+// Create a new pseudo terminal (pts). Returns a ReaderCloser for the master device and a pts number
+func (p *OsPts) NewPts() (io.ReadCloser, int, error) {
+	ptmxPath := os.Getenv(PtmxPathEnv)
+	if ptmxPath == "" {
+		ptmxPath = DefaultPtmxPath
+	}
+	ptsMaster, err := os.Open(ptmxPath)
+	if err != nil {
+		return nil, 0, fmt.Errorf("Failed to open tty: %w", err)
+	}
+	success := false
+	defer func() {
+		if !success {
+			ptsMaster.Close()
+		}
+	}()
+	// grantpt ioctl to allow mount-s3 process access to the pts
+	var n uintptr // dummy int for ioctl
+	if err = unix.IoctlSetInt(int(ptsMaster.Fd()), unix.TIOCGPTN, int(uintptr(unsafe.Pointer(&n)))); err != nil {
+		return nil, 0, fmt.Errorf("Failed grantpt: %w", err)
+	}
+	n = 0
+	// unlockpt ioctl
+	err = unix.IoctlSetInt(int(ptsMaster.Fd()), unix.TIOCSPTLCK, int(uintptr(unsafe.Pointer(&n))))
+	if err != nil {
+		return nil, 0, fmt.Errorf("Failed unlockpt: %w", err)
+	}
+	// ptsname ioctl to get pts path for systemd
+	ptsN, err := unix.IoctlGetInt(int(ptsMaster.Fd()), unix.TIOCGPTN)
+	if err != nil {
+		return nil, 0, fmt.Errorf("Failed to get ptsname: %w", err)
+	}
+
+	success = true
+	return ptsMaster, ptsN, err
+}

--- a/pkg/system/pts_test.go
+++ b/pkg/system/pts_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package system_test
 
 import (


### PR DESCRIPTION
This allows us to build and test our code on macOS for local development. With this change, `make test` works on macOS.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
