### PR TITLE
Add `PodMounter`

### DIFF
--- a/cmd/aws-s3-csi-mounter/csimounter/csimounter.go
+++ b/cmd/aws-s3-csi-mounter/csimounter/csimounter.go
@@ -82,7 +82,7 @@ func Run(options Options) (int, error) {
 	if err != nil {
 		// If Mountpoint fails, write it to `options.MountErrPath` to let `PodMounter` running in the same node know.
 		if writeErr := os.WriteFile(options.MountErrPath, stderrBuf.Bytes(), mountErrorFileperm); writeErr != nil {
-			klog.Infof("Failed to write mount error logs to %s: %v\n", options.MountErrPath, err)
+			klog.Errorf("Failed to write mount error logs to %s: %v\n", options.MountErrPath, err)
 		}
 		return exitCode, err
 	}

--- a/cmd/aws-s3-csi-mounter/csimounter/csimounter_test.go
+++ b/cmd/aws-s3-csi-mounter/csimounter/csimounter_test.go
@@ -1,6 +1,7 @@
 package csimounter_test
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -120,5 +121,35 @@ func TestRunningMountpoint(t *testing.T) {
 			},
 		})
 		assert.Equals(t, cmpopts.AnyError, err)
+	})
+
+	t.Run("Exists with zero code if `mount.exit` file exist", func(t *testing.T) {
+		basepath := t.TempDir()
+		mountExitPath := filepath.Join(basepath, "mount.exit")
+
+		dev := mountertest.OpenDevNull(t)
+		runner := func(c *exec.Cmd) (int, error) {
+			mountertest.AssertSameFile(t, dev, c.ExtraFiles[0])
+			assert.Equals(t, mountpointPath, c.Path)
+			assert.Equals(t, []string{mountpointPath, "test-bucket", "/dev/fd/3"}, c.Args[:3])
+			return 1, nil
+		}
+
+		// Create `mount.exit` file
+		_, err := os.OpenFile(mountExitPath, os.O_RDONLY|os.O_CREATE, 0666)
+		assert.NoError(t, err)
+
+		exitCode, err := csimounter.Run(csimounter.Options{
+			MountpointPath: mountpointPath,
+			MountExitPath:  mountExitPath,
+			MountOptions: mountoptions.Options{
+				Fd:         int(dev.Fd()),
+				BucketName: "test-bucket",
+			},
+			CmdRunner: runner,
+		})
+		assert.NoError(t, err)
+		// Should be `0` even though Mountpoint exited with a different exit code
+		assert.Equals(t, 0, exitCode)
 	})
 }

