### PR TITLE
Stop retrying to delete security group if we got "NotFound" error

### DIFF
--- a/tests/e2e-kubernetes/scripts/eksctl.sh
+++ b/tests/e2e-kubernetes/scripts/eksctl.sh
@@ -106,10 +106,13 @@ function delete_security_group() {
   REGION=${1}
   SECURITY_GROUP=${2}
 
-  remaining_attemps=20
-  while (( remaining_attemps-- > 0 ))
+  remaining_attempts=20
+  while (( remaining_attempts-- > 0 ))
   do
-      if $(aws ec2 delete-security-group --region ${REGION} --group-id ${SECURITY_GROUP}); then
+      if output=$(aws ec2 delete-security-group --region ${REGION} --group-id ${SECURITY_GROUP} 2>&1); then
+        return
+      fi
+      if [[ $output == *"InvalidGroup.NotFound"* ]]; then
         return
       fi
       sleep 30
@@ -120,8 +123,8 @@ function delete_eni() {
   REGION=${1}
   ENI_ID=${2}
 
-  remaining_attemps=20
-  while (( remaining_attemps-- > 0 ))
+  remaining_attempts=20
+  while (( remaining_attempts-- > 0 ))
   do
       if output=$(aws ec2 delete-network-interface --network-interface-id ${ENI_ID} --region ${REGION} 2>&1); then
         return


### PR DESCRIPTION
We were missing "NotFound" checks in our CI while trying to remove security groups, and it was causing this operation to retry until max retry time which is 10 minutes. This was resulting temporary credentials issued for CI to expire, and the CI run to fail. See https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/12392057877/job/34648273564 for example. We might still need to increase duration of temporary credentials from 1 hour to a longer duration if our CI keeps taking longer, but for now this should address the issue, hopefully.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
