### PR TITLE
Add cluster role to helm service account definition

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-node.yaml
@@ -13,4 +13,32 @@ metadata:
 {{- if .Values.node.serviceAccount.automountServiceAccountToken }}
 automountServiceAccountToken: {{ .Values.node.serviceAccount.automountServiceAccountToken }}
 {{- end }}
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-cluster-role
+  labels:
+    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mountpoint-s3-csi-node-binding
+  labels:
+    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.node.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: s3-csi-driver-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+
 {{- end -}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes permission issue where the driver's service role was unable to get service account information


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
