### PR TITLE
Disable fast-fast for end-to-end tests in CI

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -70,6 +70,9 @@ jobs:
   test:
     needs: build
     strategy:
+      # Failing fast causes some resources created during the test to leak,
+      # so we disable it to ensure all resources created during test are properly cleaned up.
+      fail-fast: false
       matrix:
         cluster-type: ["eksctl", "kops"]
         arch: ["x86", "arm"]


### PR DESCRIPTION
Fail-fast causes some testing resources to leak if one of tests fails. We disable it to ensure all testing resources are properly cleaned up.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
