### PR TITLE
Add reusable matrix creation workflow

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -1,0 +1,39 @@
+matrix:
+  cluster-type: [ "eksctl", "kops" ]
+  arch: [ "x86", "arm" ]
+  family: [ "AmazonLinux2", "Bottlerocket" ]
+  kubernetes-version: [ "1.28.13", "1.29.8", "1.30.4", "1.31.0" ]
+  include:
+    # Ubuntu2004 supported for EKS <= 1.29 and Ubuntu2204 supported for EKS >= 1.29.
+    # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
+    - cluster-type: "eksctl"
+      arch: "x86"
+      family: "Ubuntu2004"
+      kubernetes-version: "1.28.13"
+    - cluster-type: "eksctl"
+      arch: "arm"
+      family: "Ubuntu2004"
+      kubernetes-version: "1.29.8"
+    - cluster-type: "eksctl"
+      arch: "x86"
+      family: "Ubuntu2204"
+      kubernetes-version: "1.30.4"
+    - cluster-type: "eksctl"
+      arch: "arm"
+      family: "Ubuntu2204"
+      kubernetes-version: "1.31.0"
+  exclude:
+    - cluster-type: "kops"
+      family: "Bottlerocket"
+    - cluster-type: "eksctl"
+      arch: "arm"
+      family: "Bottlerocket"
+    # Our tests are failing on clusters created with kops 1.29+.
+    # Until we fix that issue, we use kops 1.28 which only supports k8s versions up to 1.28.
+    # So, we only run our tests in k8s versions 1.29 and 1.30 on eksctl.
+    - cluster-type: "kops"
+      kubernetes-version: "1.29.8"
+    - cluster-type: "kops"
+      kubernetes-version: "1.30.4"
+    - cluster-type: "kops"
+      kubernetes-version: "1.31.0"

--- a/.github/workflows/build_matrix.yaml
+++ b/.github/workflows/build_matrix.yaml
@@ -1,0 +1,17 @@
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        description: "Matrix"
+        value: ${{ jobs.build_matrix.outputs.matrix }}
+jobs:
+  build_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.parse_yaml.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse matrix.yaml file
+        id: parse_yaml
+        run: |
+            echo "matrix=$(yq -P -o=json '.matrix' '.github/matrix.yaml' | jq -c)" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -22,6 +22,9 @@ env:
   TAG_UNTESTED: "untested_${{ inputs.ref }}"
   TAG_PASSED: "test_passed_${{ inputs.ref }}"
 jobs:
+  build_matrix:
+    name: Build Matrix
+    uses: ./.github/workflows/build_matrix.yaml
   build:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
@@ -56,50 +59,12 @@ jobs:
         run: |
           make -j `nproc` all-push-skip-if-present
   test:
-    needs: build
+    needs: ["build", "build_matrix"]
     strategy:
       # Failing fast causes some resources created during the test to leak,
       # so we disable it to ensure all resources created during test are properly cleaned up.
       fail-fast: false
-      matrix:
-        cluster-type: ["eksctl", "kops"]
-        arch: ["x86", "arm"]
-        family: ["AmazonLinux2", "Bottlerocket"]
-        kubernetes-version: ["1.28.13", "1.29.8", "1.30.4", "1.31.0"]
-        include:
-          # Ubuntu2004 supported for EKS <= 1.29 and Ubuntu2204 supported for EKS >= 1.29.
-          # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
-          - cluster-type: "eksctl"
-            arch: "x86"
-            family: "Ubuntu2004"
-            kubernetes-version: "1.28.13"
-          - cluster-type: "eksctl"
-            arch: "arm"
-            family: "Ubuntu2004"
-            kubernetes-version: "1.29.8"
-          - cluster-type: "eksctl"
-            arch: "x86"
-            family: "Ubuntu2204"
-            kubernetes-version: "1.30.4"
-          - cluster-type: "eksctl"
-            arch: "arm"
-            family: "Ubuntu2204"
-            kubernetes-version: "1.31.0"
-        exclude:
-          - cluster-type: "kops"
-            family: "Bottlerocket"
-          - cluster-type: "eksctl"
-            arch: "arm"
-            family: "Bottlerocket"
-          # Our tests are failing on clusters created with kops 1.29+.
-          # Until we fix that issue, we use kops 1.28 which only supports k8s versions up to 1.28.
-          # So, we only run our tests in k8s versions 1.29 and 1.30 on eksctl.
-          - cluster-type: "kops"
-            kubernetes-version: "1.29.8"
-          - cluster-type: "kops"
-            kubernetes-version: "1.30.4"
-          - cluster-type: "kops"
-            kubernetes-version: "1.31.0"
+      matrix: ${{ fromJson(needs.build_matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adds a new workflow which generates a reusable matrix of K8s versions that we can use in other workflows (e2e tests)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
