### PR TITLE
For OIDC credentials, allow providers starting with 'oidc.'

### DIFF
--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -804,7 +804,7 @@ func oidcProviderForCluster(ctx context.Context, f *framework.Framework) string 
 
 	issuer, _ := configuration["issuer"].(string)
 
-	if !strings.HasPrefix(issuer, "https://oidc.eks") {
+	if !strings.HasPrefix(issuer, "https://oidc.") {
 		// For now, we only set up a _public_ OIDC provider via `eksctl`,
 		// with `kops` we're setting up a _local_ OIDC provider which wouldn't work with AWS IAM.
 		// So, we're ignoring non-EKS OIDC providers.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Remove 'eks' prefix requirement for OIDC detection for E2E tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
