### PR TITLE
Add `aws-s3-csi-mounter` component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ install-go-test-coverage:
 
 .PHONY: test
 test:
-	go test -v -race ./pkg/... -coverprofile=./cover.out -covermode=atomic -coverpkg=./pkg/...
+	go test -v -race ./{cmd,pkg}/... -coverprofile=./cover.out -covermode=atomic -coverpkg=./{cmd,pkg}/...
 	# skipping controller test cases because we don't implement controller for static provisioning,
 	# this is a known limitation of sanity testing package: https://github.com/kubernetes-csi/csi-test/issues/214
 	go test -v ./tests/sanity/... -ginkgo.skip="ControllerGetCapabilities" -ginkgo.skip="ValidateVolumeCapabilities"

--- a/cmd/aws-s3-csi-mounter/csimounter/csimounter.go
+++ b/cmd/aws-s3-csi-mounter/csimounter/csimounter.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"slices"
 
+	"k8s.io/klog/v2"
+
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
 )
 
@@ -64,6 +66,8 @@ func Run(options Options) (int, error) {
 	// so Mountpoint logs can be viewable with `kubectl logs`.
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	klog.Info("Starting Mountpoint process")
 
 	return options.CmdRunner(cmd)
 }

--- a/cmd/aws-s3-csi-mounter/csimounter/csimounter.go
+++ b/cmd/aws-s3-csi-mounter/csimounter/csimounter.go
@@ -1,0 +1,69 @@
+package csimounter
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+)
+
+// A CmdRunner is responsible for running given `cmd` until completion and returning its exit code and its error (if any).
+// This is mainly exposed for mocking in tests, `DefaultCmdRunner` is always used in non-test environments.
+type CmdRunner func(cmd *exec.Cmd) (int, error)
+
+// DefaultCmdRunner is a real CmdRunner implementation that runs given `cmd`.
+func DefaultCmdRunner(cmd *exec.Cmd) (int, error) {
+	err := cmd.Run()
+	if err != nil {
+		return 0, err
+	}
+	return cmd.ProcessState.ExitCode(), nil
+}
+
+// An Options represents options to use while mounting Mountpoint.
+type Options struct {
+	MountpointPath string
+	MountOptions   mountoptions.Options
+	CmdRunner      CmdRunner
+}
+
+// Run runs Mountpoint with given options until completion and returns its exit code and its error (if any).
+func Run(options Options) (int, error) {
+	if options.CmdRunner == nil {
+		options.CmdRunner = DefaultCmdRunner
+	}
+
+	mountOptions := options.MountOptions
+
+	fuseDev := os.NewFile(uintptr(mountOptions.Fd), "/dev/fuse")
+	if fuseDev == nil {
+		return 0, fmt.Errorf("passed file descriptor %d is invalid", mountOptions.Fd)
+	}
+
+	args := mountOptions.Args
+
+	// By default Mountpoint runs in a detached mode. Here we want to monitor it by relaying its output,
+	// and also we want to wait until it terminates. We're passing `--foreground` to achieve this.
+	const foreground = "--foreground"
+	if !slices.Contains(args, foreground) {
+		args = append(args, foreground)
+	}
+
+	args = append([]string{
+		mountOptions.BucketName,
+		// We pass FUSE fd using `ExtraFiles`, and each entry becomes as file descriptor 3+i.
+		"/dev/fd/3",
+	}, args...)
+
+	cmd := exec.Command(options.MountpointPath, args...)
+	cmd.ExtraFiles = []*os.File{fuseDev}
+	cmd.Env = options.MountOptions.Env
+	// Connect Mountpoint's stdout/stderr to this commands stdout/stderr,
+	// so Mountpoint logs can be viewable with `kubectl logs`.
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return options.CmdRunner(cmd)
+}

