### PR TITLE
Use kubectl matching with cluster's version

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -134,6 +134,7 @@ jobs:
       - name: Install tools
         run: |
           export ACTION=install_tools
+          export K8S_VERSION=${{ matrix.kubernetes-version }}
           tests/e2e-kubernetes/scripts/run.sh
       - name: Run Controller Tests
         run: |

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -79,8 +79,8 @@ mkdir -p ${BIN_DIR}
 export PATH="$PATH:${BIN_DIR}"
 
 function kubectl_install() {
-  curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-  curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+  curl -LO "https://dl.k8s.io/release/v$K8S_VERSION/bin/linux/amd64/kubectl"
+  curl -LO "https://dl.k8s.io/release/v$K8S_VERSION/bin/linux/amd64/kubectl.sha256"
   echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
   sudo install -o root -g root -m 0755 kubectl ${KUBECTL_INSTALL_PATH}/kubectl
 }


### PR DESCRIPTION
Currently, we use stable version of kubectl (v1.32 as of today), and that might cause some problems as kubectl [emits a warning](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/12561703668/job/35021134764#step:11:4567): 
> WARNING: version difference between client (1.32) and server (1.29) exceeds the supported minor version skew of +/-1

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
