### PR TITLE
Feature/pod level identity cache key

### DIFF
--- a/pkg/driver/credential.go
+++ b/pkg/driver/credential.go
@@ -154,6 +154,10 @@ func (c *CredentialProvider) provideFromPod(ctx context.Context, volumeID string
 	hostPluginDir := hostPluginDirWithDefault()
 	hostTokenPath := path.Join(hostPluginDir, c.tokenFilename(podID, volumeID))
 
+	podNamespace := volumeContext[volumeCtxPodNamespace]
+	podServiceAccount := volumeContext[volumeCtxServiceAccountName]
+	cacheKey := podNamespace + "/" + podServiceAccount
+
 	return &MountCredentials{
 		Region:        region,
 		DefaultRegion: defaultRegion,
@@ -171,6 +175,8 @@ func (c *CredentialProvider) provideFromPod(ctx context.Context, volumeID string
 
 		// Ensure to disable IMDS provider
 		DisableIMDSProvider: true,
+
+		MountpointCacheKey: cacheKey,
 	}, nil
 }
 

--- a/pkg/driver/credential_test.go
+++ b/pkg/driver/credential_test.go
@@ -115,6 +115,8 @@ func TestProvidingPodLevelCredentials(t *testing.T) {
 	assertEquals(t, credentials.DefaultRegion, "eu-north-1")
 	assertEquals(t, credentials.StsEndpoints, "regional")
 
+	assertEquals(t, credentials.MountpointCacheKey, "test-ns/test-sa")
+
 	token, err := os.ReadFile(tokenFilePath(credentials, pluginDir))
 	assertEquals(t, nil, err)
 	assertEquals(t, "test-service-account-token", string(token))
@@ -479,6 +481,7 @@ func TestProvidingPodLevelCredentialsForDifferentPodsWithDifferentRoles(t *testi
 	assertEquals(t, credentialsPodOne.WebTokenPath, "/test/csi/plugin/dir/test-pod-1-test-vol-id.token")
 	assertEquals(t, credentialsPodOne.StsEndpoints, "regional")
 	assertEquals(t, credentialsPodOne.AwsRoleArn, "arn:aws:iam::123456789012:role/Test1")
+	assertEquals(t, credentialsPodOne.MountpointCacheKey, "test-ns/test-sa-1")
 
 	token, err := os.ReadFile(tokenFilePath(credentialsPodOne, pluginDir))
 	assertEquals(t, nil, err)
@@ -493,6 +496,7 @@ func TestProvidingPodLevelCredentialsForDifferentPodsWithDifferentRoles(t *testi
 	assertEquals(t, credentialsPodTwo.WebTokenPath, "/test/csi/plugin/dir/test-pod-2-test-vol-id.token")
 	assertEquals(t, credentialsPodTwo.StsEndpoints, "regional")
 	assertEquals(t, credentialsPodTwo.AwsRoleArn, "arn:aws:iam::123456789012:role/Test2")
+	assertEquals(t, credentialsPodTwo.MountpointCacheKey, "test-ns/test-sa-2")
 
 	token, err = os.ReadFile(tokenFilePath(credentialsPodTwo, pluginDir))
 	assertEquals(t, nil, err)

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -44,6 +44,7 @@ const (
 	stsEndpointsEnv          = "AWS_STS_REGIONAL_ENDPOINTS"
 	MountS3PathEnv           = "MOUNT_S3_PATH"
 	awsMaxAttemptsEnv        = "AWS_MAX_ATTEMPTS"
+	MountpointCacheKey       = "UNSTABLE_MOUNTPOINT_CACHE_KEY"
 	defaultMountS3Path       = "/usr/bin/mount-s3"
 	procMounts               = "/host/proc/mounts"
 	userAgentPrefix          = "--user-agent-prefix"
@@ -81,6 +82,9 @@ type MountCredentials struct {
 	Region        string
 	DefaultRegion string
 	StsEndpoints  string
+
+	// -- TODO - Move somewhere better
+	MountpointCacheKey string
 }
 
 // Get environment variables to pass to mount-s3 for authentication.
@@ -124,6 +128,10 @@ func (mc *MountCredentials) Env() []string {
 	}
 	if mc.StsEndpoints != "" {
 		env = append(env, stsEndpointsEnv+"="+mc.StsEndpoints)
+	}
+
+	if mc.MountpointCacheKey != "" {
+		env = append(env, MountpointCacheKey+"="+mc.MountpointCacheKey)
 	}
 
 	return env

--- a/pkg/driver/mount_test.go
+++ b/pkg/driver/mount_test.go
@@ -273,6 +273,14 @@ func TestProvidingEnvVariablesForMountpointProcess(t *testing.T) {
 				"AWS_STS_REGIONAL_ENDPOINTS=regional",
 			},
 		},
+		"Mountpoint Cache Key": {
+			credentials: &driver.MountCredentials{
+				MountpointCacheKey: "test_cache_key",
+			},
+			expected: []string{
+				"UNSTABLE_MOUNTPOINT_CACHE_KEY=test_cache_key",
+			},
+		},
 		"All Combined": {
 			credentials: &driver.MountCredentials{
 				AccessKeyID:               "access_key",
@@ -286,6 +294,7 @@ func TestProvidingEnvVariablesForMountpointProcess(t *testing.T) {
 				ConfigFilePath:            "~/.aws/config",
 				SharedCredentialsFilePath: "~/.aws/credentials",
 				DisableIMDSProvider:       true,
+				MountpointCacheKey:        "test/cache/key",
 			},
 			expected: []string{
 				"AWS_ACCESS_KEY_ID=access_key",
@@ -299,6 +308,7 @@ func TestProvidingEnvVariablesForMountpointProcess(t *testing.T) {
 				"AWS_EC2_METADATA_DISABLED=true",
 				"AWS_CONFIG_FILE=~/.aws/config",
 				"AWS_SHARED_CREDENTIALS_FILE=~/.aws/credentials",
+				"UNSTABLE_MOUNTPOINT_CACHE_KEY=test/cache/key",
 			},
 		},
 	}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -144,12 +144,6 @@ func (ns *S3NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 		mountpointArgs = compileMountOptions(mountpointArgs, mountFlags)
 	}
 
-	if volumeContext[volumeCtxAuthenticationSource] == authenticationSourcePod {
-		if _, ok := ExtractMountpointArgument(mountpointArgs, mountpointArgCache); ok {
-			return nil, status.Error(codes.InvalidArgument, "Caching with `authenticationSource=pod` is not supported at the moment, see TODO")
-		}
-	}
-
 	ns.targetPathPodIDMapping.Store(target, req.VolumeContext[volumeCtxPodUID])
 
 	credentials, err := ns.credentialProvider.Provide(ctx, req.VolumeId, req.VolumeContext, mountpointArgs)

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -458,11 +458,6 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 					expectFailToMount(enablePodLevelIdentity(ctx), sa.Name, nil)
 				})
 
-				It("should fail to mount if cache is enabled", func(ctx context.Context) {
-					sa := createServiceAccountWithPolicy(ctx, iamPolicyS3FullAccess)
-					expectFailToMount(enablePodLevelIdentity(ctx), sa.Name, []string{"cache /tmp"})
-				})
-
 				It("should refresh credentials after receiving new tokens", func(ctx context.Context) {
 					// TODO:
 					// 1. Trigger a manual `TokenRequest` or wait for it's own lifecylce


### PR DESCRIPTION
*Description of changes:*

When using pod level identity, use send a cache key to MP, which separates caches even if the cache location is the same. This is frequent when using the PLI feature.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
