### PR TITLE
Pod-level identity improvements

### DIFF
--- a/pkg/driver/credential.go
+++ b/pkg/driver/credential.go
@@ -230,13 +230,9 @@ func (c *CredentialProvider) stsRegion(volumeContext map[string]string, mountpoi
 		return region, nil
 	}
 
-	for _, arg := range mountpointArgs {
-		// we normalize all `mountpointArgs` to have `--arg=val` in `S3NodeServer.NodePublishVolume`
-		if strings.HasPrefix(arg, "--region=") {
-			region = strings.SplitN(arg, "=", 2)[1]
-			klog.V(5).Infof("NodePublishVolume: Pod-level: Detected STS region %s from S3 bucket region", region)
-			return region, nil
-		}
+	if region, ok := ExtractMountpointArgument(mountpointArgs, mountpointArgRegion); ok {
+		klog.V(5).Infof("NodePublishVolume: Pod-level: Detected STS region %s from S3 bucket region", region)
+		return region, nil
 	}
 
 	region = os.Getenv(regionEnv)

--- a/pkg/driver/credential.go
+++ b/pkg/driver/credential.go
@@ -160,6 +160,17 @@ func (c *CredentialProvider) provideFromPod(ctx context.Context, volumeID string
 		StsEndpoints:  os.Getenv(stsEndpointsEnv),
 		WebTokenPath:  hostTokenPath,
 		AwsRoleArn:    awsRoleARN,
+
+		// Ensure to disable env credential provider
+		AccessKeyID:     "",
+		SecretAccessKey: "",
+
+		// Ensure to disable profile provider
+		ConfigFilePath:            path.Join(hostPluginDir, "disable-config"),
+		SharedCredentialsFilePath: path.Join(hostPluginDir, "disable-credentials"),
+
+		// Ensure to disable IMDS provider
+		DisableIMDSProvider: true,
 	}, nil
 }
 

--- a/pkg/driver/credential_test.go
+++ b/pkg/driver/credential_test.go
@@ -95,14 +95,25 @@ func TestProvidingPodLevelCredentials(t *testing.T) {
 	}, nil)
 	assertEquals(t, nil, err)
 
+	// Should disable env variable provider
 	assertEquals(t, credentials.AccessKeyID, "")
 	assertEquals(t, credentials.SecretAccessKey, "")
 	assertEquals(t, credentials.SessionToken, "")
+
+	// Should disable profile provider
+	assertEquals(t, credentials.ConfigFilePath, "/test/csi/plugin/dir/disable-config")
+	assertEquals(t, credentials.SharedCredentialsFilePath, "/test/csi/plugin/dir/disable-credentials")
+
+	// Should disable IMDS provider
+	assertEquals(t, credentials.DisableIMDSProvider, true)
+
+	// Should populate env variables for STS Web Identity provider
+	assertEquals(t, credentials.WebTokenPath, "/test/csi/plugin/dir/test-pod-test-vol-id.token")
+	assertEquals(t, credentials.AwsRoleArn, "arn:aws:iam::123456789012:role/Test")
+
 	assertEquals(t, credentials.Region, "eu-west-1")
 	assertEquals(t, credentials.DefaultRegion, "eu-north-1")
-	assertEquals(t, credentials.WebTokenPath, "/test/csi/plugin/dir/test-pod-test-vol-id.token")
 	assertEquals(t, credentials.StsEndpoints, "regional")
-	assertEquals(t, credentials.AwsRoleArn, "arn:aws:iam::123456789012:role/Test")
 
 	token, err := os.ReadFile(tokenFilePath(credentials, pluginDir))
 	assertEquals(t, nil, err)

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -409,3 +409,20 @@ func parseProcMounts(data []byte) ([]mount.MountPoint, error) {
 
 	return mounts, nil
 }