--- a/cmd/aws-s3-csi-mounter/csimounter/csimounter_test.go
+++ b/cmd/aws-s3-csi-mounter/csimounter/csimounter_test.go
@@ -1,0 +1,151 @@
+package csimounter_test
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/awslabs/aws-s3-csi-driver/cmd/aws-s3-csi-mounter/csimounter"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestRunningMountpoint(t *testing.T) {
+	mountpointPath := filepath.Join(t.TempDir(), "mount-s3")
+
+	t.Run("Passes bucket name and FUSE device as mount point", func(t *testing.T) {
+		dev := openDevNull(t)
+
+		runner := func(c *exec.Cmd) (int, error) {
+			assertSameFile(t, dev, c.ExtraFiles[0])
+			assert.Equals(t, mountpointPath, c.Path)
+			assert.Equals(t, []string{mountpointPath, "test-bucket", "/dev/fd/3"}, c.Args[:3])
+			return 0, nil
+		}
+
+		exitCode, err := csimounter.Run(csimounter.Options{
+			MountpointPath: mountpointPath,
+			MountOptions: mountoptions.Options{
+				Fd:         int(dev.Fd()),
+				BucketName: "test-bucket",
+			},
+			CmdRunner: runner,
+		})
+		assert.NoError(t, err)
+		assert.Equals(t, 0, exitCode)
+	})
+
+	t.Run("Passes bucket name", func(t *testing.T) {
+		runner := func(c *exec.Cmd) (int, error) {
+			assert.Equals(t, mountpointPath, c.Path)
+			assert.Equals(t, []string{mountpointPath, "test-bucket"}, c.Args[:2])
+			return 0, nil
+		}
+
+		exitCode, err := csimounter.Run(csimounter.Options{
+			MountpointPath: mountpointPath,
+			MountOptions: mountoptions.Options{
+				Fd:         int(openDevNull(t).Fd()),
+				BucketName: "test-bucket",
+			},
+			CmdRunner: runner,
+		})
+		assert.NoError(t, err)
+		assert.Equals(t, 0, exitCode)
+	})
+
+	t.Run("Passes environment variables", func(t *testing.T) {
+		env := []string{"FOO=bar", "BAZ=qux"}
+
+		runner := func(c *exec.Cmd) (int, error) {
+			assert.Equals(t, env, c.Env)
+			return 0, nil
+		}
+
+		exitCode, err := csimounter.Run(csimounter.Options{
+			MountpointPath: mountpointPath,
+			MountOptions: mountoptions.Options{
+				Fd:  int(openDevNull(t).Fd()),
+				Env: env,
+			},
+			CmdRunner: runner,
+		})
+		assert.NoError(t, err)
+		assert.Equals(t, 0, exitCode)
+	})
+
+	t.Run("Adds `--foreground` argument if not passed", func(t *testing.T) {
+		runner := func(c *exec.Cmd) (int, error) {
+			assert.Equals(t, []string{
+				mountpointPath,
+				"test-bucket", "/dev/fd/3",
+				"--foreground",
+			}, c.Args)
+			return 0, nil
+		}
+
+		exitCode, err := csimounter.Run(csimounter.Options{
+			MountpointPath: mountpointPath,
+			MountOptions: mountoptions.Options{
+				Fd:         int(openDevNull(t).Fd()),
+				BucketName: "test-bucket",
+			},
+			CmdRunner: runner,
+		})
+		assert.NoError(t, err)
+		assert.Equals(t, 0, exitCode)
+
+		exitCode, err = csimounter.Run(csimounter.Options{
+			MountpointPath: mountpointPath,
+			MountOptions: mountoptions.Options{
+				Fd:         int(openDevNull(t).Fd()),
+				BucketName: "test-bucket",
+				Args:       []string{"--foreground"},
+			},
+			CmdRunner: runner,
+		})
+		assert.NoError(t, err)
+		assert.Equals(t, 0, exitCode)
+	})
+
+	t.Run("Fails if file descriptor is invalid", func(t *testing.T) {
+		_, err := csimounter.Run(csimounter.Options{
+			MountpointPath: mountpointPath,
+			MountOptions: mountoptions.Options{
+				Fd:         -1,
+				BucketName: "test-bucket",
+			},
+		})
+		assert.Equals(t, cmpopts.AnyError, err)
+	})
+}
+
+func openDevNull(t *testing.T) *os.File {
+	file, err := os.Open(os.DevNull)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		err = file.Close()
+		if err != nil {
+			log.Printf("Failed to close file handle: %v\n", err)
+		}
+	})
+	return file
+}
+
+func assertSameFile(t *testing.T, want *os.File, got *os.File) {
+	var wantStat = &syscall.Stat_t{}
+	err := syscall.Fstat(int(want.Fd()), wantStat)
+	assert.NoError(t, err)
+
+	var gotStat = &syscall.Stat_t{}
+	err = syscall.Fstat(int(got.Fd()), gotStat)
+	assert.NoError(t, err)
+
+	assert.Equals(t, wantStat.Dev, gotStat.Dev)
+	assert.Equals(t, wantStat.Ino, gotStat.Ino)
+}

