### PR TITLE
Make `s3-plugin` container's `imagePullPolicy` configurable

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -81,7 +81,7 @@ spec:
               role: {{ .role }}
               level: {{ .level }}
             {{- end }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --v={{ .Values.node.logLevel }}


### PR DESCRIPTION
*Description of changes:*
Currently, the `imagePullPolicy` was hardcoded to `IfNotPresent` for `s3-plugin` . This PR updates the Helm chart template to make the` imagePullPolicy` for the `s3-plugin` container configurable via Helm values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
