### PR TITLE
Add approval gate environment

### DIFF
--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -8,9 +8,18 @@ permissions:
   contents: read
 
 jobs:
+  approval:
+    name: Approval Gate
+    environment: "approval-gate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approval Gate
+        run: |
+          echo "Approved!"
   e2e:
     name: E2E Tests
     uses: ./.github/workflows/e2e-tests.yaml
+    needs: approval
     with:
       environment: "untrusted"
       ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adds an 'approval gate' step, which only waits to be approved. In the main MP CSI Driver repo, added an environment 'approval-gate' which needs an approval to run. Adding the 'needs' delays the rest of the tests from running until an admin approves, and means we can remove the approver from the 'untrusted' environment after merging


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