--- a/cmd/aws-s3-csi-mounter/main.go
+++ b/cmd/aws-s3-csi-mounter/main.go
@@ -1,0 +1,53 @@
+// WIP: Part of https://github.com/awslabs/mountpoint-s3-csi-driver/issues/279.
+//
+// `aws-s3-csi-mounter` is the entrypoint binary running on Mountpoint Pods.
+// It is responsible for receiving mount options from the CSI Driver Node Pod,
+// and spawning a Mountpoint instance in turn.
+// It will then wait until Mountpoint process terminates (which normally happens as a result of `unmount`).
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/awslabs/aws-s3-csi-driver/cmd/aws-s3-csi-mounter/csimounter"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+)
+
+var mountSockPath = flag.String("mount-sock-path", "/sock/mount.sock", "Path of the Unix socket to receive mount options from.")
+var mountSockRecvTimeout = flag.Duration("mount-sock-recv-timeout", 2*time.Minute, "Timeout for receiving mount options from passed Unix socket.")
+var mountpointBinDir = flag.String("mountpoint-bin-dir", os.Getenv("MOUNTPOINT_BIN_DIR"), "Directory of mount-s3 binary.")
+
+const mountpointBin = "mount-s3"
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	mountpointBinFullPath := filepath.Join(*mountpointBinDir, mountpointBin)
+	mountOptions := recvMountOptions()
+
+	exitCode, err := csimounter.Run(csimounter.Options{
+		MountpointPath: mountpointBinFullPath,
+		MountOptions:   mountOptions,
+	})
+	if err != nil {
+		klog.Fatalf("Failed to run Mountpoint: %v\n", err)
+	}
+	os.Exit(exitCode)
+}
+
+func recvMountOptions() mountoptions.Options {
+	ctx, cancel := context.WithTimeout(context.Background(), *mountSockRecvTimeout)
+	defer cancel()
+	options, err := mountoptions.Recv(ctx, *mountSockPath)
+	if err != nil {
+		klog.Fatalf("Failed to receive mount options from %s: %v\n", *mountSockPath, err)
+	}
+	return options
+}

--- a/cmd/aws-s3-csi-mounter/main.go
+++ b/cmd/aws-s3-csi-mounter/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
 )
 
-var mountSockPath = flag.String("mount-sock-path", "/sock/mount.sock", "Path of the Unix socket to receive mount options from.")
+var mountSockPath = flag.String("mount-sock-path", "/comm/mount.sock", "Path of the Unix socket to receive mount options from.")
 var mountSockRecvTimeout = flag.Duration("mount-sock-recv-timeout", 2*time.Minute, "Timeout for receiving mount options from passed Unix socket.")
 var mountpointBinDir = flag.String("mountpoint-bin-dir", os.Getenv("MOUNTPOINT_BIN_DIR"), "Directory of mount-s3 binary.")
 
@@ -39,15 +39,18 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Failed to run Mountpoint: %v\n", err)
 	}
+	klog.Infof("Mountpoint exited with %d exit code\n", exitCode)
 	os.Exit(exitCode)
 }
 
 func recvMountOptions() mountoptions.Options {
 	ctx, cancel := context.WithTimeout(context.Background(), *mountSockRecvTimeout)
 	defer cancel()
+	klog.Infof("Trying to receive mount options from %s", *mountSockPath)
 	options, err := mountoptions.Recv(ctx, *mountSockPath)
 	if err != nil {
 		klog.Fatalf("Failed to receive mount options from %s: %v\n", *mountSockPath, err)
 	}
+	klog.Infof("Mount options has been received from %s", *mountSockPath)
 	return options
 }

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/moby/sys/mountinfo v0.7.1 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect

