### PR TITLE
Update `Dockerfile`s to use CSI minimal image and add new components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,12 +60,15 @@ ENV MOUNTPOINT_BIN_DIR=/mountpoint-s3/bin
 
 # Copy Mountpoint binary
 COPY --from=mp_builder /mountpoint-s3 /mountpoint-s3
-# TODO: These won't be necessary once with containerization.
+# TODO: These won't be necessary with containerization.
 COPY --from=mp_builder /lib64/libfuse.so.2 /mountpoint-s3/bin/
 COPY --from=mp_builder /lib64/libgcc_s.so.1 /mountpoint-s3/bin/
 
 # Copy CSI Driver binaries
 COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/aws-s3-csi-driver /bin/aws-s3-csi-driver
+COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/aws-s3-csi-controller /bin/aws-s3-csi-controller
+COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/aws-s3-csi-mounter /bin/aws-s3-csi-mounter
+# TODO: This won't be necessary with containerization.
 COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/install-mp /bin/install-mp
 
 ENTRYPOINT ["/bin/aws-s3-csi-driver"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -28,7 +28,7 @@ RUN dnf upgrade -y && \
     pkg-config && \
     dnf clean all
 
-# Install rust
+# Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
@@ -45,7 +45,7 @@ RUN cd mountpoint-s3 && \
 # Build CSI Driver
 #
 
-# Build driver. Use BUILDPLATFORM not TARGETPLATFORM for cross compilation
+# Use BUILDPLATFORM not TARGETPLATFORM for cross compilation
 FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.22-bullseye as builder
 ARG TARGETARCH
 
@@ -54,17 +54,24 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
     TARGETARCH=${TARGETARCH} make bin
 
-FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:latest AS linux-amazon
+#
+# Build the final image
+#
+
+# `eks-distro-minimal-base-csi` includes `libfuse` and mount utils such as `umount`.
+# We need to make sure to use same Amazon Linux version here and while building Mountpoint to not have glibc compatibility issues.
+FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi:latest-al23 AS linux-amazon
 ARG MOUNTPOINT_VERSION
 ENV MOUNTPOINT_VERSION=${MOUNTPOINT_VERSION}
 ENV MOUNTPOINT_BIN_DIR=/mountpoint-s3/bin
 
-# MP Installer
+# Copy Mountpoint binary
 COPY --from=mp_builder /mountpoint-s3/target/release/mount-s3 /mountpoint-s3/bin/mount-s3
+# TODO: These won't be necessary once with containerization.
 COPY --from=mp_builder /lib64/libfuse.so.2 /mountpoint-s3/bin/
 COPY --from=mp_builder /lib64/libgcc_s.so.1 /mountpoint-s3/bin/
 
-# Install driver
+# Copy CSI Driver binaries
 COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/aws-s3-csi-driver /bin/aws-s3-csi-driver
 COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/install-mp /bin/install-mp
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -67,12 +67,15 @@ ENV MOUNTPOINT_BIN_DIR=/mountpoint-s3/bin
 
 # Copy Mountpoint binary
 COPY --from=mp_builder /mountpoint-s3/target/release/mount-s3 /mountpoint-s3/bin/mount-s3
-# TODO: These won't be necessary once with containerization.
+# TODO: These won't be necessary with containerization.
 COPY --from=mp_builder /lib64/libfuse.so.2 /mountpoint-s3/bin/
 COPY --from=mp_builder /lib64/libgcc_s.so.1 /mountpoint-s3/bin/
 
 # Copy CSI Driver binaries
 COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/aws-s3-csi-driver /bin/aws-s3-csi-driver
+COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/aws-s3-csi-controller /bin/aws-s3-csi-controller
+COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/aws-s3-csi-mounter /bin/aws-s3-csi-mounter
+# TODO: This won't be necessary with containerization.
 COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/install-mp /bin/install-mp
 
 ENTRYPOINT ["/bin/aws-s3-csi-driver"]

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,9 @@ login_registry:
 bin:
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags ${LDFLAGS} -o bin/aws-s3-csi-driver ./cmd/aws-s3-csi-driver/
+	CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags ${LDFLAGS} -o bin/aws-s3-csi-controller ./cmd/aws-s3-csi-controller/
+	CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags ${LDFLAGS} -o bin/aws-s3-csi-mounter ./cmd/aws-s3-csi-mounter/
+	# TODO: `install-mp` component won't be necessary with the containerization.
 	CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags ${LDFLAGS} -o bin/install-mp ./cmd/install-mp/
 
 .PHONY: install-go-test-coverage


### PR DESCRIPTION
With containerization, we will run Mountpoint inside our container and we will need `libfuse` and `glibc` for Mountpoint to run - which CSI base image provides.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