+
+const (
+	mountpointArgRegion = "region"
+)
+
+// ExtractMountpointArgument extracts value of a given argument from `mountpointArgs`.
+func ExtractMountpointArgument(mountpointArgs []string, argument string) (string, bool) {
+	// `mountpointArgs` normalized to `--arg=val` in `S3NodeServer.NodePublishVolume`.
+	prefix := fmt.Sprintf("--%s=", argument)
+	for _, arg := range mountpointArgs {
+		if strings.HasPrefix(arg, prefix) {
+			val := strings.SplitN(arg, "=", 2)[1]
+			return val, true
+		}
+	}
+	return "", false
+}

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -309,8 +309,6 @@ func (m *S3Mounter) Mount(bucketName string, target string,
 	options, env = moveOptionToEnvironmentVariables(awsMaxAttemptsOption, awsMaxAttemptsEnv, options, env)
 	options = addUserAgentToOptions(options, UserAgent(m.kubernetesVersion))
 
-	klog.V(4).Infof("FIXME: MP env (with credentials): %v", env)
-
 	output, err := m.Runner.StartService(timeoutCtx, &system.ExecConfig{
 		Name:        "mount-s3-" + m.MpVersion + "-" + uuid.New().String() + ".service",
 		Description: "Mountpoint for Amazon S3 CSI driver FUSE daemon",

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -412,6 +412,7 @@ func parseProcMounts(data []byte) ([]mount.MountPoint, error) {
 
 const (
 	mountpointArgRegion = "region"
+	mountpointArgCache  = "cache"
 )
 
 // ExtractMountpointArgument extracts value of a given argument from `mountpointArgs`.

--- a/pkg/driver/mount_test.go
+++ b/pkg/driver/mount_test.go
@@ -316,3 +316,38 @@ func TestProvidingEnvVariablesForMountpointProcess(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractMountpointArgument(t *testing.T) {
+	for name, test := range map[string]struct {
+		input           []string
+		argument        string
+		expectedToFound bool
+		expectedValue   string
+	}{
+		"Extract Existing Argument": {
+			input: []string{
+				"--region=us-east-1",
+			},
+			argument:        "region",
+			expectedToFound: true,
+			expectedValue:   "us-east-1",
+		},
+		"Extract Non Existing Argument": {
+			input: []string{
+				"--bucket=test",
+			},
+			argument:        "region",
+			expectedToFound: false,
+		},
+		"Extract Non Existing Argument With Empty Input": {
+			argument:        "region",
+			expectedToFound: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			val, found := driver.ExtractMountpointArgument(test.input, test.argument)
+			assertEquals(t, test.expectedToFound, found)
+			assertEquals(t, test.expectedValue, val)
+		})
+	}
+}

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -243,50 +243,87 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 	// we shouldn't run them in parallel with other tests.
 	//                        |
 	//                      ------
-	Describe("Credentials", Serial, func() {
-		Describe("Driver Level", Ordered, func() {
-			var afterAllCleanup []func(context.Context) error
+	Describe("Credentials", Serial, Ordered, func() {
+		cleanClusterWideResources := func(ctx context.Context) {
+			// Since we're using cluster-wide resources and we're running multiple tests in the same cluster,
+			// we need to clean up all credential related resources before each test to ensure we've a
+			// clean starting point in each test.
+			By("Cleaning up cluster-wide resources")
 
-			cleanClusterWideResources := func(ctx context.Context) {
-				// Since we're using cluster-wide resources and we're running multiple tests in the same cluster,
-				// we need to clean up all credential related resources before each test to ensure we've a
-				// clean starting point in each test.
-				By("Cleaning up cluster-wide resources")
+			sa := csiDriverServiceAccount(ctx, f)
+			overrideServiceAccountRole(ctx, f, sa, "")
 
-				sa := csiDriverServiceAccount(ctx, f)
-				overrideServiceAccountRole(ctx, f, sa, "")
+			framework.ExpectNoError(deleteCredentialSecret(ctx, f))
 
-				framework.ExpectNoError(deleteCredentialSecret(ctx, f))
+			// Trigger recreation of our pods to ensure they're not using deleted resources
+			killCSIDriverPods(ctx, f)
+		}
 
-				// Trigger recreation of our pods to ensure they're not using deleted resources
-				killCSIDriverPods(ctx, f)
+		var (
+			afterAllCleanup   []func(context.Context) error
+			oidcProvider      string
+			policyRoleMapping = map[string]*iamtypes.Role{}
+		)
+
+		BeforeAll(func(ctx context.Context) {
+			oidcProvider = oidcProviderForCluster(ctx, f)
+
+			By("Pre-creating IAM roles for common policies")
+			for _, policyARN := range []string{
+				iamPolicyS3FullAccess,
+				iamPolicyS3ReadOnlyAccess,
+				iamPolicyS3NoAccess,
+			} {
+				role, removeRole := createRole(ctx, f, assumeRolePolicyDocument(ctx), policyARN)
+				policyRoleMapping[policyARN] = role
+				afterAllCleanup = append(afterAllCleanup, removeRole)
 			}
+		})
 
-			policyRoleMapping := map[string]*iamtypes.Role{}
-			BeforeAll(func(ctx context.Context) {
-				By("Pre-creating IAM roles for common policies")
-				for _, policyARN := range []string{
-					iamPolicyS3FullAccess,
-					iamPolicyS3ReadOnlyAccess,
-					iamPolicyS3NoAccess,
-				} {
-					role, removeRole := createRole(ctx, f, assumeRolePolicyDocument(ctx), policyARN)
-					policyRoleMapping[policyARN] = role
-					afterAllCleanup = append(afterAllCleanup, removeRole)
-				}
-			})
+		AfterAll(func(ctx context.Context) {
+			By("Cleaning up resources created for credential tests")
+			cleanClusterWideResources(ctx)
 
-			AfterAll(func(ctx context.Context) {
-				By("Cleaning up resources created for Driver-level tests")
-				cleanClusterWideResources(ctx)
+			var errs []error
+			for _, f := range afterAllCleanup {
+				errs = append(errs, f(ctx))
+			}
+			framework.ExpectNoError(errors.NewAggregate(errs), "while cleanup global resource")
+		})
 
-				var errs []error
-				for _, f := range afterAllCleanup {
-					errs = append(errs, f(ctx))
-				}
-				framework.ExpectNoError(errors.NewAggregate(errs), "while cleanup global resource")
-			})
+		updateCSIDriversServiceAccountRole := func(ctx context.Context, policyARN string) {
+			By("Updating CSI Driver's Service Account Role")
+			sa := csiDriverServiceAccount(ctx, f)
 
+			role, removeRole := createRole(ctx, f, assumeRoleWithWebIdentityPolicyDocument(ctx, oidcProvider, sa), policyARN)
+			deferCleanup(removeRole)
+
+			sa, restoreServiceAccountRole := overrideServiceAccountRole(ctx, f, sa, *role.Arn)
+			deferCleanup(restoreServiceAccountRole)
+
+			waitUntilRoleIsAssumableWithWebIdentity(ctx, f, sa)
+
+			// Trigger recreation of our pods to use the new IAM role
+			killCSIDriverPods(ctx, f)
+		}
+
+		updateDriverLevelCredentials := func(ctx context.Context, policyARN string) {
+			By("Updating Kubernetes Secret with temporary credentials")
+
+			role, ok := policyRoleMapping[policyARN]
+			if !ok {
+				framework.Failf("Missing role mapping for policy %s", policyARN)
+			}
+			assumeRoleOutput := assumeRole(ctx, f, *role.Arn)
+
+			_, deleteSecret := createCredentialSecret(ctx, f, assumeRoleOutput.Credentials)
+			deferCleanup(deleteSecret)
+
+			// Trigger recreation of our pods to use the new credentials
+			killCSIDriverPods(ctx, f)
+		}
+
+		Describe("Driver Level", Ordered, func() {
 			BeforeEach(func(ctx context.Context) {
 				cleanClusterWideResources(ctx)
 			})
@@ -301,77 +338,45 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 			})
 
 			Context("IAM Roles for Service Accounts (IRSA)", Ordered, func() {
-				var oidcProvider string
 				BeforeAll(func(ctx context.Context) {
-					oidcProvider = oidcProviderForCluster(ctx, f)
 					if oidcProvider == "" {
 						Skip("OIDC provider is not configured, skipping IRSA tests")
 					}
 				})
 
-				updateServiceAccountRole := func(ctx context.Context, policyARN string) {
-					By("Updating CSI Driver's Service Account Role")
-					sa := csiDriverServiceAccount(ctx, f)
-
-					role, removeRole := createRole(ctx, f, assumeRoleWithWebIdentityPolicyDocument(ctx, oidcProvider, sa), policyARN)
-					deferCleanup(removeRole)
-
-					_, restoreServiceAccountRole := overrideServiceAccountRole(ctx, f, sa, *role.Arn)
-					deferCleanup(restoreServiceAccountRole)
-
-					// Trigger recreation of our pods to use the new IAM role
-					killCSIDriverPods(ctx, f)
-				}
-
 				It("should use service account's read-only role", func(ctx context.Context) {
-					updateServiceAccountRole(ctx, iamPolicyS3ReadOnlyAccess)
+					updateCSIDriversServiceAccountRole(ctx, iamPolicyS3ReadOnlyAccess)
 					pod := createPodWithVolume(ctx)
 					expectReadOnly(pod)
 				})
 
 				It("should use service account's full access role", func(ctx context.Context) {
-					updateServiceAccountRole(ctx, iamPolicyS3FullAccess)
+					updateCSIDriversServiceAccountRole(ctx, iamPolicyS3FullAccess)
 					pod := createPodAllowsDelete(ctx)
 					expectFullAccess(pod)
 				})
 
 				It("should fail to mount if service account's role does not allow s3::ListObjectsV2", func(ctx context.Context) {
-					updateServiceAccountRole(ctx, iamPolicyS3NoAccess)
+					updateCSIDriversServiceAccountRole(ctx, iamPolicyS3NoAccess)
 					expectFailToMount(ctx, "")
 				})
 			})
 
 			Context("Credentials via Kubernetes Secrets", func() {
-				updateCredentials := func(ctx context.Context, policyARN string) {
-					By("Updating Kubernetes Secret with temporary credentials")
-
-					role, ok := policyRoleMapping[policyARN]
-					if !ok {
-						framework.Failf("Missing role mapping for policy %s", policyARN)
-					}
-					assumeRoleOutput := assumeRole(ctx, f, *role.Arn)
-
-					_, deleteSecret := createCredentialSecret(ctx, f, assumeRoleOutput.Credentials)
-					deferCleanup(deleteSecret)
-
-					// Trigger recreation of our pods to use the new credentials
-					killCSIDriverPods(ctx, f)
-				}
-
 				It("should use read-only access aws credentials", func(ctx context.Context) {
-					updateCredentials(ctx, iamPolicyS3ReadOnlyAccess)
+					updateDriverLevelCredentials(ctx, iamPolicyS3ReadOnlyAccess)
 					pod := createPodWithVolume(ctx)
 					expectReadOnly(pod)
 				})
 
 				It("should use full access aws credentials", func(ctx context.Context) {
-					updateCredentials(ctx, iamPolicyS3FullAccess)
+					updateDriverLevelCredentials(ctx, iamPolicyS3FullAccess)
 					pod := createPodAllowsDelete(ctx)
 					expectFullAccess(pod)
 				})
 
 				It("should fail to mount if aws credentials does not allow s3::ListObjectsV2", func(ctx context.Context) {
-					updateCredentials(ctx, iamPolicyS3NoAccess)
+					updateDriverLevelCredentials(ctx, iamPolicyS3NoAccess)
 					expectFailToMount(ctx, "")
 				})
 			})
@@ -387,9 +392,7 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 			}
 
 			Context("IAM Roles for Service Accounts (IRSA)", Ordered, func() {
-				var oidcProvider string
 				BeforeAll(func(ctx context.Context) {
-					oidcProvider = oidcProviderForCluster(ctx, f)
 					if oidcProvider == "" {
 						Skip("OIDC provider is not configured, skipping IRSA tests")
 					}
@@ -486,16 +489,14 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				})
 
 				It("should not use csi driver's service account tokens", func(ctx context.Context) {
-					driverSA := csiDriverServiceAccount(ctx, f)
+					updateCSIDriversServiceAccountRole(ctx, iamPolicyS3FullAccess)
 
-					driverRole, removeDriverRole := createRole(ctx, f, assumeRoleWithWebIdentityPolicyDocument(ctx, oidcProvider, driverSA), iamPolicyS3FullAccess)
-					deferCleanup(removeDriverRole)
+					pod, _ := createPodWithServiceAccountAndPolicy(ctx, iamPolicyS3ReadOnlyAccess, true)
+					expectReadOnly(pod)
+				})
 
-					_, restoreDriverSA := overrideServiceAccountRole(ctx, f, driverSA, *driverRole.Arn)
-					deferCleanup(restoreDriverSA)
-
-					// Trigger recreation of CSI driver pods to use the new IAM role
-					killCSIDriverPods(ctx, f)
+				It("should not use driver-level kubernetes secrets", func(ctx context.Context) {
+					updateDriverLevelCredentials(ctx, iamPolicyS3FullAccess)
 
 					pod, _ := createPodWithServiceAccountAndPolicy(ctx, iamPolicyS3ReadOnlyAccess, true)
 					expectReadOnly(pod)
@@ -527,16 +528,7 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				})
 
 				It("should not use pod's service account's role if 'authenticationSource' is 'driver'", func(ctx context.Context) {
-					driverSA := csiDriverServiceAccount(ctx, f)
-
-					driverRole, removeDriverRole := createRole(ctx, f, assumeRoleWithWebIdentityPolicyDocument(ctx, oidcProvider, driverSA), iamPolicyS3ReadOnlyAccess)
-					deferCleanup(removeDriverRole)
-
-					_, restoreDriverSA := overrideServiceAccountRole(ctx, f, driverSA, *driverRole.Arn)
-					deferCleanup(restoreDriverSA)
-
-					// Trigger recreation of CSI driver pods to use the new IAM role
-					killCSIDriverPods(ctx, f)
+					updateDriverLevelCredentials(ctx, iamPolicyS3ReadOnlyAccess)
 
 					vol := createVolumeResourceWithMountOptions(enableDriverLevelIdentity(ctx), l.config, pattern, []string{"allow-delete"})
 					deferCleanup(vol.CleanupResource)
@@ -772,9 +764,17 @@ func overrideServiceAccountRole(ctx context.Context, f *framework.Framework, sa 
 	framework.ExpectNoError(err)
 
 	return sa, func(ctx context.Context) error {
+		sa, err := client.Get(ctx, sa.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
 		framework.Logf("Restoring ServiceAccount %s's role", sa.Name)
 		annotateServiceAccountWithRole(sa, originalRoleARN)
-		_, err := client.Update(ctx, sa, metav1.UpdateOptions{})
+		_, err = client.Update(ctx, sa, metav1.UpdateOptions{})
 		return err
 	}
 }


### PR DESCRIPTION
This PR adds the following improvements:

- Ensure we don't log sensitive information from `csi.NodePublishVolumeRequest`
- Disable caching with pod-level credentials
- Ensure to disable all other credential providers except STS provider
- Add a test case to make sure we're not using secrets if pod-level identity is enabled

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
