### PR TITLE
Enable `podInfoOnMount` when using k8s>=1.30

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/csidriver.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 spec:
   attachRequired: false
-  {{- if or (.Values.node.podInfoOnMountCompat.enable) (semverCompare ">=1.30" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if or (.Values.node.podInfoOnMountCompat.enable) (semverCompare ">=1.30" .Capabilities.KubeVersion.Version) }}
   podInfoOnMount: true
   {{- end }}
   tokenRequests:

--- a/charts/aws-mountpoint-s3-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/csidriver.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 spec:
   attachRequired: false
-  {{- if .Values.node.podInfoOnMountCompat.enable }}
+  {{- if or (.Values.node.podInfoOnMountCompat.enable) (semverCompare ">=1.30" .Capabilities.KubeVersion.GitVersion) }}
   podInfoOnMount: true
   {{- end }}
   tokenRequests:

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -46,7 +46,7 @@ node:
                 values:
                   - fargate
   podInfoOnMountCompat:
-    enable: false # TODO: Should be `true` for k8s > 1.30
+    enable: false
 sidecars:
   nodeDriverRegistrar:
     image:

--- a/deploy/kubernetes/base/csidriver.yaml
+++ b/deploy/kubernetes/base/csidriver.yaml
@@ -6,6 +6,7 @@ metadata:
   name: s3.csi.aws.com
 spec:
   attachRequired: false
+  podInfoOnMount: true
   tokenRequests:
     - audience: "sts.amazonaws.com"
       expirationSeconds: 3600

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -188,6 +188,10 @@ graph LR;
 
 ## Pod-Level Credentials
 
+> [!WARNING]
+> To enable Pod-Level credentials on K8s clusters <1.30, you need to pass `node.podInfoOnMountCompat.enable=true` into
+> your Helm installation.
+
 You can configure Mountpoint CSI Driver to use the credentials associated with the pod's Service Account rather than the
 driver's own credentials.
 
@@ -287,6 +291,21 @@ kubectl describe sa s3-pod-sa --namespace $POD_NAMESPACE
 ```
 For more validation steps see the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html).
 
+
+### Configuring the STS region
+
+You can manually configure the STS region that's used for Pod-Level credentials with the `stsRegion` volume attribute.
+This may be required in case the CSI Driver is unable to automatically configure a value.
+
+```yaml
+csi:
+  driver: s3.csi.aws.com
+  volumeHandle: example-s3-pv
+  volumeAttributes:
+    bucketName: amzn-s3-demo-bucket
+    authenticationSource: pod
+    stsRegion: us-east-1
+```
 
 ## Configure driver toleration settings
 Toleration of all taints is set to `false` by default. If you don't want to deploy the driver on all nodes, add 

--- a/pkg/driver/credential.go
+++ b/pkg/driver/credential.go
@@ -43,6 +43,9 @@ const serviceAccountTokenAudienceSTS = "sts.amazonaws.com"
 
 const serviceAccountRoleAnnotation = "eks.amazonaws.com/role-arn"
 
+const podLevelCredentialsDocsPage = "https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#pod-level-credentials"
+const stsConfigDocsPage = "https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#configuring-the-sts-region"
+
 var errUnknownRegion = errors.New("NodePublishVolume: Pod-level: unknown region")
 
 type CredentialProvider struct {
@@ -112,7 +115,7 @@ func (c *CredentialProvider) provideFromPod(ctx context.Context, volumeID string
 
 	tokensJson := volumeContext[volumeCtxServiceAccountTokens]
 	if tokensJson == "" {
-		klog.Error("`authenticationSource` configured to `pod` but no service account tokens are received. Please make sure to enable `podInfoOnMountCompat`, see TODO")
+		klog.Error("`authenticationSource` configured to `pod` but no service account tokens are received. Please make sure to enable `podInfoOnMountCompat`, see " + podLevelCredentialsDocsPage)
 		return nil, status.Error(codes.InvalidArgument, "Missing service account tokens")
 	}
 
@@ -123,7 +126,7 @@ func (c *CredentialProvider) provideFromPod(ctx context.Context, volumeID string
 
 	stsToken := tokens[serviceAccountTokenAudienceSTS]
 	if stsToken == nil {
-		klog.Errorf("`authenticationSource` configured to `pod` but no service account tokens for %s received. Please make sure to enable `podInfoOnMountCompat`, see TODO", serviceAccountTokenAudienceSTS)
+		klog.Errorf("`authenticationSource` configured to `pod` but no service account tokens for %s received. Please make sure to enable `podInfoOnMountCompat`, see "+podLevelCredentialsDocsPage, serviceAccountTokenAudienceSTS)
 		return nil, status.Errorf(codes.InvalidArgument, "Missing service account token for %s", serviceAccountTokenAudienceSTS)
 	}
 
@@ -134,7 +137,7 @@ func (c *CredentialProvider) provideFromPod(ctx context.Context, volumeID string
 
 	region, err := c.stsRegion(volumeContext, mountpointArgs)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Failed to detect STS AWS Region, please explicitly set the AWS Region, see TODO")
+		return nil, status.Errorf(codes.InvalidArgument, "Failed to detect STS AWS Region, please explicitly set the AWS Region, see "+stsConfigDocsPage)
 	}
 
 	defaultRegion := os.Getenv(defaultRegionEnv)
@@ -206,7 +209,7 @@ func (c *CredentialProvider) findPodServiceAccountRole(ctx context.Context, volu
 	podNamespace := volumeContext[volumeCtxPodNamespace]
 	podServiceAccount := volumeContext[volumeCtxServiceAccountName]
 	if podNamespace == "" || podServiceAccount == "" {
-		klog.Error("`authenticationSource` configured to `pod` but no pod info found. Please make sure to enable `podInfoOnMountCompat`, see TODO")
+		klog.Error("`authenticationSource` configured to `pod` but no pod info found. Please make sure to enable `podInfoOnMountCompat`, see " + podLevelCredentialsDocsPage)
 		return "", status.Error(codes.InvalidArgument, "Missing Pod info")
 	}
 
@@ -217,7 +220,7 @@ func (c *CredentialProvider) findPodServiceAccountRole(ctx context.Context, volu
 
 	roleArn := response.Annotations[serviceAccountRoleAnnotation]
 	if roleArn == "" {
-		klog.Error("`authenticationSource` configured to `pod` but pod's service account is not annotated with a role, see TODO")
+		klog.Error("`authenticationSource` configured to `pod` but pod's service account is not annotated with a role, see " + podLevelCredentialsDocsPage)
 		return "", status.Errorf(codes.InvalidArgument, "Missing role annotation on pod's service account %s/%s", podNamespace, podServiceAccount)
 	}
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Enable `podInfoOnMount` when k8s>=1.30

----

Tested with 

```
helm template --kube-version 1.30 --debug charts/aws-mountpoint-s3-csi-driver | python3 -m yq 'select(.kind=="CSIDriver") | .spec | .podInfoOnMount'

true

helm template --kube-version 1.29 --debug charts/aws-mountpoint-s3-csi-driver | python3 -m yq 'select(.kind=="CSIDriver") | .spec | .podInfoOnMount'

null
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
