### PR TITLE
Run e2e tests as trusted or not depending on if they're from a fork

### DIFF
--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "feature/**", "release-**", "workflow/**" ]
   merge_group:
     types: [ "checks_requested" ]
+  pull_request:
 
 permissions:
   id-token: write
@@ -13,8 +14,9 @@ permissions:
 jobs:
   e2e:
     name: E2E Tests
+    if: ${{ github.pull_request.head.repo.id == github.pull_request.base.repo.id }}
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       environment: "trusted"
-      ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
+      ref: ${{ (github.event_name == 'push' && github.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.event.merge_group.head_sha }}
     secrets: inherit

--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   e2e:
     name: E2E Tests
+    if: ${{ github.pull_request.head.repo.id != github.pull_request.base.repo.id }}
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       environment: "untrusted"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -10,7 +10,9 @@ on:
         required: true
         type: string
 
-concurrency: e2e-cluster
+concurrency:
+  group: e2e-cluster-${{ inputs.environment }}
+
 env:
   IMAGE_NAME: "s3-csi-driver"
   BENCHMARK_ARTIFACTS_FOLDER: ".github/artifacts"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Runs the trusted e2e tests for PRs from the main repo, and only runs the untrusted e2e tests for PRs from forks


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
