### PR TITLE
Mention one-to-one mapping of PVCs and PVs in the docs and examples

### DIFF
--- a/examples/kubernetes/static_provisioning/README.md
+++ b/examples/kubernetes/static_provisioning/README.md
@@ -17,6 +17,7 @@ This example shows how to make a static provisioned Mountpoint for S3 persistent
 - Bucket region (if bucket and cluster are in different regions): `PersistentVolume -> csi -> mountOptions`
 - [Mountpoint configurations](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md) can be added in the `mountOptions` of the Persistent Volume spec.
 
+See [Static Provisioning](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#static-provisioning) configuration page for more details.
 
 ## Deploy
 ```

--- a/examples/kubernetes/static_provisioning/aws_max_attempts.yaml
+++ b/examples/kubernetes/static_provisioning/aws_max_attempts.yaml
@@ -7,6 +7,10 @@ spec:
     storage: 1200Gi # ignored, required
   accessModes:
     - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
   mountOptions:
     - allow-delete
     - region us-west-2
@@ -20,15 +24,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: s3-claim
+  name: s3-pvc
 spec:
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
-  storageClassName: "" # required for static provisioning
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
   resources:
     requests:
-      storage: 1200Gi # ignored, required
-  volumeName: s3-pv
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
 ---
 apiVersion: v1
 kind: Pod
@@ -46,4 +50,4 @@ spec:
   volumes:
     - name: persistent-storage
       persistentVolumeClaim:
-        claimName: s3-claim
+        claimName: s3-pvc

--- a/examples/kubernetes/static_provisioning/caching.yaml
+++ b/examples/kubernetes/static_provisioning/caching.yaml
@@ -7,6 +7,10 @@ spec:
     storage: 1200Gi # ignored, required
   accessModes:
     - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
   mountOptions:
     - cache /tmp/s3-pv1-cache # specify cache directory, relative to root host filesystem
                               # the directory must be unique per mount on a host
@@ -21,15 +25,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: s3-claim
+  name: s3-pvc
 spec:
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
-  storageClassName: "" # required for static provisioning
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
   resources:
     requests:
-      storage: 1200Gi # ignored, required
-  volumeName: s3-pv
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
 ---
 apiVersion: v1
 kind: Pod
@@ -47,4 +51,4 @@ spec:
   volumes:
     - name: persistent-storage
       persistentVolumeClaim:
-        claimName: s3-claim
+        claimName: s3-pvc

--- a/examples/kubernetes/static_provisioning/kms_sse.yaml
+++ b/examples/kubernetes/static_provisioning/kms_sse.yaml
@@ -7,6 +7,10 @@ spec:
     storage: 1200Gi # ignored, required
   accessModes:
     - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
   mountOptions:
     - allow-delete
     - region us-west-2
@@ -21,15 +25,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: s3-claim
+  name: s3-pvc
 spec:
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
-  storageClassName: "" # required for static provisioning
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
   resources:
     requests:
-      storage: 1200Gi # ignored, required
-  volumeName: s3-pv
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
 ---
 apiVersion: v1
 kind: Pod
@@ -47,4 +51,4 @@ spec:
   volumes:
     - name: persistent-storage
       persistentVolumeClaim:
-        claimName: s3-claim
+        claimName: s3-pvc

--- a/examples/kubernetes/static_provisioning/multiple_buckets_one_pod.yaml
+++ b/examples/kubernetes/static_provisioning/multiple_buckets_one_pod.yaml
@@ -7,6 +7,10 @@ spec:
     storage: 1200Gi # ignored, required
   accessModes:
     - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
   mountOptions:
     - allow-delete
     - region us-west-2
@@ -19,15 +23,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: s3-claim
+  name: s3-pvc
 spec:
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
-  storageClassName: "" # required for static provisioning
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
   resources:
     requests:
-      storage: 1200Gi # ignored, required
-  volumeName: s3-pv
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -38,6 +42,10 @@ spec:
     storage: 1200Gi # ignored, required
   accessModes:
     - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc-2 # Name of your PVC
   mountOptions:
     - allow-delete
     - region us-west-2
@@ -50,7 +58,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: s3-claim-2
+  name: s3-pvc-2
 spec:
   accessModes:
     - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
@@ -58,7 +66,7 @@ spec:
   resources:
     requests:
       storage: 1200Gi # ignored, required
-  volumeName: s3-pv-2
+  volumeName: s3-pv-2 # Name of your PV
 ---
 apiVersion: v1
 kind: Pod
@@ -78,7 +86,7 @@ spec:
   volumes:
     - name: persistent-storage
       persistentVolumeClaim:
-        claimName: s3-claim
+        claimName: s3-pvc
     - name: persistent-storage-2
       persistentVolumeClaim:
-        claimName: s3-claim-2
+        claimName: s3-pvc-2

--- a/examples/kubernetes/static_provisioning/multiple_pods_one_pv.yaml
+++ b/examples/kubernetes/static_provisioning/multiple_pods_one_pv.yaml
@@ -7,6 +7,10 @@ spec:
     storage: 1200Gi # ignored, required
   accessModes:
     - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
   mountOptions:
     - allow-delete
     - region us-east-1
@@ -19,15 +23,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: s3-claim
+  name: s3-pvc
 spec:
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
-  storageClassName: "" # required for static provisioning
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
   resources:
     requests:
-      storage: 1200Gi # ignored, required
-  volumeName: s3-pv
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -58,4 +62,4 @@ spec:
       volumes:
       - name: persistent-storage
         persistentVolumeClaim:
-          claimName: s3-claim
+          claimName: s3-pvc

--- a/examples/kubernetes/static_provisioning/non_root.yaml
+++ b/examples/kubernetes/static_provisioning/non_root.yaml
@@ -4,9 +4,13 @@ metadata:
   name: s3-pv
 spec:
   capacity:
-    storage: 1200Gi # ignored, required
+    storage: 1200Gi # Ignored, required
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
   mountOptions:
     - uid=1000
     - gid=2000
@@ -20,15 +24,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: s3-claim
+  name: s3-pvc
 spec:
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
-  storageClassName: "" # required for static provisioning
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
   resources:
     requests:
-      storage: 1200Gi # ignored, required
-  volumeName: s3-pv
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
 ---
 apiVersion: v1
 kind: Pod
@@ -49,4 +53,4 @@ spec:
   volumes:
     - name: persistent-storage
       persistentVolumeClaim:
-        claimName: s3-claim
+        claimName: s3-pvc

--- a/examples/kubernetes/static_provisioning/pod_level_identity.yaml
+++ b/examples/kubernetes/static_provisioning/pod_level_identity.yaml
@@ -31,7 +31,7 @@ spec:
   storageClassName: "" # Required for static provisioning
   resources:
     requests:
-      storage: 1200Gi # Ignored, required
+      storage: 1Gi
   volumeName: s3-pv # Name of your PV
 ---
 apiVersion: v1

--- a/examples/kubernetes/static_provisioning/pod_level_identity.yaml
+++ b/examples/kubernetes/static_provisioning/pod_level_identity.yaml
@@ -7,6 +7,10 @@ spec:
     storage: 1Gi
   accessModes:
     - ReadWriteMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
   mountOptions:
     - allow-delete
     - region us-west-2
@@ -20,15 +24,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: s3-claim
+  name: s3-pvc
 spec:
   accessModes:
-    - ReadWriteMany
-  storageClassName: ""
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
   resources:
     requests:
-      storage: 1Gi
-  volumeName: s3-pv
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
 ---
 apiVersion: v1
 kind: Pod
@@ -46,7 +50,7 @@ spec:
   volumes:
     - name: persistent-storage
       persistentVolumeClaim:
-        claimName: s3-claim
+        claimName: s3-pvc
 ---
 apiVersion: v1
 kind: Pod
@@ -64,7 +68,7 @@ spec:
   volumes:
     - name: persistent-storage
       persistentVolumeClaim:
-        claimName: s3-claim
+        claimName: s3-pvc
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/static_provisioning/s3_express_specify_az.yaml
+++ b/examples/kubernetes/static_provisioning/s3_express_specify_az.yaml
@@ -11,6 +11,9 @@ spec:
   claimRef: # To ensure no other PVCs can claim this PV
     namespace: default # Namespace is required even though it's in "default" namespace.
     name: s3-pvc # Name of your PVC
+  mountOptions:
+    - allow-delete
+    - region us-west-2
   csi:
     driver: s3.csi.aws.com # Required
     volumeHandle: s3-csi-driver-volume

--- a/examples/kubernetes/static_provisioning/s3_express_specify_az.yaml
+++ b/examples/kubernetes/static_provisioning/s3_express_specify_az.yaml
@@ -4,14 +4,15 @@ metadata:
   name: s3-pv
 spec:
   capacity:
-    storage: 1200Gi # ignored, required
+    storage: 1200Gi # Ignored, required
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
-  mountOptions:
-    - allow-delete
-    - region us-west-2
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
   csi:
-    driver: s3.csi.aws.com # required
+    driver: s3.csi.aws.com # Required
     volumeHandle: s3-csi-driver-volume
     volumeAttributes:
       bucketName: s3-csi-driver--usw2-az1--x-s3
@@ -27,15 +28,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: s3-claim
+  name: s3-pvc
 spec:
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
-  storageClassName: "" # required for static provisioning
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
   resources:
     requests:
-      storage: 1200Gi # ignored, required
-  volumeName: s3-pv
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
 ---
 apiVersion: v1
 kind: Pod
@@ -53,4 +54,4 @@ spec:
   volumes:
     - name: persistent-storage
       persistentVolumeClaim:
-        claimName: s3-claim
+        claimName: s3-pvc

--- a/examples/kubernetes/static_provisioning/static_provisioning.yaml
+++ b/examples/kubernetes/static_provisioning/static_provisioning.yaml
@@ -4,15 +4,19 @@ metadata:
   name: s3-pv
 spec:
   capacity:
-    storage: 1200Gi # ignored, required
+    storage: 1200Gi # Ignored, required
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
+  claimRef: # To ensure no other PVCs can claim this PV
+    namespace: default # Namespace is required even though it's in "default" namespace.
+    name: s3-pvc # Name of your PVC
   mountOptions:
     - allow-delete
     - region us-west-2
     - prefix some-s3-prefix/
   csi:
-    driver: s3.csi.aws.com # required
+    driver: s3.csi.aws.com # Required
     volumeHandle: s3-csi-driver-volume
     volumeAttributes:
       bucketName: s3-csi-driver
@@ -20,15 +24,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: s3-claim
+  name: s3-pvc
 spec:
   accessModes:
-    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
-  storageClassName: "" # required for static provisioning
+    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
+  storageClassName: "" # Required for static provisioning
   resources:
     requests:
-      storage: 1200Gi # ignored, required
-  volumeName: s3-pv
+      storage: 1200Gi # Ignored, required
+  volumeName: s3-pv # Name of your PV
 ---
 apiVersion: v1
 kind: Pod
@@ -46,4 +50,4 @@ spec:
   volumes:
     - name: persistent-storage
       persistentVolumeClaim:
-        claimName: s3-claim
+        claimName: s3-pvc


### PR DESCRIPTION
The Driver only supports Static Provisioning as of today, and in order to configure it correctly, one needs to ensure there is no `storageClassName` set (it should be `""`) and also there is a one-to-one mapping between PVC and PV using `claimRef`. This PR clarifies this requirement and updates example manifests to specify one-to-one mapping between PVC and PV. See a recent issue regarding this: https://github.com/awslabs/mountpoint-s3-csi-driver/issues/249

--- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
