### PR TITLE
Add v1.32 Ubuntu2204 into CI matrix

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -22,6 +22,10 @@ matrix:
       arch: "arm"
       family: "Ubuntu2204"
       kubernetes-version: "1.31.0"
+    - cluster-type: "eksctl"
+      arch: "arm"
+      family: "Ubuntu2204"
+      kubernetes-version: "1.32.1"
   exclude:
     - cluster-type: "kops"
       family: "Bottlerocket"


### PR DESCRIPTION
*Issue #, if available:* We previously removed v1.32 Ubuntu2204 from this PR (https://github.com/awslabs/mountpoint-s3-csi-driver/pull/357) because at that time 1.32 Ubuntu2204 AMI image was not available in AWS Parameter Store. 

*Description of changes:* Add v1.32 Ubuntu2204 into CI matrix as these images are now available


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
