### PR TITLE
Properly clean service account tokens in `NodeUnpublishVolume`

### DIFF
--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -187,7 +187,7 @@ func (ns *S3NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUn
 	}
 
 	targetPath, err := ParseTargetPath(target)
-	if err != nil {
+	if err == nil {
 		if targetPath.VolumeID != volumeID {
 			klog.V(4).Infof("NodeUnpublishVolume: Volume ID from parsed target path differs from Volume ID passed: %s (parsed) != %s (passed)", targetPath.VolumeID, volumeID)
 		} else {

--- a/pkg/driver/node/node_test.go
+++ b/pkg/driver/node/node_test.go
@@ -346,7 +346,7 @@ func (d *dummyMounter) Unmount(target string) error {
 	return nil
 }
 func (d *dummyMounter) IsMountPoint(target string) (bool, error) {
-	return false, nil
+	return true, nil
 }
 
 func assertNotEquals[T comparable](t *testing.T, expected T, got T) {

--- a/pkg/driver/node/node_test.go
+++ b/pkg/driver/node/node_test.go
@@ -2,7 +2,10 @@ package node_test
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node"
@@ -10,6 +13,7 @@ import (
 	mock_driver "github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/mounter/mocks"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	"golang.org/x/net/context"
 )
 
@@ -285,6 +289,31 @@ func TestNodeUnpublishVolume(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, tc.testFunc)
 	}
+
+	t.Run("Cleaning Service Account Token", func(t *testing.T) {
+		containerPluginDir := t.TempDir()
+		credentialProvider := mounter.NewCredentialProvider(nil, containerPluginDir, mounter.RegionFromIMDSOnce)
+		nodeServer := node.NewS3NodeServer("test-node-id", &dummyMounter{}, credentialProvider)
+
+		podID := uuid.New().String()
+		volID := "test-vol-id"
+
+		serviceAccountTokenPath := filepath.Join(containerPluginDir, fmt.Sprintf("%s-%s.token", podID, volID))
+		_, err := os.Create(serviceAccountTokenPath)
+		assertEquals(t, nil, err)
+
+		targetPath := fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~csi/%s/mount", podID, volID)
+
+		_, err = nodeServer.NodeUnpublishVolume(context.Background(), &csi.NodeUnpublishVolumeRequest{
+			VolumeId:   volID,
+			TargetPath: targetPath,
+		})
+		assertEquals(t, nil, err)
+
+		_, err = os.Stat(serviceAccountTokenPath)
+		assertNotEquals(t, nil, err)
+		assertEquals(t, true, errors.Is(err, fs.ErrNotExist))
+	})
 }
 
 func TestNodeGetCapabilities(t *testing.T) {
@@ -303,4 +332,25 @@ func TestNodeGetCapabilities(t *testing.T) {
 	}
 
 	nodeTestEnv.mockCtl.Finish()
+}
+
+var _ mounter.Mounter = &dummyMounter{}
+
+type dummyMounter struct {
+}
+
+func (d *dummyMounter) Mount(bucketName string, target string, credentials *mounter.MountCredentials, options []string) error {
+	return nil
+}
+func (d *dummyMounter) Unmount(target string) error {
+	return nil
+}
+func (d *dummyMounter) IsMountPoint(target string) (bool, error) {
+	return false, nil
+}
+
+func assertNotEquals[T comparable](t *testing.T, expected T, got T) {
+	if expected == got {
+		t.Errorf("Expected %#v to not equal %#v", expected, got)
+	}
 }


### PR DESCRIPTION
- Cleanup tokens after unmounting Mountpoint. Mountpoint might still need to perform some S3 calls during shutdown and cleaning the token before unmount might cause those operations to fail.
- Add test to ensure tokens are cleaned up on `NodeUnpublishVolume`. There was a typo in `if err != nil {` check, which was skipping the cleanup if `err` was `nil`, it's been fixed as well.
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
