### PR TITLE
Update CI to use Github Environments

### DIFF
--- a/.github/workflows/e2e-test-push.yaml
+++ b/.github/workflows/e2e-test-push.yaml
@@ -15,6 +15,6 @@ jobs:
     name: E2E Tests
     uses: ./.github/workflows/e2e-tests.yaml
     with:
-      environment: "Push"
+      environment: "untrusted"
       ref: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/e2e-test-push.yaml
+++ b/.github/workflows/e2e-test-push.yaml
@@ -1,0 +1,20 @@
+name: "E2E Tests (Push)"
+
+on:
+  push:
+    branches: [ "main", "feature/**", "release-**", "workflow/**" ]
+  merge_group:
+    types: [ "checks_requested" ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E Tests
+    uses: ./.github/workflows/e2e-tests.yaml
+    with:
+      environment: "Push"
+      ref: ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -1,0 +1,20 @@
+name: "E2E Tests (Trusted)"
+
+on:
+  push:
+    branches: [ "main", "feature/**", "release-**", "workflow/**" ]
+  merge_group:
+    types: [ "checks_requested" ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E Tests
+    uses: ./.github/workflows/e2e-tests.yaml
+    with:
+      environment: "trusted"
+      ref: ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -16,5 +16,5 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       environment: "trusted"
-      ref: ${{ github.sha }}
+      ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
     secrets: inherit

--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -1,10 +1,7 @@
-name: "E2E Tests (Push)"
+name: "E2E Tests (Untrusted)"
 
 on:
-  push:
-    branches: [ "main", "feature/**", "release-**", "workflow/**" ]
-  merge_group:
-    types: [ "checks_requested" ]
+  pull_request_target:
 
 permissions:
   id-token: write

--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -13,5 +13,5 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       environment: "untrusted"
-      ref: ${{ github.sha }}
+      ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           export PLATFORM=linux/amd64,linux/arm64
           export TAG=${{ env.COMMIT_ID }}
-          make -j `nproc` all-push
+          make -j `nproc` all-push-skip-if-present
   test:
     needs: build
     strategy:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -108,8 +108,11 @@ jobs:
       CLUSTER_TYPE: "${{ matrix.cluster-type }}"
       ARCH: "${{ matrix.arch }}"
       AMI_FAMILY: "${{ matrix.family }}"
-      K8S_VERSION: "${{ matrix.kubernetes-version }}"
       TAG: "untested_${{ inputs.ref }}"
+      # envtest doesn't support all versions, here K8S_VERSION is a full version like 1.28.13,
+      # and in order to get latest supported version by envtest we convert it to 1.28.
+      K8S_VERSION: "${{ matrix.kubernetes-version }}"
+      ENVTEST_K8S_VERSION: "${K8S_VERSION%.*}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -129,16 +132,12 @@ jobs:
           role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
       - name: Install tools
+        env:
+          ACTION: "install_tools"
         run: |
-          export ACTION=install_tools
-          export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
       - name: Run Controller Tests
         run: |
-          # envtest doesn't support all versions, here K8S_VERSION is a full version like 1.28.13,
-          # and in order to get latest supported version by envtest we convert it to 1.28.
-          export K8S_VERSION=${{ matrix.kubernetes-version }}
-          export ENVTEST_K8S_VERSION="${K8S_VERSION%.*}"
           make e2e-controller
       - name: Create cluster
         env:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -12,12 +12,13 @@ on:
 
 concurrency: e2e-cluster
 env:
-  COMMIT_ID: ${{ inputs.ref }}
   IMAGE_NAME: "s3-csi-driver"
   BENCHMARK_ARTIFACTS_FOLDER: ".github/artifacts"
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   KOPS_STATE_FILE: "s3://${{ vars.KOPS_STATE_FILE }}"
   BENCHMARK_BUCKET: "s3://${{ vars.BENCHMARK_BUCKET }}"
+  TAG_UNTESTED: "untested_${{ inputs.ref }}"
+  TAG_PASSED: "test_passed_${{ inputs.ref }}"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -48,10 +49,9 @@ jobs:
       - name: Build, tag, and push docker image to Amazon ECR Private Repository
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          PLATFORM: "linux/amd64,linux/arm64"
+          TAG: ${{ env.TAG_UNTESTED }}
         run: |
-          export PLATFORM=linux/amd64,linux/arm64
-          export TAG=${{ env.COMMIT_ID }}
           make -j `nproc` all-push-skip-if-present
   test:
     needs: build
@@ -103,6 +103,13 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      AWS_REGION: "${{ vars.AWS_REGION }}"
+      CLUSTER_TYPE: "${{ matrix.cluster-type }}"
+      ARCH: "${{ matrix.arch }}"
+      AMI_FAMILY: "${{ matrix.family }}"
+      K8S_VERSION: "${{ matrix.kubernetes-version }}"
+      TAG: "untested_${{ inputs.ref }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -117,7 +124,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -134,54 +141,30 @@ jobs:
           export ENVTEST_K8S_VERSION="${K8S_VERSION%.*}"
           make e2e-controller
       - name: Create cluster
+        env:
+          ACTION: "create_cluster"
         run: |
-          export ACTION=create_cluster
-          export AWS_REGION=${{ vars.AWS_REGION }}
-          export CLUSTER_TYPE=${{ matrix.cluster-type }}
-          export ARCH=${{ matrix.arch }}
-          export AMI_FAMILY=${{ matrix.family }}
-          export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
       - name: Update kubeconfig
+        env:
+          ACTION: "update_kubeconfig"
         run: |
-          export ACTION=update_kubeconfig
-          export AWS_REGION=${{ vars.AWS_REGION }}
-          export CLUSTER_TYPE=${{ matrix.cluster-type }}
-          export ARCH=${{ matrix.arch }}
-          export AMI_FAMILY=${{ matrix.family }}
-          export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
       - name: Install the driver
+        env:
+          ACTION: "install_driver"
         run: |
-          export ACTION=install_driver
-          export AWS_REGION=${{ vars.AWS_REGION }}
-          export CLUSTER_TYPE=${{ matrix.cluster-type }}
-          export IMAGE_NAME=${{ env.IMAGE_NAME }}
-          export TAG=${{ env.COMMIT_ID }}
-          export ARCH=${{ matrix.arch }}
-          export AMI_FAMILY=${{ matrix.family }}
-          export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
       - name: Run E2E Tests
+        env:
+          ACTION: "run_tests"
         run: |
-          export ACTION=run_tests
-          export AWS_REGION=${{ vars.AWS_REGION }}
-          export CLUSTER_TYPE=${{ matrix.cluster-type }}
-          export TAG=${{ env.COMMIT_ID }}
-          export ARCH=${{ matrix.arch }}
-          export AMI_FAMILY=${{ matrix.family }}
-          export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
       - name: Run Performance Tests
         if: (env.BRANCH_NAME == 'main' || env.BRANCH_NAME == 'bench') && matrix.cluster-type == 'kops' && matrix.arch == 'x86'
+        env:
+          ACTION: "run_perf"
         run: |
-          export ACTION=run_perf
-          export AWS_REGION=${{ vars.AWS_REGION }}
-          export CLUSTER_TYPE=${{ matrix.cluster-type }}
-          export TAG=${{ env.COMMIT_ID }}
-          export ARCH=${{ matrix.arch }}
-          export AMI_FAMILY=${{ matrix.family }}
-          export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
       - name: Download previous benchmark results
         if: (env.BRANCH_NAME == 'main' || env.BRANCH_NAME == 'bench') && matrix.cluster-type == 'kops' && matrix.arch == 'x86'
@@ -205,31 +188,43 @@ jobs:
           aws s3 cp ${{ env.BENCHMARK_ARTIFACTS_FOLDER }} ${{ env.BENCHMARK_BUCKET }} --recursive
       - name: Post e2e cleanup
         if: always()
+        env:
+          ACTION: "e2e_cleanup"
         run: |
-          export ACTION=e2e_cleanup
-          export AWS_REGION=${{ vars.AWS_REGION }}
-          export CLUSTER_TYPE=${{ matrix.cluster-type }}
-          export ARCH=${{ matrix.arch }}
-          export AMI_FAMILY=${{ matrix.family }}
-          export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
       - name: Uninstall the driver
         if: always()
+        env:
+          ACTION: "uninstall_driver"
         run: |
-          export ACTION=uninstall_driver
-          export AWS_REGION=${{ vars.AWS_REGION }}
-          export CLUSTER_TYPE=${{ matrix.cluster-type }}
-          export ARCH=${{ matrix.arch }}
-          export AMI_FAMILY=${{ matrix.family }}
-          export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
       - name: Delete cluster
         if: always()
+        env:
+          ACTION: "delete_cluster"
         run: |
-          export ACTION=delete_cluster
-          export AWS_REGION=${{ vars.AWS_REGION }}
-          export CLUSTER_TYPE=${{ matrix.cluster-type }}
-          export ARCH=${{ matrix.arch }}
-          export AMI_FAMILY=${{ matrix.family }}
-          export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
+  post_test:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Configure AWS Credentials
+        id: login
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Mark tests as passed
+        env:
+          REPOSITORY: "${{ steps.login.outputs.aws-account-id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.IMAGE_NAME }}"
+        run: |
+          docker buildx imagetools create --tag ${REPOSITORY}:${TAG_PASSED} ${REPOSITORY}:${TAG_UNTESTED}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,68 +1,55 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: ["main", "release-**", "feature/*"]
-  pull_request:
-    branches: ["main", "feature/*"]
-    paths:
-      - "tests/**"
-      - "pkg/**"
-      - "cmd/**"
-      - "charts/**"
-      - ".github/workflows/**"
-      - "Dockerfile"
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      ref:
+        required: true
+        type: string
+    secrets:
+      TEST_IAM_ROLE:
+        required: true
 
-# This workflow runs e2e tests and relies on existence of EKS cluster with a `s3-csi-driver-sa` service account
-# already deployed to it, which provides the driver with access to s3.
-#
-# Since we have a single cluster for e2e tests, we ensure that no more than one instance of this workflow is
-# running by `concurrency: e2e-cluster` option.
-#
-# Successful workflows triggered by push to main will upload tested image to the private repository "PROMOTED_IMAGE_NAME":
-# - uploaded images will be tagged with main branch commit number
-# - uploaded images will be later promoted to public repository by "release" workflow
 concurrency: e2e-cluster
 env:
-  AWS_REGION: "us-east-1"
-  COMMIT_ID: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
-  TMP_IMAGE_NAME: "s3-csi-driver-tmp"
-  PROMOTED_IMAGE_NAME: "s3-csi-driver"
-  BENCHMARK_RESULTS_BUCKET: "s3://mountpoint-s3-csi-driver-benchmark"
-  BENCHMARK_RESULTS_REGION: "us-east-1"
+  COMMIT_ID: ${{ inputs.ref }}
+  IMAGE_NAME: "s3-csi-driver"
   BENCHMARK_ARTIFACTS_FOLDER: ".github/artifacts"
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 jobs:
   build:
-    # this is to prevent the job to run at forked projects
-    if: github.repository == 'awslabs/mountpoint-s3-csi-driver'
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     permissions:
       id-token: write
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
           role-to-assume: ${{ secrets.TEST_IAM_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
       - name: Build, tag, and push docker image to Amazon ECR Private Repository
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_NAME: ${{ env.TMP_IMAGE_NAME }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
         run: |
           export PLATFORM=linux/amd64,linux/arm64
           export TAG=${{ env.COMMIT_ID }}
@@ -113,12 +100,16 @@ jobs:
           - cluster-type: "kops"
             kubernetes-version: "1.31.0"
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     permissions:
       id-token: write
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -130,7 +121,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@master
         with:
           role-to-assume: ${{ secrets.TEST_IAM_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
       - name: Install tools
         run: |
           export ACTION=install_tools
@@ -146,7 +137,7 @@ jobs:
       - name: Create cluster
         run: |
           export ACTION=create_cluster
-          export AWS_REGION=${{ env.AWS_REGION }}
+          export AWS_REGION=${{ vars.AWS_REGION }}
           export CLUSTER_TYPE=${{ matrix.cluster-type }}
           export ARCH=${{ matrix.arch }}
           export AMI_FAMILY=${{ matrix.family }}
@@ -155,7 +146,7 @@ jobs:
       - name: Update kubeconfig
         run: |
           export ACTION=update_kubeconfig
-          export AWS_REGION=${{ env.AWS_REGION }}
+          export AWS_REGION=${{ vars.AWS_REGION }}
           export CLUSTER_TYPE=${{ matrix.cluster-type }}
           export ARCH=${{ matrix.arch }}
           export AMI_FAMILY=${{ matrix.family }}
@@ -164,9 +155,9 @@ jobs:
       - name: Install the driver
         run: |
           export ACTION=install_driver
-          export AWS_REGION=${{ env.AWS_REGION }}
+          export AWS_REGION=${{ vars.AWS_REGION }}
           export CLUSTER_TYPE=${{ matrix.cluster-type }}
-          export IMAGE_NAME=${{ env.TMP_IMAGE_NAME }}
+          export IMAGE_NAME=${{ env.IMAGE_NAME }}
           export TAG=${{ env.COMMIT_ID }}
           export ARCH=${{ matrix.arch }}
           export AMI_FAMILY=${{ matrix.family }}
@@ -175,7 +166,7 @@ jobs:
       - name: Run E2E Tests
         run: |
           export ACTION=run_tests
-          export AWS_REGION=${{ env.AWS_REGION }}
+          export AWS_REGION=${{ vars.AWS_REGION }}
           export CLUSTER_TYPE=${{ matrix.cluster-type }}
           export TAG=${{ env.COMMIT_ID }}
           export ARCH=${{ matrix.arch }}
@@ -186,7 +177,7 @@ jobs:
         if: (env.BRANCH_NAME == 'main' || env.BRANCH_NAME == 'bench') && matrix.cluster-type == 'kops' && matrix.arch == 'x86'
         run: |
           export ACTION=run_perf
-          export AWS_REGION=${{ env.AWS_REGION }}
+          export AWS_REGION=${{ vars.AWS_REGION }}
           export CLUSTER_TYPE=${{ matrix.cluster-type }}
           export TAG=${{ env.COMMIT_ID }}
           export ARCH=${{ matrix.arch }}
@@ -197,7 +188,7 @@ jobs:
         if: (env.BRANCH_NAME == 'main' || env.BRANCH_NAME == 'bench') && matrix.cluster-type == 'kops' && matrix.arch == 'x86'
         run: |
           mkdir -p ${{ env.BENCHMARK_ARTIFACTS_FOLDER }}
-          aws s3 cp --region ${{ env.BENCHMARK_RESULTS_REGION }} ${{ env.BENCHMARK_RESULTS_BUCKET }}/benchmark-data.json ${{ env.BENCHMARK_ARTIFACTS_FOLDER }}/benchmark-data.json || true
+          aws s3 cp --region ${{ vars.BENCHMARK_RESULTS_REGION }} ${{ vars.BENCHMARK_RESULTS_BUCKET }}/benchmark-data.json ${{ env.BENCHMARK_ARTIFACTS_FOLDER }}/benchmark-data.json || true
       - name: Update benchmark result file
         if: (env.BRANCH_NAME == 'main' || env.BRANCH_NAME == 'bench') && matrix.cluster-type == 'kops' && matrix.arch == 'x86'
         uses: benchmark-action/github-action-benchmark@v1
@@ -217,7 +208,7 @@ jobs:
         if: always()
         run: |
           export ACTION=e2e_cleanup
-          export AWS_REGION=${{ env.AWS_REGION }}
+          export AWS_REGION=${{ vars.AWS_REGION }}
           export CLUSTER_TYPE=${{ matrix.cluster-type }}
           export ARCH=${{ matrix.arch }}
           export AMI_FAMILY=${{ matrix.family }}
@@ -227,7 +218,7 @@ jobs:
         if: always()
         run: |
           export ACTION=uninstall_driver
-          export AWS_REGION=${{ env.AWS_REGION }}
+          export AWS_REGION=${{ vars.AWS_REGION }}
           export CLUSTER_TYPE=${{ matrix.cluster-type }}
           export ARCH=${{ matrix.arch }}
           export AMI_FAMILY=${{ matrix.family }}
@@ -237,34 +228,9 @@ jobs:
         if: always()
         run: |
           export ACTION=delete_cluster
-          export AWS_REGION=${{ env.AWS_REGION }}
+          export AWS_REGION=${{ vars.AWS_REGION }}
           export CLUSTER_TYPE=${{ matrix.cluster-type }}
           export ARCH=${{ matrix.arch }}
           export AMI_FAMILY=${{ matrix.family }}
           export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
-  promote:
-    if: startsWith(github.ref_name, 'release')
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Set up crane
-        uses: imjasonh/setup-crane@v0.1
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: ${{ secrets.TEST_IAM_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Promote image for release branch
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          export TMP_IMAGE_NAME=${REGISTRY}/${{ env.TMP_IMAGE_NAME }}:${{ env.COMMIT_ID }}
-          export NEW_IMAGE_NAME=${REGISTRY}/${{ env.PROMOTED_IMAGE_NAME }}:${{ env.COMMIT_ID }}
-          crane copy ${TMP_IMAGE_NAME} ${NEW_IMAGE_NAME}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -9,9 +9,6 @@ on:
       ref:
         required: true
         type: string
-    secrets:
-      TEST_IAM_ROLE:
-        required: true
 
 concurrency: e2e-cluster
 env:
@@ -43,7 +40,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: ${{ secrets.TEST_IAM_ROLE }}
+          role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
@@ -122,7 +119,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: ${{ secrets.TEST_IAM_ROLE }}
+          role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
       - name: Install tools
         run: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -50,7 +50,7 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           PLATFORM: "linux/amd64,linux/arm64"
-          TAG: ${{ env.TAG_UNTESTED }}
+          TAG: "${{ env.TAG_UNTESTED }}"
         run: |
           make -j `nproc` all-push-skip-if-present
   test:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -19,6 +19,8 @@ env:
   IMAGE_NAME: "s3-csi-driver"
   BENCHMARK_ARTIFACTS_FOLDER: ".github/artifacts"
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  KOPS_STATE_FILE: "s3://${{ vars.KOPS_STATE_FILE }}"
+  BENCHMARK_BUCKET: "s3://${{ vars.BENCHMARK_BUCKET }}"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -188,7 +190,7 @@ jobs:
         if: (env.BRANCH_NAME == 'main' || env.BRANCH_NAME == 'bench') && matrix.cluster-type == 'kops' && matrix.arch == 'x86'
         run: |
           mkdir -p ${{ env.BENCHMARK_ARTIFACTS_FOLDER }}
-          aws s3 cp --region ${{ vars.BENCHMARK_RESULTS_REGION }} ${{ vars.BENCHMARK_RESULTS_BUCKET }}/benchmark-data.json ${{ env.BENCHMARK_ARTIFACTS_FOLDER }}/benchmark-data.json || true
+          aws s3 cp --region ${{ vars.BENCHMARK_RESULTS_REGION }} ${{ vars.BENCHMARK_BUCKET }}/benchmark-data.json ${{ env.BENCHMARK_ARTIFACTS_FOLDER }}/benchmark-data.json || true
       - name: Update benchmark result file
         if: (env.BRANCH_NAME == 'main' || env.BRANCH_NAME == 'bench') && matrix.cluster-type == 'kops' && matrix.arch == 'x86'
         uses: benchmark-action/github-action-benchmark@v1
@@ -203,7 +205,7 @@ jobs:
         if: (env.BRANCH_NAME == 'main' || env.BRANCH_NAME == 'bench') && matrix.cluster-type == 'kops' && matrix.arch == 'x86'
         run: |
           tests/e2e-kubernetes/scripts/format_benchmark_data.py ${{ env.BENCHMARK_ARTIFACTS_FOLDER }}/benchmark-data.json ${{ env.BENCHMARK_ARTIFACTS_FOLDER }}/quicksight-data.json
-          aws s3 cp ${{ env.BENCHMARK_ARTIFACTS_FOLDER }} s3://mountpoint-s3-csi-driver-benchmark --recursive
+          aws s3 cp ${{ env.BENCHMARK_ARTIFACTS_FOLDER }} ${{ env.BENCHMARK_BUCKET }} --recursive
       - name: Post e2e cleanup
         if: always()
         run: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -215,7 +215,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Configure AWS Credentials
-        id: login
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.IAM_ROLE }}
@@ -225,6 +224,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - name: Mark tests as passed
         env:
-          REPOSITORY: "${{ steps.login.outputs.aws-account-id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.IMAGE_NAME }}"
+          REPOSITORY: "${{ steps.login-ecr.outputs.registry }}/${{ env.IMAGE_NAME }}"
         run: |
           docker buildx imagetools create --tag ${REPOSITORY}:${TAG_PASSED} ${REPOSITORY}:${TAG_UNTESTED}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,16 +10,16 @@ on:
 # 1) private ARS source repository
 # 2) public repository
 env:
-  AWS_SRC_REGION : "us-east-1" # this is where our testing repo exists
-  AWS_DEST_REGION : "us-west-2" # this is where our prod repos exist
-  COMMIT_ID: ${{ github.sha }}
   GIT_TAG: ${{ github.ref_name }}
+  TAG_PASSED: "test_passed_${{ github.sha }}"
   IMAGE_NAME: "s3-csi-driver"
-  PUBLIC_REGISTRY: "public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver"
+  PUBLIC_REGISTRY: ${{ vars.PUBLIC_REGISTRY }}
+  ARS_REGISTRY: ${{ vars.ARS_REGISTRY }}
 jobs:
   build:
     # this is to prevent the job to run at forked projects
-    if: github.repository == 'awslabs/mountpoint-s3-csi-driver'
+    # if: ${{ ! github.repository.fork }}
+    environment: release
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -32,40 +32,52 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Set up crane
         uses: imjasonh/setup-crane@v0.1
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Configure AWS Credentials from Test acccount
-        uses: aws-actions/configure-aws-credentials@master
+
+      - name: Configure AWS Credentials from CI Trusted acccount
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.TEST_IAM_ROLE }}
-          aws-region: ${{ env.AWS_SRC_REGION }}
-      - name: Login to Amazon ECR test
-        id: login-ecr-test
+          role-to-assume: ${{ vars.CI_TRUSTED_IAM_ROLE }}
+          aws-region: ${{ vars.AWS_CI_TRUSTED_REGION }}
+      - name: Login to Amazon ECR (trusted)
+        id: login-ecr-trusted
         uses: aws-actions/amazon-ecr-login@v1
-      - name: Configure AWS Credentials from Prod account
-        uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: ${{ secrets.PROD_IAM_IMAGE_ROLE }}
-          aws-region: ${{ env.AWS_DEST_REGION }}
+          mask-password: true
+
+      - name: Configure AWS Credentials from Prod account
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.PROD_IAM_IMAGE_ROLE }}
+          aws-region: ${{ vars.AWS_PROD_ECR_REGION }}
       - name: Login to Amazon ECR prod
         id: login-ecr-prod
         uses: aws-actions/amazon-ecr-login@v1
-      - name: Configure AWS Credentials from Prod account (for public repo)
-        uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: ${{ secrets.PROD_IAM_IMAGE_ROLE }}
+          mask-password: true
+
+      - name: Configure AWS Credentials from Prod account (for ECR public)
+        if: ${{ env.PUBLIC_REGISTRY != '' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.PROD_IAM_IMAGE_ROLE }}
           aws-region: us-east-1
       - name: Login to Amazon ECR Public
+        if: ${{ env.PUBLIC_REGISTRY != '' }}
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
         with:
           registry-type: public
+          mask-password: true
+
       - name: Promote image
         env:
-          ARS_REGISTRY: ${{ secrets.ARS_REGISTRY }}
+          SOURCE_REGISTRY: ${{ steps.login-ecr-trusted.outputs.registry }}
         run: |
-          crane copy ${{ steps.login-ecr-test.outputs.registry }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_ID }} ${ARS_REGISTRY}:${{ env.GIT_TAG }}
-          crane copy ${{ steps.login-ecr-test.outputs.registry }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_ID }} ${{ env.PUBLIC_REGISTRY }}:${{ env.GIT_TAG }}
+          crane copy ${SOURCE_REGISTRY}/${IMAGE_NAME}:${TAG_PASSED} ${ARS_REGISTRY}:${GIT_TAG}
+          if [ -n "$VAR" ]; then
+            crane copy ${SOURCE_REGISTRY}/${IMAGE_NAME}:${TAG_PASSED} ${PUBLIC_REGISTRY}:${GIT_TAG}
+          fi
+
       - name: Create Release
         id: create-release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ env:
 jobs:
   build:
     # this is to prevent the job to run at forked projects
-    # if: ${{ ! github.repository.fork }}
+    if: ${{ ! github.repository.fork }}
     environment: release
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up crane
         uses: imjasonh/setup-crane@v0.1
 
-      - name: Configure AWS Credentials from CI Trusted acccount
+      - name: Configure AWS Credentials from CI Trusted account
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.CI_TRUSTED_IAM_ROLE }}
@@ -74,7 +74,7 @@ jobs:
           SOURCE_REGISTRY: ${{ steps.login-ecr-trusted.outputs.registry }}
         run: |
           crane copy ${SOURCE_REGISTRY}/${IMAGE_NAME}:${TAG_PASSED} ${ARS_REGISTRY}:${GIT_TAG}
