### PR TITLE
Add passing e2e test suites and update tests to explicitly pass STS region

### DIFF
--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -28,6 +28,7 @@ func init() {
 	flag.Parse()
 
 	s3client.DefaultRegion = BucketRegion
+	custom_testsuites.DefaultRegion = BucketRegion
 }
 
 func TestE2E(t *testing.T) {

--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -37,10 +37,10 @@ func TestE2E(t *testing.T) {
 
 var CSITestSuites = []func() framework.TestSuite{
 	// testsuites.InitCapacityTestSuite,
-	testsuites.InitVolumesTestSuite, // success: writes 53 bytes to index.html file, reads and verifies content from another pod
-	// testsuites.InitVolumeIOTestSuite,   // tries to open a file for writing multiple times, which is unsupported by MP
-	// testsuites.InitVolumeModeTestSuite, // fail: tries to mount in block mode, success: check unused volume is not mounted
-	// testsuites.InitSubPathTestSuite,
+	testsuites.InitVolumesTestSuite, // Passed - Verifies writing 53 bytes to index.html and reading from another pod.
+	// testsuites.InitVolumeIOTestSuite,   // Failed - Requires specified MountOption for append mode, which is unsupported by the test framework.
+	testsuites.InitVolumeModeTestSuite, // Passed - Validates PV, PVC, and S3 bucket creation, failure handling for block mode, and absence of unused volumes in the pod.
+	// testsuites.InitSubPathTestSuite, // Failed - Hard links and symbolic links are both unsupported in Mountpoint.
 	// testsuites.InitProvisioningTestSuite,
 	// testsuites.InitMultiVolumeTestSuite,
 	// testsuites.InitVolumeExpandTestSuite,


### PR DESCRIPTION
This PR addresses an issue where the CSI Driver tests rely on IMDS to configure the STS region. While this works well for clusters like those created with `eksctl` and `kOps`, which configure IMDS access by default, other cluster setups may not have IMDS access configured by default. This can cause the tests to fail unless the IMDS hop limit is adjusted.

*Description of changes:*

Updated e2e Credential tests to explicitly pass the STS region through `MountOptions`.
Clarified Kubernetes e2e storage tests outcomes and update an additional passing test suite.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
