### PR TITLE
Get default Mountpoint namespace from env in CSI Controller

### DIFF
--- a/cmd/aws-s3-csi-controller/main.go
+++ b/cmd/aws-s3-csi-controller/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod"
 )
 
-var mountpointNamespace = flag.String("mountpoint-namespace", "mount-s3", "Namespace to spawn Mountpoint Pods in.")
+var mountpointNamespace = flag.String("mountpoint-namespace", os.Getenv("MOUNTPOINT_NAMESPACE"), "Namespace to spawn Mountpoint Pods in.")
 var mountpointVersion = flag.String("mountpoint-version", os.Getenv("MOUNTPOINT_VERSION"), "Version of Mountpoint within the given Mountpoint image.")
 var mountpointImage = flag.String("mountpoint-image", os.Getenv("MOUNTPOINT_IMAGE"), "Image of Mountpoint to use in spawned Mountpoint Pods.")
 var mountpointImagePullPolicy = flag.String("mountpoint-image-pull-policy", os.Getenv("MOUNTPOINT_IMAGE_PULL_POLICY"), "Pull policy of Mountpoint images.")


### PR DESCRIPTION
To have consistency with other options and to ensure we don't hard-code Mountpoint namespace, get it from `MOUNTPOINT_NAMESPACE` env by default.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