--- a/cmd/aws-s3-csi-mounter/main.go
+++ b/cmd/aws-s3-csi-mounter/main.go
@@ -25,6 +25,7 @@ var mountpointBinDir = flag.String("mountpoint-bin-dir", os.Getenv("MOUNTPOINT_B
 
 var mountSockPath = mppod.PathInsideMountpointPod(mppod.KnownPathMountSock)
 var mountExitPath = mppod.PathInsideMountpointPod(mppod.KnownPathMountExit)
+var mountErrorPath = mppod.PathInsideMountpointPod(mppod.KnownPathMountError)
 
 const mountpointBin = "mount-s3"
 
@@ -38,6 +39,7 @@ func main() {
 	exitCode, err := csimounter.Run(csimounter.Options{
 		MountpointPath: mountpointBinFullPath,
 		MountExitPath:  mountExitPath,
+		MountErrPath:   mountErrorPath,
 		MountOptions:   mountOptions,
 	})
 	if err != nil {

--- a/cmd/aws-s3-csi-mounter/main.go
+++ b/cmd/aws-s3-csi-mounter/main.go
@@ -24,6 +24,7 @@ var mountSockRecvTimeout = flag.Duration("mount-sock-recv-timeout", 2*time.Minut
 var mountpointBinDir = flag.String("mountpoint-bin-dir", os.Getenv("MOUNTPOINT_BIN_DIR"), "Directory of mount-s3 binary.")
 
 var mountSockPath = mppod.PathInsideMountpointPod(mppod.KnownPathMountSock)
+var mountExitPath = mppod.PathInsideMountpointPod(mppod.KnownPathMountExit)
 
 const mountpointBin = "mount-s3"
 
@@ -36,6 +37,7 @@ func main() {
 
 	exitCode, err := csimounter.Run(csimounter.Options{
 		MountpointPath: mountpointBinFullPath,
+		MountExitPath:  mountExitPath,
 		MountOptions:   mountOptions,
 	})
 	if err != nil {

--- a/pkg/driver/node/mounter/mounter.go
+++ b/pkg/driver/node/mounter/mounter.go
@@ -3,12 +3,19 @@ package mounter
 
 import (
 	"context"
+	"fmt"
 	"os"
+
+	"k8s.io/klog/v2"
+	"k8s.io/mount-utils"
 
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/system"
 )
+
+// https://github.com/awslabs/mountpoint-s3/blob/9ed8b6243f4511e2013b2f4303a9197c3ddd4071/mountpoint-s3/src/cli.rs#L421
+const mountpointDeviceName = "mountpoint-s3"
 
 type ServiceRunner interface {
 	StartService(ctx context.Context, config *system.ExecConfig) (string, error)
@@ -31,4 +38,30 @@ func MountS3Path() string {
 		mountS3Path = defaultMountS3Path
 	}
 	return mountS3Path
+}
+
+// isMountPoint returns whether given `target` is a `mount-s3` mount.
+// We implement additional check on top of `mounter.IsMountPoint` because we need
+// to verify not only that the target is a mount point but also that it is specifically a mount-s3 mount point.
+// This is achieved by calling the `mounter.List()` method to enumerate all mount points.
+func isMountPoint(mounter mount.Interface, target string) (bool, error) {
+	if _, err := os.Stat(target); os.IsNotExist(err) {
+		return false, err
+	}
+
+	mountPoints, err := mounter.List()
+	if err != nil {
+		return false, fmt.Errorf("Failed to list mounts: %w", err)
+	}
+	for _, mp := range mountPoints {
+		if mp.Path == target {
+			if mp.Device != mountpointDeviceName {
+				klog.V(4).Infof("IsMountPoint: %s is not a `mount-s3` mount. Expected device type to be %s but got %s, skipping unmount", target, mountpointDeviceName, mp.Device)
+				continue
+			}
+
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -283,7 +283,11 @@ func (pm *PodMounter) waitForMountpointPod(ctx context.Context, podID, volumeID 
 
 // waitForMount waits until Mountpoint is successfully mounted at `target`.
 // It returns an error if Mountpoint fails to mount.
-func (pm *PodMounter) waitForMount(ctx context.Context, target, podName, podMountErrorPath string) error {
+func (pm *PodMounter) waitForMount(parentCtx context.Context, target, podName, podMountErrorPath string) error {
+	ctx, cancel := context.WithCancel(parentCtx)
+	// Cancel at the end to ensure we cancel polling from goroutines.
+	defer cancel()
+
 	mountResultCh := make(chan error)
 
 	klog.V(4).Infof("Waiting until Mountpoint Pod %s mounts on %s", podName, target)

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -82,14 +82,14 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 
 	isMountPoint, err := pm.IsMountPoint(target)
 	if err != nil {
-		return fmt.Errorf("Could not check if %q is a mount point: %w", target, err)
+		return fmt.Errorf("Could not check if %q is already a mount point: %w", target, err)
 	}
 
 	// TODO: If `target` is a `systemd`-mounted Mountpoint, this would return an error,
 	// but we should still update the credentials for it by calling `credProvider.Provide`.
 	pod, podPath, err := pm.waitForMountpointPod(ctx, podID, volumeID)
 	if err != nil {
-		return fmt.Errorf("Failed to wait for Mountpoint Pod for %q: %w", target, err)
+		return fmt.Errorf("Failed to wait for Mountpoint Pod to be ready for %q: %w", target, err)
 	}
 
 	// TODO: After this point we know Mountpoint Pod's name, we should add some debugging tips to our error messages returned, like:
@@ -177,7 +177,7 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 		Env:        env.List(),
 	})
 	if err != nil {
-		klog.V(4).Infof("Failed to send mount option to Mountpoint Pod %s for %s: %s\n", pod.Name, target, err)
+		klog.V(4).Infof("Failed to send mount option to Mountpoint Pod %s for %s: %v\n", pod.Name, target, err)
 		return fmt.Errorf("Failed to send mount options to Mountpoint Pod %s for %s: %w", pod.Name, target, err)
 	}
 

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -356,7 +356,7 @@ func (pm *PodMounter) verifyOrSetupMountTarget(target string) error {
 		klog.V(4).Infof("Target path %q is a corrupted mount. Trying to unmount", target)
 		if unmountErr := pm.unmountTarget(target); unmountErr != nil {
 			klog.V(4).Infof("Failed to unmount target path %q: %v, original failure of stat: %v", target, unmountErr, err)
-			return fmt.Errorf("Unable to unmount the target %q: %w", target, unmountErr)
+			return fmt.Errorf("Failed to unmount target path %q: %w, original failure of stat: %v", target, unmountErr, err)
 		}
 
 		return nil

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -144,9 +144,6 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 
 	fuseDeviceFD, err := pm.mountSyscallWithDefault(target, args)
 	if err != nil {
-		if fuseDeviceFD > 0 {
-			pm.closeFUSEDevFD(fuseDeviceFD)
-		}
 		return fmt.Errorf("Failed to mount %s: %w", target, err)
 	}
 

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -153,7 +153,7 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 	defer func() {
 		if unmount {
 			if err := pm.unmountTarget(target); err != nil {
-				klog.V(4).Infof("Failed to unmount mounted target %s: %s\n", target, err)
+				klog.V(4).ErrorS(err, "Failed to unmount mounted target %s\n", target)
 			} else {
 				klog.V(4).Infof("Target %s unmounted successfully\n", target)
 			}

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -276,7 +276,7 @@ func (pm *PodMounter) waitForMountpointPod(ctx context.Context, podID, volumeID 
 		return nil, "", errors.New("Failed to get Mountpoint Pod")
 	}
 
-	klog.V(4).Infof("Mountpoint Pod %s is running with id %s", podName, foundPod.UID)
+	klog.V(4).Infof("Mountpoint Pod %s/%s is running with id %s", foundPod.Namespace, podName, foundPod.UID)
 
 	return foundPod, pm.podPath(foundPod), nil
 }

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -75,7 +75,7 @@ func NewPodMounter(client k8sv1.CoreV1Interface, credProvider *credentialprovide
 func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args) error {
 	podID, volumeID := credentialCtx.PodID, credentialCtx.VolumeID
 
-	err := pm.checkTargetPath(target)
+	err := pm.verifyOrSetupMountTarget(target)
 	if err != nil {
 		return fmt.Errorf("Failed to verify target path can be used as a mount point %q: %w", target, err)
 	}
@@ -336,10 +336,10 @@ func (pm *PodMounter) closeFUSEDevFD(fd int) {
 	}
 }
 
-// checkTargetPath checks target path for existence and corrupted mount error.
+// verifyOrSetupMountTarget checks target path for existence and corrupted mount error.
 // If the target dir does not exists it tries to create it.
 // If the target dir is corrupted (decided with `mount.IsCorruptedMnt`) it tries to unmount it to have a clean mount.
-func (pm *PodMounter) checkTargetPath(target string) error {
+func (pm *PodMounter) verifyOrSetupMountTarget(target string) error {
 	_, err := os.Stat(target)
 	if err == nil {
 		return nil

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -142,7 +142,7 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 	fuseDeviceFD, err := pm.mountSyscallWithDefault(target, args)
 	if err != nil {
 		if fuseDeviceFD > 0 {
-			pm.closeFd(fuseDeviceFD)
+			pm.closeFUSEDevFD(fuseDeviceFD)
 		}
 		return fmt.Errorf("Failed to mount %s: %w", target, err)
 	}
@@ -163,7 +163,7 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 	// This function can either fail or successfully send mount options to Mountpoint Pod - in which
 	// Mountpoint Pod will get its own fd referencing the same underlying file description.
 	// In both case we need to close the fd in this process.
-	defer pm.closeFd(fuseDeviceFD)
+	defer pm.closeFUSEDevFD(fuseDeviceFD)
 
 	// Remove old mount error file if exists
 	_ = os.Remove(podMountErrorPath)
@@ -324,8 +324,8 @@ func (pm *PodMounter) waitForMount(ctx context.Context, target, podName, podMoun
 	return err
 }
 
-// closeFd closes given FUSE file descriptor.
-func (pm *PodMounter) closeFd(fd int) {
+// closeFUSEDevFD closes given FUSE file descriptor.
+func (pm *PodMounter) closeFUSEDevFD(fd int) {
 	err := syscall.Close(fd)
 	if err != nil {
 		klog.V(4).Infof("Mount: Failed to close /dev/fuse file descriptor %d: %v\n", fd, err)

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -77,7 +77,7 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 
 	err := pm.checkTargetPath(target)
 	if err != nil {
-		return fmt.Errorf("Failed to check target path %q: %w", target, err)
+		return fmt.Errorf("Failed to verify target path can be used as a mount point %q: %w", target, err)
 	}
 
 	isMountPoint, err := pm.IsMountPoint(target)

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -1,0 +1,399 @@
+package mounter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	k8sv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/mount-utils"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/credentialprovider"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/envprovider"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util"
+)
+
+const mountpointPodReadinessTimeout = 10 * time.Second
+const mountpointPodReadinessCheckInterval = 100 * time.Millisecond
+
+// mountSyscall is the function that performs `mount` operation for given `target` with given Mountpoint `args`.
+// It returns mounted FUSE file descriptor as a result.
+// This is mainly exposed for testing, in production platform-native function (`mountSyscallDefault`) will be used.
+type mountSyscall func(target string, args mountpoint.Args) (fd int, err error)
+
+// A PodMounter is a [Mounter] that mounts Mountpoint on pre-created Kubernetes Pod running in the same node.
+type PodMounter struct {
+	client                 k8sv1.CoreV1Interface
+	mountpointPodNamespace string
+	mount                  mount.Interface
+	kubeletPath            string
+	mountSyscall           mountSyscall
+	kubernetesVersion      string
+	credProvider           *credentialprovider.Provider
+}
+
+// NewPodMounter creates a new [PodMounter] with given Kubernetes client.
+func NewPodMounter(client k8sv1.CoreV1Interface, credProvider *credentialprovider.Provider, mountpointPodNamespace string, mount mount.Interface, mountSyscall mountSyscall, kubernetesVersion string) (*PodMounter, error) {
+	return &PodMounter{
+		client:                 client,
+		mountpointPodNamespace: mountpointPodNamespace,
+		mount:                  mount,
+		kubeletPath:            util.KubeletPath(),
+		mountSyscall:           mountSyscall,
+		kubernetesVersion:      kubernetesVersion,
+		credProvider:           credProvider,
+	}, nil
+}
+
+// Mount mounts the given `bucketName` at the `target` path using provided credential context and Mountpoint arguments.
+//
+// At high level, this method will:
+//  1. Wait for Mountpoint Pod to be `Running`
+//  2. Write credentials to Mountpoint Pod's credentials directory
+//  3. Obtain a FUSE file descriptor
+//  4. Call `mount` syscall with `target` and obtained FUSE file descriptor
+//  5. Send mount options (including FUSE file descriptor) to Mountpoint Pod
+//  6. Wait until Mountpoint successfully mounts at `target`
+//
+// If Mountpoint is already mounted at `target`, it will return early at step 2 to ensure credentials are up-to-date.
+func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args) error {
+	podID, volumeID := credentialCtx.PodID, credentialCtx.VolumeID
+
+	err := pm.checkTargetPath(target)
+	if err != nil {
+		return fmt.Errorf("Failed to check target path %q: %w", target, err)
+	}
+
+	isMountPoint, err := pm.IsMountPoint(target)
+	if err != nil {
+		return fmt.Errorf("Could not check if %q is a mount point: %w", target, err)
+	}
+
+	// TODO: If `target` is a `systemd`-mounted Mountpoint, this would return an error,
+	// but we should still update the credentials for it by calling `credProvider.Provide`.
+	pod, podPath, err := pm.waitForMountpointPod(ctx, podID, volumeID)
+	if err != nil {
+		return fmt.Errorf("Failed to wait for Mountpoint Pod for %q: %w", target, err)
+	}
+
+	// TODO: After this point we know Mountpoint Pod's name, we should add some debugging tips to our error messages returned, like:
+	// """
+	// Failed to mount on "..." because "..."`
+	// You can see logs for Mountpoint Pod by running:
+	// `kubectl logs -n mount-s3 "mp-..." --previous`
+	// """
+
+	podCredentialsPath, err := pm.ensureCredentialsDirExists(podPath)
+	if err != nil {
+		return fmt.Errorf("Failed to create credentials directory for %q: %W", target, err)
+	}
+
+	credentialCtx.SetWriteAndEnvPath(podCredentialsPath, mppod.PathInsideMountpointPod(mppod.KnownPathCredentials))
+
+	// Note that this part happens before `isMountPoint` check, as we want to update credentials even though
+	// there is an existing mount point at `target`.
+	credEnv, authenticationSource, err := pm.credProvider.Provide(ctx, credentialCtx)
+	if err != nil {
+		klog.V(4).Infof("NodePublishVolume: Failed to provide credentials for %s: %v", target, err)
+		return fmt.Errorf("Failed to provide credentials for %q: %w", target, err)
+	}
+
+	if isMountPoint {
+		klog.V(4).Infof("Target path %q is already mounted", target)
+		return nil
+	}
+
+	env := envprovider.Default()
+	env.Merge(credEnv)
+
+	// Move `--aws-max-attempts` to env if provided
+	if maxAttempts, ok := args.Remove(mountpoint.ArgAWSMaxAttempts); ok {
+		env.Set(envprovider.EnvMaxAttempts, maxAttempts)
+	}
+
+	args.Set(mountpoint.ArgUserAgentPrefix, UserAgent(authenticationSource, pm.kubernetesVersion))
+
+	podMountSockPath := mppod.PathOnHost(podPath, mppod.KnownPathMountSock)
+	podMountErrorPath := mppod.PathOnHost(podPath, mppod.KnownPathMountError)
+
+	klog.V(4).Infof("Waiting for Mountpoint Pod %s to be ready to accept connections on %s", pod.Name, podMountSockPath)
+
+	// Wait until Mountpoint Pod is ready to accept connections
+	err = util.WaitForUnixSocket(mountpointPodReadinessTimeout, mountpointPodReadinessCheckInterval, podMountSockPath)
+	if err != nil {
+		return fmt.Errorf("Failed to wait for Mountpoint Pod to be ready in given timeout for %q: %w", target, err)
+	}
+
+	klog.V(4).Infof("Mounting %s for %s", target, pod.Name)
+
+	fd, err := pm.mountSyscallWithDefault(target, args)
+	if err != nil {
+		if fd > 0 {
+			pm.closeFd(fd)
+		}
+		return fmt.Errorf("Failed to mount %s: %w", target, err)
+	}
+
+	// This will set to true in all error conditions to ensure we don't leave
+	// `target` mounted if Mountpoint is not started to serve requests for it.
+	unmount := false
+	defer func() {
+		if unmount {
+			if err := pm.unmountTarget(target); err != nil {
+				klog.V(4).Infof("Failed to unmount mounted target %s: %s\n", target, err)
+			} else {
+				klog.V(4).Infof("Target %s unmounted successfully\n", target)
+			}
+		}
+	}()
+
+	// This function can either fail or successfully send mount options to Mountpoint Pod - in which
+	// Mountpoint Pod will get its own fd referencing the same underlying file description.
+	// In both case we need to close the fd in this process.
+	defer pm.closeFd(fd)
+
+	// Remove old mount error file if exists
+	_ = os.Remove(podMountErrorPath)
+
+	klog.V(4).Infof("Sending mount options to Mountpoint Pod %s on %s", pod.Name, podMountSockPath)
+
+	err = mountoptions.Send(ctx, podMountSockPath, mountoptions.Options{
+		Fd:         fd,
+		BucketName: bucketName,
+		Args:       args.SortedList(),
+		Env:        env.List(),
+	})
+	if err != nil {
+		unmount = true
+		klog.V(4).Infof("Failed to send mount option to Mountpoint Pod %s for %s: %s\n", pod.Name, target, err)
+		return fmt.Errorf("Failed to send mount options to Mountpoint Pod %s for %s: %w", pod.Name, target, err)
+	}
+
+	err = pm.waitForMount(ctx, target, pod.Name, podMountErrorPath)
+	if err != nil {
+		unmount = true
+		return fmt.Errorf("Failed to wait for Mountpoint Pod %s to be ready for %s: %w", pod.Name, target, err)
+	}
+
+	return nil
+}
+
+// Unmount unmounts the mount point at `target` and cleans all credentials.
+func (pm *PodMounter) Unmount(ctx context.Context, target string, credentialCtx credentialprovider.CleanupContext) error {
+	podID, volumeID := credentialCtx.PodID, credentialCtx.VolumeID
+
+	// TODO: If `target` is a `systemd`-mounted Mountpoint, this would return an error,
+	// but we should still unmount it and clean the credentials.
+	_, podPath, err := pm.waitForMountpointPod(ctx, podID, volumeID)
+	if err != nil {
+		return fmt.Errorf("Failed to wait for Mountpoint Pod for %q: %w", target, err)
+	}
+
+	credentialCtx.WritePath = pm.credentialsDir(podPath)
+
+	// Write `mount.exit` file to indicate Mountpoint Pod to cleanly exit.
+	podMountExitPath := mppod.PathOnHost(podPath, mppod.KnownPathMountExit)
+	_, err = os.OpenFile(podMountExitPath, os.O_RDONLY|os.O_CREATE, credentialprovider.CredentialFilePerm)
+	if err != nil {
+		return fmt.Errorf("Failed to send a exit message to Mountpoint Pod for %q: %w", target, err)
+	}
+
+	err = pm.unmountTarget(target)
+	if err != nil {
+		return fmt.Errorf("Failed to unmount %q: %w", target, err)
+	}
+
+	err = pm.credProvider.Cleanup(credentialCtx)
+	if err != nil {
+		klog.V(4).Infof("Unmount: Failed to clean up credentials for %s: %v", target, err)
+		return fmt.Errorf("Failed to clean up credentials for %q: %w", target, err)
+	}
+
+	return nil
+}
+
+// IsMountPoint returns whether given `target` is a `mount-s3` mount.
+func (pm *PodMounter) IsMountPoint(target string) (bool, error) {
+	// TODO: Can we just use regular `IsMountPoint` check from `mounter` with containerization?
+	return isMountPoint(pm.mount, target)
+}
+
+// waitForMountpointPod waints until Mountpoint Pod for given `podID` and `volumeID` is in `Running` state.
+// It returns found Mountpoint Pod and it's base directory.
+func (pm *PodMounter) waitForMountpointPod(ctx context.Context, podID, volumeID string) (*corev1.Pod, string, error) {
+	podName := mppod.MountpointPodNameFor(podID, volumeID)
+
+	// Pod already exists and in `Running` state
+	// TODO: Should we do caching here?
+	pod, err := pm.client.Pods(pm.mountpointPodNamespace).Get(ctx, podName, metav1.GetOptions{})
+	if err == nil && pod.Status.Phase == corev1.PodRunning {
+		return pod, pm.podPath(pod), nil
+	}
+
+	// Pod does not exists or not `Running` yet, watch for the Pod until it's `Running`.
+
+	klog.V(4).Infof("Waiting for Mountpoint Pod %s to running", podName)
+
+	w, err := pm.client.Pods(pm.mountpointPodNamespace).Watch(ctx, metav1.SingleObject(metav1.ObjectMeta{Name: podName}))
+	if err != nil {
+		return nil, "", err
+	}
+	defer w.Stop()
+
+	var foundPod *corev1.Pod
+
+	for event := range w.ResultChan() {
+		if event.Type != watch.Added &&
+			event.Type != watch.Modified {
+			continue
+		}
+
+		pod, ok := event.Object.(*corev1.Pod)
+		if !ok {
+			continue
+		}
+
+		if pod.Status.Phase == corev1.PodRunning {
+			foundPod = pod
+			break
+		}
+	}
+
+	if foundPod == nil {
+		return nil, "", errors.New("Failed to get Mountpoint Pod")
+	}
+
+	klog.V(4).Infof("Mountpoint Pod %s is running with id %s", podName, foundPod.UID)
+
+	return foundPod, pm.podPath(foundPod), nil
+}
+
+// waitForMount waits until Mountpoint is successfully mounted at `target`.
+// It returns an error if Mountpoint fails to mount.
+func (pm *PodMounter) waitForMount(ctx context.Context, target, podName, podMountErrorPath string) error {
+	mountResultCh := make(chan error)
+
+	klog.V(4).Infof("Waiting until Mountpoint Pod %s mounts on %s", podName, target)
+
+	// Poll for mount error file
+	go func() {
+		wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
+			res, err := os.ReadFile(podMountErrorPath)
+			if err != nil {
+				return false, nil
+			}
+
+			mountResultCh <- fmt.Errorf("Mountpoint Pod %s failed: %s", podName, res)
+			return true, nil
+		})
+	}()
+
+	// Poll for `IsMountPoint` check
+	go func() {
+		err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
+			return pm.IsMountPoint(target)
+		})
+
+		if err != nil {
+			mountResultCh <- fmt.Errorf("Failed to check if Mountpoint Pod %s mounted: %w", podName, err)
+		} else {
+			mountResultCh <- nil
+		}
+	}()
+
+	err := <-mountResultCh
+	if err == nil {
+		klog.V(4).Infof("Mountpoint Pod %s mounted on %s", podName, target)
+	} else {
+		klog.V(4).Infof("Mountpoint Pod %s failed to mount on %s: %v", podName, target, err)
+	}
+
+	return err
+}
+
+// closeFd closes given FUSE file descriptor.
+func (pm *PodMounter) closeFd(fd int) {
+	err := syscall.Close(fd)
+	if err != nil {
+		klog.V(4).Infof("Mount: Failed to close /dev/fuse file descriptor %d: %v\n", fd, err)
+	}
+}
+
+// checkTargetPath checks target path for existence and corrupted mount error.
+// If the target dir does not exists it tries to create it.
+// If the target dir is corrupted (decided with `mount.IsCorruptedMnt`) it tries to unmount it to have a clean mount.
+func (pm *PodMounter) checkTargetPath(target string) error {
+	_, err := os.Stat(target)
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, fs.ErrNotExist) {
+		klog.V(5).Infof("Target path does not exists %s, trying to create", target)
+		if err := os.MkdirAll(target, 0755); err != nil {
+			return fmt.Errorf("Failed to create target directory: %w", err)
+		}
+
+		return nil
+	} else if mount.IsCorruptedMnt(err) {
+		klog.V(4).Infof("Target path %q is a corrupted mount. Trying to unmount", target)
+		if unmountErr := pm.unmountTarget(target); unmountErr != nil {
+			klog.V(4).Infof("Failed to unmount target path %q: %v, original failure of stat: %v", target, unmountErr, err)
+			return fmt.Errorf("Unable to unmount the target %q: %w", target, unmountErr)
+		}
+
+		return nil
+	}
+
+	return err
+}
+
+// ensureCredentialsDirExists ensures credentials dir for `podPath` is exists.
+// It returns credentials dir and any error.
+func (pm *PodMounter) ensureCredentialsDirExists(podPath string) (string, error) {
+	credentialsBasepath := pm.credentialsDir(podPath)
+	err := os.Mkdir(credentialsBasepath, credentialprovider.CredentialDirPerm)
+	if err != nil && !errors.Is(err, fs.ErrExist) {
+		klog.V(4).Infof("Failed to create credentials directory for pod %s: %v", podPath, err)
+		return "", err
+	}
+
+	return credentialsBasepath, nil
+}
+
+// credentialsDir returns credentials dir for `podPath`.
+func (pm *PodMounter) credentialsDir(podPath string) string {
+	return mppod.PathOnHost(podPath, mppod.KnownPathCredentials)
+}
+
+// podPath returns `pod`'s basepath inside kubelet's path.
+func (pm *PodMounter) podPath(pod *corev1.Pod) string {
+	return filepath.Join(pm.kubeletPath, "pods", string(pod.UID))
+}
+
+// mountSyscallWithDefault delegates to `mountSyscall` if set, or fallbacks to platform-native `mountSyscallDefault`.
+func (pm *PodMounter) mountSyscallWithDefault(target string, args mountpoint.Args) (int, error) {
+	if pm.mountSyscall != nil {
+		return pm.mountSyscall(target, args)
+	}
+
+	return pm.mountSyscallDefault(target, args)
+}
+
+// unmountTarget calls `unmount` syscall on `target`.
+func (pm *PodMounter) unmountTarget(target string) error {
+	return pm.mount.Unmount(target)
+}

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -29,6 +29,9 @@ import (
 const mountpointPodReadinessTimeout = 10 * time.Second
 const mountpointPodReadinessCheckInterval = 100 * time.Millisecond
 
+// targetDirPerm is the permission to use while creating target directory if its not exists.
+const targetDirPerm = fs.FileMode(0755)
+
 // mountSyscall is the function that performs `mount` operation for given `target` with given Mountpoint `args`.
 // It returns mounted FUSE file descriptor as a result.
 // This is mainly exposed for testing, in production platform-native function (`mountSyscallDefault`) will be used.
@@ -347,7 +350,7 @@ func (pm *PodMounter) checkTargetPath(target string) error {
 
 	if errors.Is(err, fs.ErrNotExist) {
 		klog.V(5).Infof("Target path does not exists %s, trying to create", target)
-		if err := os.MkdirAll(target, 0755); err != nil {
+		if err := os.MkdirAll(target, targetDirPerm); err != nil {
 			return fmt.Errorf("Failed to create target directory: %w", err)
 		}
 

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -247,15 +247,15 @@ func (pm *PodMounter) waitForMountpointPod(ctx context.Context, podID, volumeID 
 
 	klog.V(4).Infof("Waiting for Mountpoint Pod %s to running", podName)
 
-	w, err := pm.client.Pods(pm.mountpointPodNamespace).Watch(ctx, metav1.SingleObject(metav1.ObjectMeta{Name: podName}))
+	watcher, err := pm.client.Pods(pm.mountpointPodNamespace).Watch(ctx, metav1.SingleObject(metav1.ObjectMeta{Name: podName}))
 	if err != nil {
 		return nil, "", err
 	}
-	defer w.Stop()
+	defer watcher.Stop()
 
 	var foundPod *corev1.Pod
 
-	for event := range w.ResultChan() {
+	for event := range watcher.ResultChan() {
 		if event.Type != watch.Added &&
 			event.Type != watch.Modified {
 			continue

--- a/pkg/driver/node/mounter/pod_mounter_darwin.go
+++ b/pkg/driver/node/mounter/pod_mounter_darwin.go
@@ -1,0 +1,11 @@
+package mounter
+
+import (
+	"errors"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
+)
+
+func (pm *PodMounter) mountSyscallDefault(_ string, _ mountpoint.Args) (int, error) {
+	return 0, errors.New("Only supported on Linux")
+}

--- a/pkg/driver/node/mounter/pod_mounter_linux.go
+++ b/pkg/driver/node/mounter/pod_mounter_linux.go
@@ -21,7 +21,7 @@ func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (
 	closeFd := false
 	defer func() {
 		if closeFd {
-			pm.closeFd(fd)
+			pm.closeFUSEDevFD(fd)
 		}
 	}()
 

--- a/pkg/driver/node/mounter/pod_mounter_linux.go
+++ b/pkg/driver/node/mounter/pod_mounter_linux.go
@@ -1,0 +1,62 @@
+package mounter
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"k8s.io/klog/v2"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
+)
+
+// mountSyscallDefault creates a FUSE file descriptor and performs a `mount` syscall with given `target` and mount arguments.
+func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (int, error) {
+	fd, err := syscall.Open("/dev/fuse", os.O_RDWR, 0)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open /dev/fuse: %w", err)
+	}
+
+	closeFd := false
+	defer func() {
+		if closeFd {
+			pm.closeFd(fd)
+		}
+	}()
+
+	var stat syscall.Stat_t
+	err = syscall.Stat(target, &stat)
+	if err != nil {
+		closeFd = true
+		return 0, fmt.Errorf("failed to stat mount point %s: %w", target, err)
+	}
+
+	options := []string{
+		fmt.Sprintf("fd=%d", fd),
+		fmt.Sprintf("rootmode=%o", stat.Mode&syscall.S_IFMT),
+		fmt.Sprintf("user_id=%d", os.Geteuid()),
+		fmt.Sprintf("group_id=%d", os.Getegid()),
+		"default_permissions",
+	}
+
+	var flags uintptr = uintptr(syscall.MS_NODEV | syscall.MS_NOSUID | syscall.MS_NOATIME)
+
+	if args.Has(mountpoint.ArgReadOnly) {
+		flags |= syscall.MS_RDONLY
+	}
+
+	if args.Has(mountpoint.ArgAllowOther) || args.Has(mountpoint.ArgAllowRoot) {
+		options = append(options, "allow_other")
+	}
+
+	optionsJoined := strings.Join(options, ",")
+	klog.V(4).Infof("Mounting %s with options %s", target, optionsJoined)
+	err = syscall.Mount(mountpointDeviceName, target, "fuse", flags, optionsJoined)
+	if err != nil {
+		closeFd = true
+		return 0, fmt.Errorf("failed to mount %s: %w", target, err)
+	}
+
+	return fd, nil
+}

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -1,0 +1,374 @@
+package mounter_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/mount-utils"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/credentialprovider"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/envprovider"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/mounter"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/mounter/mountertest"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+const mountpointPodNamespace = "mount-s3"
+const testK8sVersion = "v1.28.0"
+
+type testCtx struct {
+	t   *testing.T
+	ctx context.Context
+
+	podMounter *mounter.PodMounter
+
+	client       *fake.Clientset
+	mount        *mount.FakeMounter
+	mountSyscall func(target string, args mountpoint.Args) (fd int, err error)
+
+	bucketName  string
+	kubeletPath string
+	targetPath  string
+	podUID      string
+	volumeID    string
+}
+
+func setup(t *testing.T) *testCtx {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	kubeletPath := t.TempDir()
+	t.Setenv("KUBELET_PATH", kubeletPath)
+
+	bucketName := "test-bucket"
+	podUID := uuid.New().String()
+	volumeID := "s3-csi-driver-volume"
+	targetPath := filepath.Join(
+		kubeletPath,
+		fmt.Sprintf("pods/%s/volumes/kubernetes.io~csi/%s/mount", podUID, volumeID),
+	)
+
+	// Same behaviour as Kubernetes, see https://github.com/kubernetes/kubernetes/blob/8f8c94a04d00e59d286fe4387197bc62c6a4f374/pkg/volume/csi/csi_mounter.go#L211-L215
+	err := os.MkdirAll(filepath.Dir(targetPath), 0750)
+	assert.NoError(t, err)
+
+	// Eval symlinks on `targetPath` as `mount.NewFakeMounter` also does that and we rely on
+	// `mount.List()` to compare mount points and they need to be the same.
+	parentDir, err := filepath.EvalSymlinks(filepath.Dir(targetPath))
+	assert.NoError(t, err)
+	targetPath = filepath.Join(parentDir, filepath.Base(targetPath))
+
+	client := fake.NewClientset()
+	mount := mount.NewFakeMounter(nil)
+
+	testCtx := &testCtx{
+		t:           t,
+		ctx:         ctx,
+		client:      client,
+		mount:       mount,
+		bucketName:  bucketName,
+		kubeletPath: kubeletPath,
+		targetPath:  targetPath,
+		podUID:      podUID,
+		volumeID:    volumeID,
+	}
+
+	mountSyscall := func(target string, args mountpoint.Args) (fd int, err error) {
+		if testCtx.mountSyscall != nil {
+			return testCtx.mountSyscall(target, args)
+		}
+
+		mount.Mount("mountpoint-s3", target, "fuse", nil)
+		return int(mountertest.OpenDevNull(t).Fd()), nil
+	}
+
+	credProvider := credentialprovider.New(client.CoreV1(), func() (string, error) {
+		return "us-west-2", nil
+	})
+
+	podMounter, err := mounter.NewPodMounter(client.CoreV1(), credProvider, mountpointPodNamespace, mount, mountSyscall, testK8sVersion)
+	assert.NoError(t, err)
+
+	testCtx.podMounter = podMounter
+
+	return testCtx
+}
+
+func TestPodMounter(t *testing.T) {
+	t.Run("Mounting", func(t *testing.T) {
+		t.Run("Correctly passes mount options", func(t *testing.T) {
+			testCtx := setup(t)
+
+			devNull := mountertest.OpenDevNull(t)
+
+			testCtx.mountSyscall = func(target string, args mountpoint.Args) (fd int, err error) {
+				testCtx.mount.Mount("mountpoint-s3", target, "fuse", nil)
+
+				// Since `PodMounter.Mount` closes the file descriptor once it passes it to Mountpoint,
+				// we should duplicate our file descriptor to ensure underlying file description won't
+				// closed once the file descriptor passed to `PodMounter.Mount` closed.
+				fd, err = syscall.Dup(int(devNull.Fd()))
+				assert.NoError(t, err)
+
+				return fd, nil
+			}
+
+			args := mountpoint.ParseArgs([]string{mountpoint.ArgReadOnly})
+
+			mountRes := make(chan error)
+			go func() {
+				err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
+					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
+					VolumeID:             testCtx.volumeID,
+					PodID:                testCtx.podUID,
+				}, args)
+				if err != nil {
+					log.Println("Mount failed", err)
+				}
+				mountRes <- err
+			}()
+
+			mpPod := createMountpointPod(testCtx)
+			mpPod.run()
+
+			got := mpPod.receiveMountOptions(testCtx.ctx)
+
+			err := <-mountRes
+			assert.NoError(t, err)
+
+			gotFile := os.NewFile(uintptr(got.Fd), "fd")
+			mountertest.AssertSameFile(t, devNull, gotFile)
+			got.Fd = 0
+
+			assert.Equals(t, mountoptions.Options{
+				BucketName: testCtx.bucketName,
+				Args: []string{
+					"--read-only",
+					"--user-agent-prefix=" + mounter.UserAgent(credentialprovider.AuthenticationSourceDriver, testK8sVersion),
+				},
+				Env: envprovider.Default().List(),
+			}, got)
+		})
+
+		t.Run("Waits for Mountpoint Pod", func(t *testing.T) {
+			testCtx := setup(t)
+
+			go func() {
+				// Add delays to each Mountpoint Pod step
+				time.Sleep(100 * time.Millisecond)
+				mpPod := createMountpointPod(testCtx)
+				time.Sleep(100 * time.Millisecond)
+				mpPod.run()
+				time.Sleep(100 * time.Millisecond)
+				mpPod.receiveMountOptions(testCtx.ctx)
+			}()
+
+			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
+				VolumeID: testCtx.volumeID,
+				PodID:    testCtx.podUID,
+			}, mountpoint.ParseArgs(nil))
+			assert.NoError(t, err)
+		})
+
+		t.Run("Does not duplicate mounts if target is already mounted", func(t *testing.T) {
+			testCtx := setup(t)
+
+			var mountCount atomic.Int32
+
+			testCtx.mountSyscall = func(target string, args mountpoint.Args) (fd int, err error) {
+				mountCount.Add(1)
+				testCtx.mount.Mount("mountpoint-s3", target, "fuse", nil)
+				return int(mountertest.OpenDevNull(t).Fd()), nil
+			}
+
+			go func() {
+				mpPod := createMountpointPod(testCtx)
+				mpPod.run()
+				mpPod.receiveMountOptions(testCtx.ctx)
+			}()
+
+			for i := 0; i < 5; i++ {
+				err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
+					VolumeID: testCtx.volumeID,
+					PodID:    testCtx.podUID,
+				}, mountpoint.ParseArgs(nil))
+				assert.NoError(t, err)
+			}
+
+			assert.Equals(t, int32(1), mountCount.Load())
+		})
+
+		t.Run("Unmounts target if Mountpoint Pod does not receive mount options", func(t *testing.T) {
+			testCtx := setup(t)
+
+			go func() {
+				mpPod := createMountpointPod(testCtx)
+				mpPod.run()
+
+				// Create the `mount.sock` but does not receive anything from it
+				mountSock := mppod.PathOnHost(mpPod.podPath, mppod.KnownPathMountSock)
+				_, err := os.Create(mountSock)
+				assert.NoError(t, err)
+			}()
+
+			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
+				VolumeID: testCtx.volumeID,
+				PodID:    testCtx.podUID,
+			}, mountpoint.ParseArgs(nil))
+			if err == nil {
+				t.Errorf("mount shouldn't succeeded if Mountpoint does not receive the mount options")
+			}
+
+			ok, err := testCtx.mount.IsMountPoint(testCtx.targetPath)
+			assert.NoError(t, err)
+			if ok {
+				t.Errorf("it should unmount the target path if Mountpoint does not receive the mount options")
+			}
+		})
+
+		t.Run("Unmounts target if Mountpoint Pod fails to start", func(t *testing.T) {
+			testCtx := setup(t)
+
+			testCtx.mountSyscall = func(target string, args mountpoint.Args) (fd int, err error) {
+				// Does not do real mounting
+				return int(mountertest.OpenDevNull(t).Fd()), nil
+			}
+
+			go func() {
+				mpPod := createMountpointPod(testCtx)
+				mpPod.run()
+				mpPod.receiveMountOptions(testCtx.ctx)
+
+				// Emulate that Mountpoint failed to mount
+				mountErrorPath := mppod.PathOnHost(mpPod.podPath, mppod.KnownPathMountError)
+				err := os.WriteFile(mountErrorPath, []byte("mount failed"), 0777)
+				assert.NoError(t, err)
+			}()
+
+			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
+				VolumeID: testCtx.volumeID,
+				PodID:    testCtx.podUID,
+			}, mountpoint.ParseArgs(nil))
+			if err == nil {
+				t.Errorf("mount shouldn't succeeded if Mountpoint fails to start")
+			}
+
+			ok, err := testCtx.mount.IsMountPoint(testCtx.targetPath)
+			assert.NoError(t, err)
+			if ok {
+				t.Errorf("it should unmount the target path if Mountpoint fails to start")
+			}
+		})
+	})
+
+	t.Run("Checking if its mount point", func(t *testing.T) {
+		testCtx := setup(t)
+
+		ok, _ := testCtx.podMounter.IsMountPoint(testCtx.targetPath)
+		assert.Equals(t, false, ok)
+
+		go func() {
+			mpPod := createMountpointPod(testCtx)
+			mpPod.run()
+			mpPod.receiveMountOptions(testCtx.ctx)
+		}()
+
+		err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
+			VolumeID: testCtx.volumeID,
+			PodID:    testCtx.podUID,
+		}, mountpoint.ParseArgs(nil))
+		assert.NoError(t, err)
+
+		ok, err = testCtx.podMounter.IsMountPoint(testCtx.targetPath)
+		assert.NoError(t, err)
+		assert.Equals(t, true, ok)
+	})
+
+	t.Run("Unmounting", func(t *testing.T) {
+		testCtx := setup(t)
+
+		go func() {
+			mpPod := createMountpointPod(testCtx)
+			mpPod.run()
+			mpPod.receiveMountOptions(testCtx.ctx)
+		}()
+
+		err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
+			VolumeID: testCtx.volumeID,
+			PodID:    testCtx.podUID,
+		}, mountpoint.ParseArgs(nil))
+		assert.NoError(t, err)
+
+		ok, err := testCtx.podMounter.IsMountPoint(testCtx.targetPath)
+		assert.NoError(t, err)
+		assert.Equals(t, true, ok)
+
+		err = testCtx.podMounter.Unmount(testCtx.ctx, testCtx.targetPath, credentialprovider.CleanupContext{
+			VolumeID: testCtx.volumeID,
+			PodID:    testCtx.podUID,
+		})
+		assert.NoError(t, err)
+
+		ok, err = testCtx.podMounter.IsMountPoint(testCtx.targetPath)
+		assert.NoError(t, err)
+		assert.Equals(t, false, ok)
+	})
+}
+
+type mountpointPod struct {
+	testCtx *testCtx
+	pod     *corev1.Pod
+	podPath string
+}
+
+func createMountpointPod(testCtx *testCtx) *mountpointPod {
+	t := testCtx.t
+	t.Helper()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID(uuid.New().String()),
+			Name: mppod.MountpointPodNameFor(testCtx.podUID, testCtx.volumeID),
+		},
+	}
+	pod, err := testCtx.client.CoreV1().Pods(mountpointPodNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	podPath := filepath.Join(testCtx.kubeletPath, "pods", string(pod.UID))
+	// same with `emptyDir` volume, https://github.com/kubernetes/kubernetes/blob/8f8c94a04d00e59d286fe4387197bc62c6a4f374/pkg/volume/emptydir/empty_dir.go#L43-L48
+	err = os.MkdirAll(mppod.PathOnHost(podPath), 0777)
+	assert.NoError(t, err)
+
+	return &mountpointPod{testCtx: testCtx, pod: pod, podPath: podPath}
+}
+
+func (mp *mountpointPod) run() {
+	mp.testCtx.t.Helper()
+	mp.pod.Status.Phase = corev1.PodRunning
+	var err error
+	mp.pod, err = mp.testCtx.client.CoreV1().Pods(mountpointPodNamespace).UpdateStatus(context.Background(), mp.pod, metav1.UpdateOptions{})
+	assert.NoError(mp.testCtx.t, err)
+}
+
+func (mp *mountpointPod) receiveMountOptions(ctx context.Context) mountoptions.Options {
+	mp.testCtx.t.Helper()
+	mountSock := mppod.PathOnHost(mp.podPath, mppod.KnownPathMountSock)
+	options, err := mountoptions.Recv(ctx, mountSock)
+	assert.NoError(mp.testCtx.t, err)
+	return options
+}

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 const mountpointPodNamespace = "mount-s3"
+const dummyIMDSRegion = "us-west-2"
 const testK8sVersion = "v1.28.0"
 
 type testCtx struct {
@@ -103,7 +104,7 @@ func setup(t *testing.T) *testCtx {
 	}
 
 	credProvider := credentialprovider.New(client.CoreV1(), func() (string, error) {
-		return "us-west-2", nil
+		return dummyIMDSRegion, nil
 	})
 
 	podMounter, err := mounter.NewPodMounter(client.CoreV1(), credProvider, mountpointPodNamespace, mount, mountSyscall, testK8sVersion)

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
 )
 
@@ -54,6 +55,10 @@ func setup(t *testing.T) *testCtx {
 
 	kubeletPath := t.TempDir()
 	t.Setenv("KUBELET_PATH", kubeletPath)
+
+	// Chdir to `kubeletPath` so `mountoptions.{Recv, Send}` can use relative paths to Unix sockets
+	// to overcome `bind: invalid argument`.
+	testutil.Chdir(t, kubeletPath)
 
 	bucketName := "test-bucket"
 	podUID := uuid.New().String()

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -373,6 +373,8 @@ func (mp *mountpointPod) run() {
 	assert.NoError(mp.testCtx.t, err)
 }
 
+// receiveMountOptions will receive mount options sent to the Mountpoint Pod.
+// This operation will block in place, and ideally should be called from a separate goroutine.
 func (mp *mountpointPod) receiveMountOptions(ctx context.Context) mountoptions.Options {
 	mp.testCtx.t.Helper()
 	mountSock := mppod.PathOnHost(mp.podPath, mppod.KnownPathMountSock)

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -158,6 +158,8 @@ func TestPodMounter(t *testing.T) {
 
 			gotFile := os.NewFile(uintptr(got.Fd), "fd")
 			mountertest.AssertSameFile(t, devNull, gotFile)
+			// Reset fd as they might be different in different ends.
+			// To verify underlying objects are the same, we need to compare "dev" and "ino" from "fstat" syscall, which we do with `AssertSameFile`.
 			got.Fd = 0
 
 			assert.Equals(t, mountoptions.Options{

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -283,7 +283,7 @@ func TestPodMounter(t *testing.T) {
 		})
 	})
 
-	t.Run("Checking if its mount point", func(t *testing.T) {
+	t.Run("Checking if target is a mount point", func(t *testing.T) {
 		testCtx := setup(t)
 
 		ok, _ := testCtx.podMounter.IsMountPoint(testCtx.targetPath)

--- a/pkg/podmounter/mountoptions/mount_options.go
+++ b/pkg/podmounter/mountoptions/mount_options.go
@@ -172,6 +172,7 @@ func tryToMakeSockPathRelative(path string) string {
 	if err != nil {
 		// Failed to make it relative to the current working directory,
 		// just emit a warning if needed and return unmodified path.
+		klog.Warningf("Length of Unix domain socket %q is larger than 108 characters, failed to make it relative to the current working directory to shorten it: %v\n", path, err)
 		warnAboutLongUnixSocketPath(path)
 		return path
 	}

--- a/pkg/podmounter/mountoptions/mount_options.go
+++ b/pkg/podmounter/mountoptions/mount_options.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"syscall"
 
 	"k8s.io/klog/v2"
@@ -25,7 +27,7 @@ type Options struct {
 
 // Send sends given mount `options` to given `sockPath` to be received by `Recv` function on the other end.
 func Send(ctx context.Context, sockPath string, options Options) error {
-	warnAboutLongUnixSocketPath(sockPath)
+	sockPath = tryToMakeSockPathRelative(sockPath)
 
 	message, err := json.Marshal(&options)
 	if err != nil {
@@ -70,7 +72,7 @@ var (
 
 // Recv receives passed mount options via `Send` function through given `sockPath`.
 func Recv(ctx context.Context, sockPath string) (Options, error) {
-	warnAboutLongUnixSocketPath(sockPath)
+	sockPath = tryToMakeSockPathRelative(sockPath)
 
 	var lc net.ListenConfig
 	l, err := lc.Listen(ctx, "unix", sockPath)
@@ -154,12 +156,59 @@ func parseUnixRights(buf []byte) ([]int, error) {
 	return fds, nil
 }
 
+// tryToMakeSockPathRelative tries to make `path` relative to the current working directory
+// if its longer than 108 characters. This is because Go returns `invalid argument` errors
+// if you try to do `net.Listen()` or `net.Dial()`, see https://github.com/golang/go/issues/6895 for more details.
+//
+// If the `path` is still longer than 108 characters after making it relative, this function emits a warning log.
+// If the `path` is not relative, this function just returns unmodified `path` and emits a warning log if needed.
+func tryToMakeSockPathRelative(path string) string {
+	if len(path) < 108 {
+		// Nothing to do, its already shorter than 108 characters
+		return path
+	}
+
+	shortPath, err := relative(path)
+	if err != nil {
+		// Failed to make it relative to the current working directory,
+		// just emit a warning if needed and return unmodified path.
+		warnAboutLongUnixSocketPath(path)
+		return path
+	}
+
+	// Successfully turned `path` into a relative path,
+	// just return relative path and emit a warning if its still longer than 108 characters.
+	warnAboutLongUnixSocketPath(shortPath)
+	return shortPath
+}
+
 // warnAboutLongUnixSocketPath emits a warning if `path` is longer than 108 characters.
-// There is a limit on Unix domain socket path on some platforms and
-// Go returns `bind: invalid argument` in this case which is hard to debug.
-// See https://github.com/golang/go/issues/6895 for more details.
 func warnAboutLongUnixSocketPath(path string) {
 	if len(path) > 108 {
 		klog.Warningf("Length of Unix domain socket is larger than 108 characters and it might not work in some platforms, see https://github.com/golang/go/issues/6895. Fullpath: %q", path)
 	}
+}
+
+// relative tries to make `p` relative to the current working directory.
+// Copied from https://github.com/moby/vpnkit/blob/604ab7f0d2c999693ab4aa920bdda05f350f497e/go/pkg/vpnkit/transport/unix_unix.go#L66-L86
+func relative(p string) (string, error) {
+	// Assume the parent directory exists already but the child (the socket)
+	// hasn't been created.
+	path2, err := filepath.EvalSymlinks(filepath.Dir(p))
+	if err != nil {
+		return "", err
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir2, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(dir2, path2)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(rel, filepath.Base(p)), nil
 }

--- a/pkg/podmounter/mountoptions/mount_options_test.go
+++ b/pkg/podmounter/mountoptions/mount_options_test.go
@@ -4,16 +4,47 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
 )
 
-func TestSendingAndReceivingMountOptions(t *testing.T) {
+func TestMountOptions(t *testing.T) {
+	// Go returns `invalid argument` errors if you try to do `net.Listen()` or `net.Dial()` with a Unix socket
+	// path thats longer than 108 characters by default. We're trying to use relative paths if that's the case
+	// to make the socket paths shorter. Here we add test cases for both short and long Unix socket paths.
+	// See https://github.com/golang/go/issues/6895 for more details.
+
+	basePath := t.TempDir()
+	testutil.Chdir(t, basePath)
+
+	t.Run("Short Path", func(t *testing.T) {
+		mountSock := filepath.Join(basePath, "m")
+		if len(mountSock) >= 108 {
+			t.Fatalf("test Unix socket path %q must be shorter than 108 characters", mountSock)
+		}
+		testRoundtrip(t, mountSock)
+	})
+
+	t.Run("Long Path", func(t *testing.T) {
+		sockBasepath := filepath.Join(basePath, "long"+strings.Repeat("g", 50))
+		assert.NoError(t, os.Mkdir(sockBasepath, 0700))
+
+		mountSock := filepath.Join(sockBasepath, "mount.sock")
+		if len(mountSock) <= 108 {
+			t.Fatalf("test Unix socket path %q must be longer than 108 characters", mountSock)
+		}
+		testRoundtrip(t, mountSock)
+	})
+}
+
+func testRoundtrip(t *testing.T, mountSock string) {
 	file, err := os.Open(os.DevNull)
 	assert.NoError(t, err)
 	defer file.Close()
@@ -21,8 +52,6 @@ func TestSendingAndReceivingMountOptions(t *testing.T) {
 	var wantStat = &syscall.Stat_t{}
 	err = syscall.Fstat(int(file.Fd()), wantStat)
 	assert.NoError(t, err)
-
-	mountSock := filepath.Join(t.TempDir(), "m")
 
 	c := make(chan mountoptions.Options)
 	go func() {

--- a/pkg/podmounter/mountoptions/mount_options_test.go
+++ b/pkg/podmounter/mountoptions/mount_options_test.go
@@ -21,10 +21,10 @@ func TestMountOptions(t *testing.T) {
 	// to make the socket paths shorter. Here we add test cases for both short and long Unix socket paths.
 	// See https://github.com/golang/go/issues/6895 for more details.
 
-	basePath := t.TempDir()
-	testutil.Chdir(t, basePath)
-
 	t.Run("Short Path", func(t *testing.T) {
+		basePath := t.TempDir()
+		testutil.Chdir(t, basePath)
+
 		mountSock := filepath.Join(basePath, "m")
 		if len(mountSock) >= 108 {
 			t.Fatalf("test Unix socket path %q must be shorter than 108 characters", mountSock)
@@ -33,8 +33,11 @@ func TestMountOptions(t *testing.T) {
 	})
 
 	t.Run("Long Path", func(t *testing.T) {
-		sockBasepath := filepath.Join(basePath, "long"+strings.Repeat("g", 50))
-		assert.NoError(t, os.Mkdir(sockBasepath, 0700))
+		basePath := filepath.Join(t.TempDir(), "long"+strings.Repeat("g", 108))
+		sockBasepath := filepath.Join(basePath, "mount")
+		assert.NoError(t, os.MkdirAll(sockBasepath, 0700))
+
+		testutil.Chdir(t, basePath)
 
 		mountSock := filepath.Join(sockBasepath, "mount.sock")
 		if len(mountSock) <= 108 {

--- a/pkg/podmounter/mppod/path.go
+++ b/pkg/podmounter/mppod/path.go
@@ -13,6 +13,10 @@ const KnownPathMountSock = "mount.sock"
 // will propagate contents of this error file to the Kubernetes and to the operator to resolve any operator error.
 const KnownPathMountError = "mount.err"
 
+// KnownPathMountExit is the path of mount exit file that's created by CSI Driver Node Pod that indicates
+// Mountpoint Pod is no longer needed and can cleany exit.
+const KnownPathMountExit = "mount.exit"
+
 // CommunicationDirName is the name of `emptyDir` volume each Mountpoint Pod will create
 // for the communication between Mountpoint Pod and the CSI Driver Node Pod.
 // Each Pod will have a different view for the files inside this folder,

--- a/pkg/podmounter/mppod/path.go
+++ b/pkg/podmounter/mppod/path.go
@@ -17,6 +17,9 @@ const KnownPathMountError = "mount.err"
 // Mountpoint Pod is no longer needed and can cleany exit.
 const KnownPathMountExit = "mount.exit"
 
+// KnownPathCredentials is the base directory for storing credential files.
+const KnownPathCredentials = "credentials"
+
 // CommunicationDirName is the name of `emptyDir` volume each Mountpoint Pod will create
 // for the communication between Mountpoint Pod and the CSI Driver Node Pod.
 // Each Pod will have a different view for the files inside this folder,

--- a/pkg/util/testutil/chdir.go
+++ b/pkg/util/testutil/chdir.go
@@ -1,0 +1,29 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+)
+
+// Chdir changes working directory to `dir` and resets it back to the original in `t.Cleanup`.
+// TODO: Go 1.24 will have `t.Chdir`, remove this once Go 1.24 released and we start using it.
+// Copied from https://github.com/golang/go/blob/go1.23.5/src/os/exec/exec_test.go#L198-L218.
+func Chdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Chdir(%#q)", dir)
+	t.Cleanup(func() {
+		if err := os.Chdir(prev); err != nil {
+			// Couldn't chdir back to the original working directory.
+			// panic instead of t.Fatal so that we don't run other tests
+			// in an unexpected location.
+			panic("couldn't restore working directory: " + err.Error())
+		}
+	})
+}


### PR DESCRIPTION
Part of https://github.com/awslabs/mountpoint-s3-csi-driver/issues/279. This `PodMounter` is not in use at the moment, only tests are running for it. I'll do a follow-up PR to add Kubernetes manifests and enabling this `PodMounter` via Helm flag.

Best reviewed on commit-by-commit.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
