### PR TITLE
Add Kubernetes v1.32.1 to CI

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -2,7 +2,7 @@ matrix:
   cluster-type: [ "eksctl", "kops" ]
   arch: [ "x86", "arm" ]
   family: [ "AmazonLinux2", "Bottlerocket" ]
-  kubernetes-version: [ "1.28.13", "1.29.8", "1.30.4", "1.31.0" ]
+  kubernetes-version: [ "1.28.13", "1.29.8", "1.30.4", "1.31.0", "1.32.1" ]
   include:
     # Ubuntu2004 supported for EKS <= 1.29 and Ubuntu2204 supported for EKS >= 1.29.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
@@ -22,6 +22,10 @@ matrix:
       arch: "arm"
       family: "Ubuntu2204"
       kubernetes-version: "1.31.0"
+    - cluster-type: "eksctl"
+      arch: "arm"
+      family: "Ubuntu2204"
+      kubernetes-version: "1.32.1"
   exclude:
     - cluster-type: "kops"
       family: "Bottlerocket"
@@ -37,3 +41,5 @@ matrix:
       kubernetes-version: "1.30.4"
     - cluster-type: "kops"
       kubernetes-version: "1.31.0"
+    - cluster-type: "kops"
+      kubernetes-version: "1.32.1"

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -70,7 +70,7 @@ KOPS_STATE_FILE=${KOPS_STATE_FILE:-"s3://mountpoint-s3-csi-driver-kops-state-sto
 SSH_KEY=${SSH_KEY:-""}
 HELM_RELEASE_NAME=mountpoint-s3-csi-driver
 
-EKSCTL_VERSION=${EKSCTL_VERSION:-0.191.0}
+EKSCTL_VERSION=${EKSCTL_VERSION:-0.202.0}
 EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-${BASE_DIR}/eksctl-patch.json}
 CI_ROLE_ARN=${CI_ROLE_ARN:-""}
 


### PR DESCRIPTION
*Description of changes:* EKS now supports v1.32. 

- Added support for Kubernetes v1.32.1 to CI
- Upgraded `eksctl` to v0.202.0 as 0.191.0 does not support v1.32

- https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html#platform-versions-1.32
- https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
