### PR TITLE
Add tests for Express cache

### DIFF
--- a/tests/e2e-kubernetes/testsuites/cache.go
+++ b/tests/e2e-kubernetes/testsuites/cache.go
@@ -20,6 +20,8 @@ import (
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
+
+	"github.com/awslabs/aws-s3-csi-driver/tests/e2e-kubernetes/s3client"
 )
 
 const volumeName1 = "volume1"
@@ -115,16 +117,13 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		checkDeletingPath(f, pod, second)
 	}
 
-	createPod := func(ctx context.Context, additionalMountOptions []string, podModifiers ...func(*v1.Pod)) (*v1.Pod, string) {
-		cacheDir := randomCacheDir()
-
-		vol := createVolumeResourceWithMountOptions(ctx, l.config, pattern, append(additionalMountOptions, fmt.Sprintf("cache %s", cacheDir)))
+	createPod := func(ctx context.Context, mountOptions []string, podModifiers ...func(*v1.Pod)) (*v1.Pod, string) {
+		vol := createVolumeResourceWithMountOptions(ctx, l.config, pattern, mountOptions)
 		deferCleanup(vol.CleanupResource)
 
 		bucketName := bucketNameFromVolumeResource(vol)
 
 		pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{vol.Pvc}, admissionapi.LevelBaseline, "")
-		ensureCacheDirExistsInNode(pod, cacheDir)
 		for _, pm := range podModifiers {
 			pm(pod)
 		}
@@ -136,52 +135,173 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		return pod, bucketName
 	}
 
