### PR TITLE
Add CODEOWNERS file with default team for all files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @awslabs/aws-s3-csi-driver


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adds a codeowners file which requires a review from the S3 CSI Driver team before merging


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
