### PR TITLE
Move fuction to get kubelet path into `util` package

### DIFF
--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -33,13 +33,10 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/targetpath"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/volumecontext"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util"
 )
 
-const (
-	defaultKubeletPath = "/var/lib/kubelet"
-)
-
-var kubeletPath = getKubeletPath()
+var kubeletPath = util.KubeletPath()
 
 var (
 	nodeCaps = []csi.NodeServiceCapability_RPC_Type{}
@@ -171,14 +168,6 @@ func compileMountOptions(currentOptions []string, newOptions []string) []string 
 	}
 
 	return allMountOptions.List()
-}
-
-func getKubeletPath() string {
-	kubeletPath := os.Getenv("KUBELET_PATH")
-	if kubeletPath == "" {
-		return defaultKubeletPath
-	}
-	return kubeletPath
 }
 
 func (ns *S3NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {

--- a/pkg/util/kubelet.go
+++ b/pkg/util/kubelet.go
@@ -1,0 +1,15 @@
+package util
+
+import "os"
+
+const defaultKubeletPath = "/var/lib/kubelet"
+
+// KubeletPath returns path of the kubelet.
+// It looks for `KUBELET_PATH` variable, and returns a default path if its not defined.
+func KubeletPath() string {
+	kubeletPath := os.Getenv("KUBELET_PATH")
+	if kubeletPath == "" {
+		return defaultKubeletPath
+	}
+	return kubeletPath
+}


### PR DESCRIPTION
This function will be reused in upcoming `PodMounter` and `util` package seems like a better place.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