-          if [ -n "$VAR" ]; then
+          if [ -n "${PUBLIC_REGISTRY}" ]; then
             crane copy ${SOURCE_REGISTRY}/${IMAGE_NAME}:${TAG_PASSED} ${PUBLIC_REGISTRY}:${GIT_TAG}
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,11 @@ all: all-image-docker
 all-push: create-manifest-and-images
 	docker manifest push --purge $(IMAGE):$(TAG)
 
+# Builds images only if not present with the tag
+.PHONY: all-push-skip-if-present
+all-push-skip-if-present:
+	docker manifest inspect $(IMAGE):$(TAG) > /dev/null || $(MAKE) all-push
+
 .PHONY: build_image
 build_image:
 	DOCKER_BUILDKIT=1 docker buildx build -f ${DOCKERFILE} -t=${IMAGE}:${TAG} --platform=${PLATFORM} .


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Use github environments to separate the different security boundaries we have: an 'untrusted' account for third party forks, and a 'trusted' account for direct pushes and merges. The 'trusted' account is then used as a source for releases, and it will only run code that's already merged into the main repository. 

Testing E2E: https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/12653780902
Testing release: https://github.com/muddyfish/mountpoint-s3-csi-driver/actions/runs/12411681334

**Before Merging**: Need to create GitHub environments on main repository.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