-	Describe("Cache", func() {
-		Describe("Local", func() {
-			It("basic file operations as root", func(ctx context.Context) {
-				pod, bucketName := createPod(ctx, []string{"allow-delete"}, func(pod *v1.Pod) {
+	type cacheTestConfig struct {
+		useLocalCache   bool
+		useExpressCache bool
+	}
+
+	testCache := func(config cacheTestConfig) {
+		var baseMountOptions []string
+		var basePodModifiers []func(*v1.Pod)
+		var expressCacheBucketName string
+
+		BeforeEach(func(ctx context.Context) {
+			// Reset shared configuration on each run
+			baseMountOptions = nil
+			basePodModifiers = nil
+			expressCacheBucketName = ""
+
+			if config.useLocalCache {
+				cacheDir := randomCacheDir()
+				basePodModifiers = append(basePodModifiers, func(pod *v1.Pod) {
+					ensureCacheDirExistsInNode(pod, cacheDir)
+				})
+				baseMountOptions = append(baseMountOptions, fmt.Sprintf("cache %s", cacheDir))
+			}
+
+			if config.useExpressCache {
+				client := s3client.New()
+				cacheBucketName, deleteBucket := client.CreateDirectoryBucket(ctx)
+				deferCleanup(deleteBucket)
+				baseMountOptions = append(baseMountOptions, fmt.Sprintf("cache-xz %s", cacheBucketName))
+				expressCacheBucketName = cacheBucketName
+			}
+		})
+
+		It("basic file operations as root", func(ctx context.Context) {
+			mountOptions := append(baseMountOptions, "allow-delete")
+			podModifiers := append(basePodModifiers, func(pod *v1.Pod) {
+				pod.Spec.Containers[0].SecurityContext.RunAsUser = ptr.To(root)
+				pod.Spec.Containers[0].SecurityContext.RunAsGroup = ptr.To(root)
+			})
+
+			pod, bucketName := createPod(ctx, mountOptions, podModifiers...)
+			checkBasicFileOperations(ctx, pod, bucketName, e2epod.VolumeMountPath1)
+		})
+
+		It("basic file operations as non-root", func(ctx context.Context) {
+			mountOptions := append(baseMountOptions,
+				"allow-delete",
+				"allow-other",
+				fmt.Sprintf("uid=%d", *e2epod.GetDefaultNonRootUser()),
+				fmt.Sprintf("gid=%d", defaultNonRootGroup))
+			podModifiers := append(basePodModifiers, func(pod *v1.Pod) {
+				pod.Spec.Containers[0].SecurityContext.RunAsUser = e2epod.GetDefaultNonRootUser()
+				pod.Spec.Containers[0].SecurityContext.RunAsGroup = ptr.To(defaultNonRootGroup)
+				pod.Spec.Containers[0].SecurityContext.RunAsNonRoot = ptr.To(true)
+			})
+
+			pod, bucketName := createPod(ctx, mountOptions, podModifiers...)
+			checkBasicFileOperations(ctx, pod, bucketName, e2epod.VolumeMountPath1)
+		})
+
+		It("two containers in the same pod using the same cache", func(ctx context.Context) {
+			testFile := filepath.Join(e2epod.VolumeMountPath1, "helloworld.txt")
+
+			mountOptions := append(baseMountOptions, "allow-delete")
+			podModifiers := append(basePodModifiers, func(pod *v1.Pod) {
+				// Make it init container to ensure it runs before regular containers
+				pod.Spec.InitContainers = append(pod.Spec.InitContainers, v1.Container{
+					Name:  "populate-cache",
+					Image: e2epod.GetDefaultTestImage(),
+					Command: e2epod.GenerateScriptCmd(
+						fmt.Sprintf("echo 'hello world!' > %s && cat %s | grep -q 'hello world!'", testFile, testFile)),
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      volumeName1,
+							MountPath: e2epod.VolumeMountPath1,
+						},
+					},
+				})
+			})
+
+			pod, _ := createPod(ctx, mountOptions, podModifiers...)
+			e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("cat %s | grep -q 'hello world!'", testFile))
+		})
+
+		// If we're testing multi-level cache, add two more test cases:
+		// 	1) Ensure it still works if local-cache is wiped out
+		// 	1) Ensure it still works if Express-cache is wiped out
+		if config.useLocalCache && config.useExpressCache {
+			It("should use Express cache if local cache is empty", func(ctx context.Context) {
+				mountOptions := append(baseMountOptions, "allow-delete")
+				podModifiers := append(basePodModifiers, func(pod *v1.Pod) {
 					pod.Spec.Containers[0].SecurityContext.RunAsUser = ptr.To(root)
 					pod.Spec.Containers[0].SecurityContext.RunAsGroup = ptr.To(root)
 				})
-				checkBasicFileOperations(ctx, pod, bucketName, e2epod.VolumeMountPath1)
-			})
 
-			It("basic file operations as non-root", func(ctx context.Context) {
-				mountOptions := []string{
-					"allow-delete",
-					"allow-other",
-					fmt.Sprintf("uid=%d", *e2epod.GetDefaultNonRootUser()),
-					fmt.Sprintf("gid=%d", defaultNonRootGroup),
+				pod, bucketName := createPod(ctx, mountOptions, podModifiers...)
+
+				seed := time.Now().UTC().UnixNano()
+				testWriteSize := 1024 // 1KB
+
+				first := filepath.Join(e2epod.VolumeMountPath1, "first")
+
+				checkWriteToPath(f, pod, first, testWriteSize, seed)
+				// Initial read should work and populate both local and Express cache
+				for i := 0; i < 3; i++ {
+					checkReadFromPath(f, pod, first, testWriteSize, seed)
 				}
-				pod, bucketName := createPod(ctx, mountOptions, func(pod *v1.Pod) {
-					pod.Spec.Containers[0].SecurityContext.RunAsUser = e2epod.GetDefaultNonRootUser()
-					pod.Spec.Containers[0].SecurityContext.RunAsGroup = ptr.To(defaultNonRootGroup)
-					pod.Spec.Containers[0].SecurityContext.RunAsNonRoot = ptr.To(true)
-				})
 
-				checkBasicFileOperations(ctx, pod, bucketName, e2epod.VolumeMountPath1)
+				// Now remove the file from S3 and wipe out local cache
+				deleteObjectFromS3(ctx, bucketName, "first")
+				e2evolume.VerifyExecInPodSucceed(f, pod, "rm -rf /cache/*")
+
+				// Reading should still work
+				for i := 0; i < 3; i++ {
+					checkReadFromPath(f, pod, first, testWriteSize, seed)
+				}
 			})
 
-			It("two containers in the same pod using the same cache", func(ctx context.Context) {
-				testFile := filepath.Join(e2epod.VolumeMountPath1, "helloworld.txt")
-
-				pod, _ := createPod(ctx, []string{"allow-delete"}, func(pod *v1.Pod) {
-					// Make it init container to ensure it runs before regular containers
-					pod.Spec.InitContainers = append(pod.Spec.InitContainers, v1.Container{
-						Name:  "populate-cache",
-						Image: e2epod.GetDefaultTestImage(),
-						Command: e2epod.GenerateScriptCmd(
-							fmt.Sprintf("echo 'hello world!' > %s && cat %s | grep -q 'hello world!'", testFile, testFile)),
-						VolumeMounts: []v1.VolumeMount{
-							{
-								Name:      volumeName1,
-								MountPath: e2epod.VolumeMountPath1,
-							},
-						},
-					})
+			It("should use local cache if Express cache is empty", func(ctx context.Context) {
+				mountOptions := append(baseMountOptions, "allow-delete")
+				podModifiers := append(basePodModifiers, func(pod *v1.Pod) {
+					pod.Spec.Containers[0].SecurityContext.RunAsUser = ptr.To(root)
+					pod.Spec.Containers[0].SecurityContext.RunAsGroup = ptr.To(root)
 				})
 
-				e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("cat %s | grep -q 'hello world!'", testFile))
+				pod, bucketName := createPod(ctx, mountOptions, podModifiers...)
+
+				seed := time.Now().UTC().UnixNano()
+				testWriteSize := 1024 // 1KB
+
+				first := filepath.Join(e2epod.VolumeMountPath1, "first")
+
+				checkWriteToPath(f, pod, first, testWriteSize, seed)
+				// Initial read should work and populate both local and Express cache
+				for i := 0; i < 3; i++ {
+					checkReadFromPath(f, pod, first, testWriteSize, seed)
+				}
+
+				// Now remove the file from S3 and wipe out Express cache
+				deleteObjectFromS3(ctx, bucketName, "first")
+				s3client.New().WipeoutBucket(ctx, expressCacheBucketName)
+
+				// Reading should still work
+				for i := 0; i < 3; i++ {
+					checkReadFromPath(f, pod, first, testWriteSize, seed)
+				}
+			})
+		}
+	}
+
+	Describe("Cache", func() {
+		Describe("Local", func() {
+			testCache(cacheTestConfig{
+				useLocalCache: true,
+			})
+		})
+
+		Describe("Express", func() {
+			testCache(cacheTestConfig{
+				useExpressCache: true,
+			})
+		})
+
+		Describe("Multi-Level", func() {
+			testCache(cacheTestConfig{
+				useLocalCache:   true,
+				useExpressCache: true,
 			})
 		})
 	})


### PR DESCRIPTION
[Mountpoint v1.11.0](https://github.com/awslabs/mountpoint-s3/blob/main/mountpoint-s3/CHANGELOG.md#v1110-november-21-2024) added support for caching objects to S3 Express bucket. This PR adds some end-to-end tests to make sure it works with the CSI Driver without any problem.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
