### PR TITLE
Fix version compare in Helm chart for `podInfoOnMount`

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/csidriver.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 spec:
   attachRequired: false
-  {{- if or (.Values.node.podInfoOnMountCompat.enable) (semverCompare ">=1.30" .Capabilities.KubeVersion.Version) }}
+  {{- if or (.Values.node.podInfoOnMountCompat.enable) (semverCompare ">=1.30.0-0" .Capabilities.KubeVersion.Version) }}
   podInfoOnMount: true
   {{- end }}
   tokenRequests:


### PR DESCRIPTION
Current version compare `(semverCompare ">=1.30" .Capabilities.KubeVersion.Version)` does not work with EKS versions (e.g., `v1.30.4-eks-a737599`) and requires customers to set `node.podInfoOnMountCompat.enable=true` even though they're on 1.30+ clusters. 

The test script:
```bash
#!/usr/bin/env bash

echo "Testing versions >=1.30:"
for version in "v1.30.0" "v1.31.2" "v1.30.4-eks-a737599" "v1.30.1+k3s1" "v1.30.4+k0s"; do
   helm template --debug aws-mountpoint-s3-csi-driver \
        --namespace kube-system \
        --kube-version "$version" \
        ./charts/aws-mountpoint-s3-csi-driver 2>&1 | grep -q podInfoOnMount && echo -e "\t$version - OK" || echo -e "\t$version - FAIL"
done

echo "Testing versions <1.30:"
for version in "v1.29.0" "v1.27.2" "v1.29.1-eks-61c0bbb" "v1.29.1+k3s1"; do
   helm template --debug aws-mountpoint-s3-csi-driver \
        --namespace kube-system \
        --kube-version "$version" \
        ./charts/aws-mountpoint-s3-csi-driver 2>&1 | grep -v -q podInfoOnMount && echo -e "\t$version - OK" || echo -e "\t$version - FAIL"
done

echo "Testing with opt-in flag:"
for version in "v1.30.0" "v1.31.2" "v1.30.4-eks-a737599" "v1.30.1+k3s1" "v1.30.4+k0s" "v1.29.0" "v1.27.2" "v1.29.1-eks-61c0bbb" "v1.29.1+k3s1"; do
   helm template --debug aws-mountpoint-s3-csi-driver \
        --namespace kube-system \
        --kube-version "$version" \
        --set "node.podInfoOnMountCompat.enable=true" \
        ./charts/aws-mountpoint-s3-csi-driver 2>&1 | grep -q podInfoOnMount && echo -e "\t$version - OK" || echo -e "\t$version - FAIL"
done
```

Without the fix:
```bash
$ ./test-helm-chart.sh
Testing versions >=1.30:
        v1.30.0 - OK
        v1.31.2 - OK
        v1.30.4-eks-a737599 - FAIL # <--
        v1.30.1+k3s1 - OK
        v1.30.4+k0s - OK
Testing versions <1.30:
        v1.29.0 - OK
        v1.27.2 - OK
        v1.29.1-eks-61c0bbb - OK
        v1.29.1+k3s1 - OK
Testing with opt-in flag:
        v1.30.0 - OK
        v1.31.2 - OK
        v1.30.4-eks-a737599 - OK
        v1.30.1+k3s1 - OK
        v1.30.4+k0s - OK
        v1.29.0 - OK
        v1.27.2 - OK
        v1.29.1-eks-61c0bbb - OK
        v1.29.1+k3s1 - OK
```

With the fix:
```bash
./test-helm-chart.sh
Testing versions >=1.30:
        v1.30.0 - OK
        v1.31.2 - OK
        v1.30.4-eks-a737599 - OK
        v1.30.1+k3s1 - OK
        v1.30.4+k0s - OK
Testing versions <1.30:
        v1.29.0 - OK
        v1.27.2 - OK
        v1.29.1-eks-61c0bbb - OK
        v1.29.1+k3s1 - OK
Testing with opt-in flag:
        v1.30.0 - OK
        v1.31.2 - OK
        v1.30.4-eks-a737599 - OK
        v1.30.1+k3s1 - OK
        v1.30.4+k0s - OK
        v1.29.0 - OK
        v1.27.2 - OK
        v1.29.1-eks-61c0bbb - OK
        v1.29.1+k3s1 - OK
```


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
