### PR TITLE
Fix typos in e2e untrusted workflow

### DIFF
--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -12,14 +12,13 @@ jobs:
     name: Approval Gate
     environment: "approval-gate"
     runs-on: ubuntu-latest
-    if: ${{ github.pull_request.head.repo.id != github.pull_request.base.repo.id }}
+    if: ${{ github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id }}
     steps:
       - name: Approval Gate
         run: |
           echo "Approved!"
   e2e:
     name: E2E Tests
-    if: ${{ github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id }}
     uses: ./.github/workflows/e2e-tests.yaml
     needs: approval
     with:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* A typo whilst merging conflicts meant that the untrusted e2e workflow never ran. This fixes it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
