### PR TITLE
Add approval gate environment

### DIFF
--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -2,7 +2,7 @@ name: "E2E Tests (Trusted)"
 
 on:
   push:
-    branches: [ "main", "feature/**", "release-**", "workflow/**" ]
+    branches: [ "main", "release-**", "workflow/**" ]
   merge_group:
     types: [ "checks_requested" ]
   pull_request:

--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   e2e:
     name: E2E Tests
-    if: ${{ github.pull_request.head.repo.id == github.pull_request.base.repo.id }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id }}
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       environment: "trusted"

--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -8,10 +8,19 @@ permissions:
   contents: read
 
 jobs:
+  approval:
+    name: Approval Gate
+    environment: "approval-gate"
+    runs-on: ubuntu-latest
+    if: ${{ github.pull_request.head.repo.id != github.pull_request.base.repo.id }}
+    steps:
+      - name: Approval Gate
+        run: |
+          echo "Approved!"
   e2e:
     name: E2E Tests
-    if: ${{ github.pull_request.head.repo.id != github.pull_request.base.repo.id }}
     uses: ./.github/workflows/e2e-tests.yaml
+    needs: approval
     with:
       environment: "untrusted"
       ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -19,6 +19,7 @@ jobs:
           echo "Approved!"
   e2e:
     name: E2E Tests
+    if: ${{ github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id }}
     uses: ./.github/workflows/e2e-tests.yaml
     needs: approval
     with:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adds an 'approval gate' step, which only waits to be approved. In the main MP CSI Driver repo, added an environment 'approval-gate' which needs an approval to run. Adding the 'needs' delays the rest of the tests from running until an admin approves, and means we can remove the approver from the 'untrusted' environment after merging


Closes https://github.com/awslabs/mountpoint-s3-csi-driver/pull/338, as previous PR was on a 'workflow' branch, and this is not required and increases the time taken to merge in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