--- a/pkg/podmounter/mountoptions/mount_options.go
+++ b/pkg/podmounter/mountoptions/mount_options.go
@@ -1,0 +1,130 @@
+// Package mountoptions provides utilities for passing mount options between
+// Mountpoint and CSI Driver Node Pods running in the same node.
+package mountoptions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"syscall"
+)
+
+// An Options struct represents mount options to use while invoking Mountpoint.
+type Options struct {
+	// Fd will be passed over Unix socket using `SCM_RIGHTS`, not as part of the serialized JSON.
+	Fd         int      `json:"-"`
+	BucketName string   `json:"bucketName"`
+	Args       []string `json:"args"`
+	Env        []string `json:"env"`
+}
+
+// Send sends given mount `options` to given `sockPath` to be received by `Recv` function on the other end.
+func Send(ctx context.Context, sockPath string, options Options) error {
+	message, err := json.Marshal(&options)
+	if err != nil {
+		return fmt.Errorf("failed to marshal message to send %s: %w", sockPath, err)
+	}
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("failed to dial to unix socket %s: %w", sockPath, err)
+	}
+	defer conn.Close()
+
+	unixConn := conn.(*net.UnixConn)
+
+	unixRights := syscall.UnixRights(options.Fd)
+	messageN, unixRightsN, err := unixConn.WriteMsgUnix(message, unixRights, nil)
+	if err != nil {
+		return fmt.Errorf("failed to write to unix socket %s: %w", sockPath, err)
+	}
+	if len(message) != messageN || len(unixRights) != unixRightsN {
+		return fmt.Errorf("partial write to unix socket %s: message: size %d - written %d, unix rights: size %d - written %d",
+			sockPath, len(message), messageN, len(unixRights), unixRightsN)
+	}
+
+	return nil
+}
+
+var (
+	messageRecvSize = 1024
+	// We only pass one file descriptor and its 32 bits
+	unixRightsRecvSize = syscall.CmsgSpace(4)
+)
+
+// Recv receives passed mount options via `Send` function through given `sockPath`.
+func Recv(ctx context.Context, sockPath string) (Options, error) {
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return Options{}, fmt.Errorf("failed to listen unix socket %s: %w", sockPath, err)
+	}
+	defer l.Close()
+
+	conn, err := l.Accept()
+	if err != nil {
+		return Options{}, fmt.Errorf("failed to accept connection from unix socket %s: %w", sockPath, err)
+	}
+
+	unixConn := conn.(*net.UnixConn)
+
+	messageBuf := make([]byte, 0)
+	unixRightsBuf := make([]byte, 0)
+
+	// Read in a loop to consume the whole message
+	for {
+		message := make([]byte, messageRecvSize)
+		unixRights := make([]byte, unixRightsRecvSize)
+
+		messageN, unixRightsN, _, _, err := unixConn.ReadMsgUnix(message, unixRights)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return Options{}, fmt.Errorf("failed to read message from unix socket %s: %w", sockPath, err)
+		}
+
+		messageBuf = append(messageBuf, message[:messageN]...)
+		unixRightsBuf = append(unixRightsBuf, unixRights[:unixRightsN]...)
+	}
+
+	var options Options
+	err = json.Unmarshal(messageBuf, &options)
+	if err != nil {
+		return Options{}, fmt.Errorf("failed to decode mount options from unix socket %s: %w", sockPath, err)
+	}
+
+	fds, err := parseUnixRights(unixRightsBuf)
+	if err != nil {
+		return Options{}, fmt.Errorf("failed to decode unix rights from unix socket %s: %w", sockPath, err)
+	}
+
+	if len(fds) != 1 {
+		return Options{}, fmt.Errorf("expected to got one file descriptor from unix socket %s, but got %d", sockPath, len(fds))
+	}
+
+	options.Fd = fds[0]
+	return options, nil
+}
+
+// parseUnixRights parses given socket control message to extract passed file descriptors.
+func parseUnixRights(buf []byte) ([]int, error) {
+	socketControlMessages, err := syscall.ParseSocketControlMessage(buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse socket control message: %w", err)
+	}
+
+	var fds []int
+	for _, msg := range socketControlMessages {
+		fd, err := syscall.ParseUnixRights(&msg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse unix rights: %w", err)
+		}
+		fds = append(fds, fd...)
+	}
+
+	return fds, nil
+}

--- a/pkg/podmounter/mountoptions/mount_options_test.go
+++ b/pkg/podmounter/mountoptions/mount_options_test.go
@@ -1,0 +1,72 @@
+package mountoptions_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestSendingAndReceivingMountOptions(t *testing.T) {
+	file, err := os.Open(os.DevNull)
+	assert.NoError(t, err)
+	defer file.Close()
+
+	var wantStat = &syscall.Stat_t{}
+	err = syscall.Fstat(int(file.Fd()), wantStat)
+	assert.NoError(t, err)
+
+	mountSock := filepath.Join(t.TempDir(), "m")
+
+	c := make(chan mountoptions.Options)
+	go func() {
+		mountOptions, err := mountoptions.Recv(defaultContext(t), mountSock)
+		assert.NoError(t, err)
+		c <- mountOptions
+	}()
+
+	err = util.WaitForUnixSocket(defaultTimeout, 500*time.Millisecond, mountSock)
+	assert.NoError(t, err)
+
+	want := mountoptions.Options{
+		Fd:         int(file.Fd()),
+		BucketName: "test-bucket",
+		Args:       []string{"--bucket=testing"},
+		Env:        []string{"TEST_ENV=testing"},
+	}
+	err = mountoptions.Send(defaultContext(t), mountSock, want)
+	assert.NoError(t, err)
+
+	got := <-c
+
+	gotFile := os.NewFile(uintptr(got.Fd), "fd")
+	if gotFile == nil {
+		t.Fatalf("received file descriptor %d is invalid\n", got.Fd)
+	}
+
+	var gotStat = &syscall.Stat_t{}
+	err = syscall.Fstat(got.Fd, gotStat)
+	assert.NoError(t, err)
+
+	// Reset fds as they might be different in different ends.
+	// To verify underlying objects are the same, we need to compare "dev" and "ino" from "fstat" syscall.
+	got.Fd = 0
+	want.Fd = 0
+	assert.Equals(t, wantStat.Dev, gotStat.Dev)
+	assert.Equals(t, wantStat.Ino, gotStat.Ino)
+	assert.Equals(t, want, got)
+}
+
+const defaultTimeout = 10 * time.Second
+
+func defaultContext(t *testing.T) context.Context {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	t.Cleanup(cancel)
+	return ctx
+}

