### PR TITLE
Update E2E Tests to Support Explicit STS Region Configuration 

### DIFF
--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -25,9 +25,12 @@ func init() {
 	flag.StringVar(&BucketRegion, "bucket-region", "us-east-1", "region where temporary buckets will be created")
 	flag.StringVar(&BucketPrefix, "bucket-prefix", "local", "prefix for temporary buckets")
 	flag.BoolVar(&Performance, "performance", false, "run performance tests")
+	flag.BoolVar(&IMDSAvailable, "imds-available", false, "indicates whether instance metadata service is available")
 	flag.Parse()
 
 	s3client.DefaultRegion = BucketRegion
+	custom_testsuites.DefaultRegion = BucketRegion
+	custom_testsuites.IMDSAvailable = IMDSAvailable
 }
 
 func TestE2E(t *testing.T) {

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -198,14 +198,14 @@ elif [[ "${ACTION}" == "install_driver" ]]; then
 elif [[ "${ACTION}" == "run_tests" ]]; then
   set +e
   pushd tests/e2e-kubernetes
-  KUBECONFIG=${KUBECONFIG} go test -ginkgo.vv -timeout 30m --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME}
+  KUBECONFIG=${KUBECONFIG} go test -ginkgo.vv -timeout 30m --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=true
   EXIT_CODE=$?
   print_cluster_info
   exit $EXIT_CODE
 elif [[ "${ACTION}" == "run_perf" ]]; then
   set +e
   pushd tests/e2e-kubernetes
-  KUBECONFIG=${KUBECONFIG} go test -ginkgo.vv --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --performance=true
+  KUBECONFIG=${KUBECONFIG} go test -ginkgo.vv --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --performance=true --imds-available=true
   EXIT_CODE=$?
   print_cluster_info
   popd

--- a/tests/e2e-kubernetes/testdriver.go
+++ b/tests/e2e-kubernetes/testdriver.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	CommitId     string
-	BucketRegion string // assumed to be the same as k8s cluster's region
-	BucketPrefix string
-	Performance  bool
+	CommitId      string
+	BucketRegion  string // assumed to be the same as k8s cluster's region
+	BucketPrefix  string
+	Performance   bool
+	IMDSAvailable bool
 )
 
 type s3Driver struct {

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -53,7 +53,7 @@ const serviceAccountTokenAudienceSTS = "sts.amazonaws.com"
 const roleARNAnnotation = "eks.amazonaws.com/role-arn"
 const credentialSecretName = "aws-secret"
 
-// DefaultRegion specifies the STS region explicitl.
+// DefaultRegion specifies the STS region explicitly.
 var DefaultRegion string
 
 // IMDSAvailable indicates whether the Instance Metadata Service is accessible.

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -472,7 +472,7 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				})
 
 				It("should use up to date role associated with pod's service account", func(ctx context.Context) {
-					var mountOptions = append([]string{"allow-delete"}, fmt.Sprintf("region %s", DefaultRegion))
+					mountOptions := []string{"allow-delete", fmt.Sprintf("region %s", DefaultRegion)}
 					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, mountOptions)
 					deferCleanup(vol.CleanupResource)
 
@@ -514,7 +514,7 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				})
 
 				It("should not mix different pod's service account tokens even when they are using the same volume", func(ctx context.Context) {
-					var mountOptions = append([]string{"allow-delete"}, fmt.Sprintf("region %s", DefaultRegion))
+					mountOptions := []string{"allow-delete", fmt.Sprintf("region %s", DefaultRegion)}
 					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, mountOptions)
 					deferCleanup(vol.CleanupResource)
 
@@ -542,7 +542,7 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				It("should not use pod's service account's role if 'authenticationSource' is 'driver'", func(ctx context.Context) {
 					updateDriverLevelKubernetesSecret(ctx, iamPolicyS3ReadOnlyAccess)
 
-					var mountOptions = append([]string{"allow-delete"}, fmt.Sprintf("region %s", DefaultRegion))
+					mountOptions := []string{"allow-delete", fmt.Sprintf("region %s", DefaultRegion)}
 					vol := createVolumeResourceWithMountOptions(enableDriverLevelIdentity(ctx), l.config, pattern, mountOptions)
 					deferCleanup(vol.CleanupResource)
 

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -53,6 +53,13 @@ const serviceAccountTokenAudienceSTS = "sts.amazonaws.com"
 const roleARNAnnotation = "eks.amazonaws.com/role-arn"
 const credentialSecretName = "aws-secret"
 
+// DefaultRegion specifies the STS region explicitl.
+var DefaultRegion string
+
+// IMDSAvailable indicates whether the Instance Metadata Service is accessible.
+// When true, it enables a test that rely on automatic detection of the STS region.
+var IMDSAvailable bool
+
 type s3CSICredentialsTestSuite struct {
 	tsInfo storageframework.TestSuiteInfo
 }
@@ -420,7 +427,7 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				createPodWithServiceAccountAndPolicy := func(ctx context.Context, policyARN string, allowDelete bool) (*v1.Pod, *v1.ServiceAccount) {
 					By("Creating Pod with ServiceAccount")
 
-					var mountOptions []string
+					mountOptions := []string{fmt.Sprintf("region %s", DefaultRegion)}
 					if allowDelete {
 						mountOptions = append(mountOptions, "allow-delete")
 					}
@@ -465,7 +472,8 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				})
 
 				It("should use up to date role associated with pod's service account", func(ctx context.Context) {
-					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, []string{"allow-delete"})
+					var mountOptions = append([]string{"allow-delete"}, fmt.Sprintf("region %s", DefaultRegion))
+					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, mountOptions)
 					deferCleanup(vol.CleanupResource)
 
 					// Create a SA with full access role
@@ -506,7 +514,8 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				})
 
 				It("should not mix different pod's service account tokens even when they are using the same volume", func(ctx context.Context) {
-					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, []string{"allow-delete"})
+					var mountOptions = append([]string{"allow-delete"}, fmt.Sprintf("region %s", DefaultRegion))
+					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, mountOptions)
 					deferCleanup(vol.CleanupResource)
 
 					saFullAccess := createServiceAccountWithPolicy(ctx, iamPolicyS3FullAccess)
