### PR TITLE
Allow overriding of hardcoded DaemonSet tolerations

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -31,14 +31,9 @@ spec:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
         {{- else }}
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - operator: Exists
-          effect: NoExecute
-          tolerationSeconds: 300
-        {{- end }}
         {{- with .Values.node.tolerations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -30,10 +30,15 @@ spec:
       tolerations:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
-        {{- else }}
+        {{- else if .Values.node.defaultTolerations }}
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
+        {{- end }}
         {{- with .Values.node.tolerations }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -34,13 +34,10 @@ node:
       memory: 40Mi
     limits:
       memory: 256Mi
+  # Tolerates all taints and overrides defaultTolerations
   tolerateAllTaints: false
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-    - operator: Exists
-      effect: NoExecute
-      tolerationSeconds: 300
+  defaultTolerations: true
+  tolerations: []
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -35,6 +35,12 @@ node:
     limits:
       memory: 256Mi
   tolerateAllTaints: false
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+    - operator: Exists
+      effect: NoExecute
+      tolerationSeconds: 300
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Resolves #348 

*Description of changes:*

This PR will move the hardcoded tolerations from the DaemonSet template to the values, ~~I just used the [aws-fsx-csi-driver](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/blob/master/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml#L39-L45) helm chart as inspiration. As this is probably the simplest solution, it may lead to unexpected changes if someone already has `tolerations` set.~~
I have added a new value: `node.defaultTolerations` and put it in the `else` condition in `tolerateAllTaints`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