--- a/pkg/util/socket.go
+++ b/pkg/util/socket.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// ErrUnixSocketNotExists is returned if the socket won't appear within the timeout duration.
+var ErrUnixSocketNotExists = errors.New("util/socket: unix socket does not exists")
+
+// WaitForUnixSocket waits for the duration of `timeout` until `path` exists by checking it every `interval`.
+// It returns `ErrUnixSocketNotExists` if the socket won't appear within the timeout, otherwise it returns nil.
+func WaitForUnixSocket(timeout time.Duration, interval time.Duration, path string) error {
+	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(_ context.Context) (bool, error) {
+		_, err := os.Stat(path)
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return false, err
+		}
+		return err == nil, nil
+	})
+
+	if wait.Interrupted(err) {
+		return ErrUnixSocketNotExists
+	}
+
+	return err
+}

--- a/pkg/util/socket_test.go
+++ b/pkg/util/socket_test.go
@@ -1,0 +1,45 @@
+package util_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestWaitingForUnixSocket(t *testing.T) {
+	const retryPeriod = 500 * time.Microsecond
+
+	t.Run("file already exists", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.sock")
+
+		_, err := os.Create(path)
+		assert.NoError(t, err)
+
+		err = util.WaitForUnixSocket(1*time.Millisecond, retryPeriod, path)
+		assert.NoError(t, err)
+	})
+
+	t.Run("file appears after a while", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.sock")
+
+		go func() {
+			time.Sleep(1 * time.Millisecond)
+			_, err := os.Create(path)
+			assert.NoError(t, err)
+		}()
+
+		err := util.WaitForUnixSocket(10*time.Millisecond, retryPeriod, path)
+		assert.NoError(t, err)
+	})
+
+	t.Run("file does not appear within the timeout", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.sock")
+
+		err := util.WaitForUnixSocket(1*time.Millisecond, retryPeriod, path)
+		assert.Equals(t, util.ErrUnixSocketNotExists, err)
+	})
+}

--- a/pkg/util/testutil/assert/assert.go
+++ b/pkg/util/testutil/assert/assert.go
@@ -1,0 +1,25 @@
+// Package assert provides utilities for making assertions during tests.
+package assert
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// Equals fails the test if `want` and `got` are not equal.
+func Equals[T interface{}](t *testing.T, want T, got T) {
+	t.Helper()
+	if diff := cmp.Diff(want, got, cmpopts.EquateErrors()); diff != "" {
+		t.Errorf("Assertion failure (-want +got):\n%s", diff)
+	}
+}
+
+// NoError fails the test if `err` is not nil.
+func NoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Expected no error, but got: %s", err)
+	}
+}

--- a/pkg/util/testutil/assert/assert.go
+++ b/pkg/util/testutil/assert/assert.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Equals fails the test if `want` and `got` are not equal.
-func Equals[T interface{}](t *testing.T, want T, got T) {
+func Equals(t *testing.T, want interface{}, got interface{}) {
 	t.Helper()
 	if diff := cmp.Diff(want, got, cmpopts.EquateErrors()); diff != "" {
 		t.Errorf("Assertion failure (-want +got):\n%s", diff)


### PR DESCRIPTION
This is part of https://github.com/awslabs/mountpoint-s3-csi-driver/issues/279.

This new component, `aws-s3-csi-mounter`, will be the entry point for the container running Mountpoint. It will be responsible for receiving mount options and FUSE file descriptor and spawning Mountpoint process until completion.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
