### PR TITLE
Remove v1.32 Ubuntu2204 from CI matrix

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -22,10 +22,6 @@ matrix:
       arch: "arm"
       family: "Ubuntu2204"
       kubernetes-version: "1.31.0"
-    - cluster-type: "eksctl"
-      arch: "arm"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.32.1"
   exclude:
     - cluster-type: "kops"
       family: "Bottlerocket"


### PR DESCRIPTION
*Description of changes:* Previous PR (https://github.com/awslabs/mountpoint-s3-csi-driver/pull/357) that upgrades CI to support EKS 1.32 failed for Ubuntu because Ubuntu AMI for v1.32 does not exit yet in AWS Parameter Store in us-east-1.

Temporarily removing Ubuntu 1.32 from CI to unblock CI.

https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/12956253264/job/36142133700

```
+ /home/runner/work/mountpoint-s3-csi-driver/mountpoint-s3-csi-driver/tests/e2e-kubernetes/scripts/../csi-test-artifacts/bin/eksctl create cluster -f /home/runner/work/mountpoint-s3-csi-driver/mountpoint-s3-csi-driver/tests/e2e-kubernetes/scripts/../csi-test-artifacts/s3-csi-cluster-eksctl-ubuntu2204-arm-1-32.eksctl.yaml --kubeconfig /home/runner/work/mountpoint-s3-csi-driver/mountpoint-s3-csi-driver/tests/e2e-kubernetes/scripts/../csi-test-artifacts/s3-csi-cluster-eksctl-ubuntu2204-arm-1-32.kubeconfig
2025-01-24 19:32:00 [ℹ]  eksctl version 0.202.0
2025-01-24 19:32:00 [ℹ]  using region us-east-1
2025-01-24 19:32:00 [ℹ]  subnets for us-east-1a - public:192.168.0.0/20 private:192.168.80.0/20
2025-01-24 19:32:00 [ℹ]  subnets for us-east-1b - public:192.168.16.0/20 private:192.168.96.0/20
2025-01-24 19:32:00 [ℹ]  subnets for us-east-1c - public:192.168.32.0/20 private:192.168.112.0/20
2025-01-24 19:32:00 [ℹ]  subnets for us-east-1d - public:192.168.48.0/20 private:192.168.128.0/20
2025-01-24 19:32:00 [ℹ]  subnets for us-east-1f - public:192.168.64.0/20 private:192.168.144.0/20
Error: unable to determine AMI to use: error getting AMI from SSM Parameter Store: operation error SSM: GetParameter, https response error StatusCode: 400, RequestID: da023fa0-756d-452a-9afd-f3f25771a92b, ParameterNotFound: . please verify that AMI Family is supported
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