@@ -533,7 +542,8 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				It("should not use pod's service account's role if 'authenticationSource' is 'driver'", func(ctx context.Context) {
 					updateDriverLevelKubernetesSecret(ctx, iamPolicyS3ReadOnlyAccess)
 
-					vol := createVolumeResourceWithMountOptions(enableDriverLevelIdentity(ctx), l.config, pattern, []string{"allow-delete"})
+					var mountOptions = append([]string{"allow-delete"}, fmt.Sprintf("region %s", DefaultRegion))
+					vol := createVolumeResourceWithMountOptions(enableDriverLevelIdentity(ctx), l.config, pattern, mountOptions)
 					deferCleanup(vol.CleanupResource)
 
 					sa := createServiceAccountWithPolicy(ctx, iamPolicyS3FullAccess)
@@ -543,6 +553,22 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 					deferCleanup(func(ctx context.Context) error { return e2epod.DeletePodWithWait(ctx, f.ClientSet, pod) })
 
 					expectReadOnly(pod)
+				})
+
+				It("should automatically detect the STS region if IMDS is available", func(ctx context.Context) {
+					if !IMDSAvailable {
+						Skip("IMDS is not available, skipping test for automatic region detection")
+					}
+
+					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, []string{"allow-delete"})
+					deferCleanup(vol.CleanupResource)
+
+					sa := createServiceAccountWithPolicy(ctx, iamPolicyS3FullAccess)
+
+					pod, err := createPodWithServiceAccount(ctx, f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{vol.Pvc}, sa.Name)
+					framework.ExpectNoError(err)
+
+					expectFullAccess(pod)
 				})
 			})
 		})


### PR DESCRIPTION
*Issue:*

This PR addresses Credentials test failures in clusters without IMDS access. 

*Description of Changes:*

- Add a new flag `imds-available` to indicate if IMDS is available.
- Configure the STS region through the `bucket-region` flag and pass the region explicitly to the tests.
- Add a test case to verify automatic STS region detection when the `imds-available` is set to true.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
