### PR TITLE
Set assume role timeout to 2 hours for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -131,6 +131,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 7200
       - name: Install tools
         env:
           ACTION: "install_tools"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* As part of testing PRs from a fork (https://github.com/muddyfish/mountpoint-s3-csi-driver/actions/runs/12668838554/job/35326379030#step:5:1), the steps timed out due to the aws credentials expiring. This is because the aws action defaults to a 1 hour validity, and our tests take a long time. This PR increases the validity requested to two hours.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
