### PR TITLE
Add `volumecontext` package for accessing volume context from CSI

### DIFF
--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -31,11 +31,11 @@ import (
 
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/mounter"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/targetpath"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/volumecontext"
 )
 
 const (
-	volumeCtxBucketName = "bucketName"
-	defaultKubeletPath  = "/var/lib/kubelet"
+	defaultKubeletPath = "/var/lib/kubelet"
 )
 
 var kubeletPath = getKubeletPath()
@@ -68,8 +68,8 @@ func NewS3NodeServer(nodeID string, mounter mounter.Mounter, credentialProvider 
 
 func (ns *S3NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	volumeContext := req.GetVolumeContext()
-	if volumeContext[mounter.VolumeCtxAuthenticationSource] == mounter.AuthenticationSourcePod {
-		podID := volumeContext[mounter.VolumeCtxPodUID]
+	if volumeContext[volumecontext.AuthenticationSource] == mounter.AuthenticationSourcePod {
+		podID := volumeContext[volumecontext.CSIPodUID]
 		volumeID := req.GetVolumeId()
 		if podID != "" && volumeID != "" {
 			err := ns.credentialProvider.CleanupToken(volumeID, podID)
@@ -96,7 +96,7 @@ func (ns *S3NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 
 	volumeContext := req.GetVolumeContext()
 
-	bucket, ok := volumeContext[volumeCtxBucketName]
+	bucket, ok := volumeContext[volumecontext.BucketName]
 	if !ok {
 		return nil, status.Error(codes.InvalidArgument, "Bucket name not provided")
 	}
@@ -295,7 +295,7 @@ func (ns *S3NodeServer) isValidVolumeCapabilities(volCaps []*csi.VolumeCapabilit
 // with sensitive fields removed.
 func logSafeNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) *csi.NodePublishVolumeRequest {
 	safeVolumeContext := maps.Clone(req.VolumeContext)
-	delete(safeVolumeContext, mounter.VolumeCtxServiceAccountTokens)
+	delete(safeVolumeContext, volumecontext.CSIServiceAccountTokens)
 
 	return &csi.NodePublishVolumeRequest{
 		VolumeId:          req.VolumeId,

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -67,9 +67,9 @@ func NewS3NodeServer(nodeID string, mounter mounter.Mounter, credentialProvider 
 }
 
 func (ns *S3NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
-	volumeContext := req.GetVolumeContext()
-	if volumeContext[volumecontext.AuthenticationSource] == mounter.AuthenticationSourcePod {
-		podID := volumeContext[volumecontext.CSIPodUID]
+	volumeCtx := req.GetVolumeContext()
+	if volumeCtx[volumecontext.AuthenticationSource] == mounter.AuthenticationSourcePod {
+		podID := volumeCtx[volumecontext.CSIPodUID]
 		volumeID := req.GetVolumeId()
 		if podID != "" && volumeID != "" {
 			err := ns.credentialProvider.CleanupToken(volumeID, podID)
@@ -94,9 +94,9 @@ func (ns *S3NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
 	}
 
-	volumeContext := req.GetVolumeContext()
+	volumeCtx := req.GetVolumeContext()
 
-	bucket, ok := volumeContext[volumecontext.BucketName]
+	bucket, ok := volumeCtx[volumecontext.BucketName]
 	if !ok {
 		return nil, status.Error(codes.InvalidArgument, "Bucket name not provided")
 	}

--- a/pkg/driver/node/volumecontext/volume_context.go
+++ b/pkg/driver/node/volumecontext/volume_context.go
@@ -1,0 +1,13 @@
+// Package volumecontext provides utilities for accessing volume context passed via CSI RPC.
+package volumecontext
+
+const (
+	BucketName           = "bucketName"
+	AuthenticationSource = "authenticationSource"
+	STSRegion            = "stsRegion"
+
+	CSIServiceAccountName   = "csi.storage.k8s.io/serviceAccount.name"
+	CSIServiceAccountTokens = "csi.storage.k8s.io/serviceAccount.tokens"
+	CSIPodNamespace         = "csi.storage.k8s.io/pod.namespace"
+	CSIPodUID               = "csi.storage.k8s.io/pod.uid"
+)


### PR DESCRIPTION
Splitted out of https://github.com/awslabs/mountpoint-s3-csi-driver/pull/328. 

This might not make sense since it's moved out of its original context, but the original motivation was that these constants was spread out to different packages and that was causing circular dependencies.

For example, if you need to use `VolumeCtxBucketName` in `pkg/driver/node/mounter` package, you'd need to import `pkg/driver/node` package which would cause a circular dependency as `pkg/driver/node` imports `pkg/driver/node/mounter`. In situations like that, it's best to extract common things into a leaf package that doesn't import anything, which is what this PR does with `pkg/driver/node/volumecontext` package.

It also makes finding these volume context keys easier by placing them into a singular place.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
