### PR TITLE
Make path argument variadic in `PathOnHost` and `PathInsideMountpointPod`

### DIFF
--- a/pkg/podmounter/mppod/path.go
+++ b/pkg/podmounter/mppod/path.go
@@ -16,12 +16,19 @@ const CommunicationDirName = "comm"
 
 // PathOnHost returns the full path on the host that refers to `path` inside Mountpoint Pod.
 // This function should be used in the CSI Driver Node Pod which uses `hostPath` volume to mount kubelet.
-func PathOnHost(podPathOnHost string, path string) string {
-	return filepath.Join(podPathOnHost, "/volumes/kubernetes.io~empty-dir/", CommunicationDirName, path)
+func PathOnHost(podPathOnHost string, path ...string) string {
+	return filepath.Join(append([]string{
+		podPathOnHost,
+		"/volumes/kubernetes.io~empty-dir/",
+		CommunicationDirName,
+	}, path...)...)
 }
 
 // PathInsideMountpointPod returns the full path that refers to `path` inside Mountpoint Pod.
 // This function should be used in the Mountpoint Pod.
-func PathInsideMountpointPod(path string) string {
-	return filepath.Join("/", CommunicationDirName, path)
+func PathInsideMountpointPod(elem ...string) string {
+	return filepath.Join(append([]string{
+		"/",
+		CommunicationDirName,
+	}, elem...)...)
 }

--- a/pkg/podmounter/mppod/path.go
+++ b/pkg/podmounter/mppod/path.go
@@ -17,18 +17,20 @@ const CommunicationDirName = "comm"
 // PathOnHost returns the full path on the host that refers to `path` inside Mountpoint Pod.
 // This function should be used in the CSI Driver Node Pod which uses `hostPath` volume to mount kubelet.
 func PathOnHost(podPathOnHost string, path ...string) string {
-	return filepath.Join(append([]string{
+	parts := append([]string{
 		podPathOnHost,
 		"/volumes/kubernetes.io~empty-dir/",
 		CommunicationDirName,
-	}, path...)...)
+	}, path...)
+	return filepath.Join(parts...)
 }
 
 // PathInsideMountpointPod returns the full path that refers to `path` inside Mountpoint Pod.
 // This function should be used in the Mountpoint Pod.
-func PathInsideMountpointPod(elem ...string) string {
-	return filepath.Join(append([]string{
+func PathInsideMountpointPod(path ...string) string {
+	parts := append([]string{
 		"/",
 		CommunicationDirName,
-	}, elem...)...)
+	}, path...)
+	return filepath.Join(parts...)
 }

--- a/pkg/podmounter/mppod/path_test.go
+++ b/pkg/podmounter/mppod/path_test.go
@@ -12,6 +12,7 @@ func TestGeneratingPathsInsideMountpointPod(t *testing.T) {
 	assert.Equals(t, "/comm/mount.sock", mppod.PathInsideMountpointPod("mount.sock"))
 	assert.Equals(t, "/comm/mount.sock", mppod.PathInsideMountpointPod("/mount.sock"))
 	assert.Equals(t, "/comm/sa-token/web-identity.token", mppod.PathInsideMountpointPod("./sa-token/web-identity.token"))
+	assert.Equals(t, "/comm/sa-token/web-identity.token", mppod.PathInsideMountpointPod("sa-token", "web-identity.token"))
 }
 
 func TestGeneratingPathsForMountpointPodOnHost(t *testing.T) {
@@ -19,4 +20,5 @@ func TestGeneratingPathsForMountpointPodOnHost(t *testing.T) {
 	assert.Equals(t, filepath.Join(podPath, "/volumes/kubernetes.io~empty-dir/comm/mount.sock"), mppod.PathOnHost(podPath, "mount.sock"))
 	assert.Equals(t, filepath.Join(podPath, "/volumes/kubernetes.io~empty-dir/comm/mount.sock"), mppod.PathOnHost(podPath, "/mount.sock"))
 	assert.Equals(t, filepath.Join(podPath, "/volumes/kubernetes.io~empty-dir/comm/sa-token/web-identity.token"), mppod.PathOnHost(podPath, "./sa-token/web-identity.token"))
+	assert.Equals(t, filepath.Join(podPath, "/volumes/kubernetes.io~empty-dir/comm/sa-token/web-identity.token"), mppod.PathOnHost(podPath, "sa-token", "./web-identity.token"))
 }


### PR DESCRIPTION
This is to make this API nicer to use by having a similar semantics to `filepath.Join`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
