### PR TITLE
Add retry to reading `/proc/mounts`

### DIFF
--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -176,12 +176,12 @@ func (pml *ProcMountLister) ListMounts() ([]mount.MountPoint, error) {
 		mounts, err = os.ReadFile(pml.ProcMountPath)
 		if err == nil {
 			if i > 1 {
-				klog.V(4).Info(err, "Successfully read %s after %d retry", pml.ProcMountPath, i)
+				klog.V(4).Infof("Successfully read %s after %d retries", pml.ProcMountPath, i)
 			}
 			break
 		}
 
-		klog.V(4).ErrorS(err, "Failed to read %s on try %d", pml.ProcMountPath, i)
+		klog.Errorf("Failed to read %s on try %d: %v", pml.ProcMountPath, i, err)
 		time.Sleep(procMountsReadRetryBackoff)
 	}
 

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -181,7 +181,7 @@ func (pml *ProcMountLister) ListMounts() ([]mount.MountPoint, error) {
 			break
 		}
 
-		klog.V(4).ErrorS(err, "Failed to read %s on %d try", pml.ProcMountPath, i)
+		klog.V(4).ErrorS(err, "Failed to read %s on try %d", pml.ProcMountPath, i)
 		time.Sleep(procMountsReadRetryBackoff)
 	}
 


### PR DESCRIPTION
Until we find the root cause of why reading `/proc/mounts` on newly spawned Karpenter/GPU nodes fails, we're adding retry mechanism to reading `/proc/mounts` as people reported that reading `/proc/mounts` works after retries. See  https://github.com/awslabs/mountpoint-s3-csi-driver/issues/174

This originally contributed by @Shellmode, but since our CI is not properly set up yet, the original PR didn't triggered the CI. This PR is from a branch, and it should properly trigger the CI.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
