### PR TITLE
Add context argument to `mounter.Unmount` method

### DIFF
--- a/pkg/driver/node/mounter/fake_mounter.go
+++ b/pkg/driver/node/mounter/fake_mounter.go
@@ -14,7 +14,7 @@ func (m *FakeMounter) Mount(ctx context.Context, bucketName string, target strin
 	return nil
 }
 
-func (m *FakeMounter) Unmount(target string, credentialCtx credentialprovider.CleanupContext) error {
+func (m *FakeMounter) Unmount(ctx context.Context, target string, credentialCtx credentialprovider.CleanupContext) error {
 	return nil
 }
 

--- a/pkg/driver/node/mounter/mocks/mock_mount.go
+++ b/pkg/driver/node/mounter/mocks/mock_mount.go
@@ -120,15 +120,15 @@ func (mr *MockMounterMockRecorder) Mount(ctx, bucketName, target, credentialCtx,
 }
 
 // Unmount mocks base method.
-func (m *MockMounter) Unmount(target string, credentialCtx credentialprovider.CleanupContext) error {
+func (m *MockMounter) Unmount(ctx context.Context, target string, credentialCtx credentialprovider.CleanupContext) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unmount", target, credentialCtx)
+	ret := m.ctrl.Call(m, "Unmount", ctx, target, credentialCtx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Unmount indicates an expected call of Unmount.
-func (mr *MockMounterMockRecorder) Unmount(target, credentialCtx interface{}) *gomock.Call {
+func (mr *MockMounterMockRecorder) Unmount(ctx, target, credentialCtx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unmount", reflect.TypeOf((*MockMounter)(nil).Unmount), target, credentialCtx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unmount", reflect.TypeOf((*MockMounter)(nil).Unmount), ctx, target, credentialCtx)
 }

--- a/pkg/driver/node/mounter/mounter.go
+++ b/pkg/driver/node/mounter/mounter.go
@@ -25,7 +25,7 @@ type ServiceRunner interface {
 // Mounter is an interface for mount operations
 type Mounter interface {
 	Mount(ctx context.Context, bucketName string, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args) error
-	Unmount(target string, credentialCtx credentialprovider.CleanupContext) error
+	Unmount(ctx context.Context, target string, credentialCtx credentialprovider.CleanupContext) error
 	IsMountPoint(target string) (bool, error)
 }
 

--- a/pkg/driver/node/mounter/systemd_mounter_test.go
+++ b/pkg/driver/node/mounter/systemd_mounter_test.go
@@ -37,7 +37,6 @@ func initMounterTestEnv(t *testing.T) *mounterTestEnv {
 		mockCtl:    mockCtl,
 		mockRunner: mockRunner,
 		mounter: &mounter.SystemdMounter{
-			Ctx:         ctx,
 			Runner:      mockRunner,
 			Mounter:     mount.NewFakeMounter(nil),
 			MpVersion:   mountpointVersion,

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -159,7 +159,7 @@ func (ns *S3NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUn
 	credentialCtx := credentialCleanupContextFromUnpublishRequest(req)
 
 	klog.V(4).Infof("NodeUnpublishVolume: unmounting %s", target)
-	err = ns.Mounter.Unmount(target, credentialCtx)
+	err = ns.Mounter.Unmount(ctx, target, credentialCtx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not unmount %q: %v", target, err)
 	}

--- a/pkg/driver/node/node_test.go
+++ b/pkg/driver/node/node_test.go
@@ -235,7 +235,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				}
 
 				nodeTestEnv.mockMounter.EXPECT().IsMountPoint(gomock.Eq(targetPath)).Return(true, nil)
-				nodeTestEnv.mockMounter.EXPECT().Unmount(gomock.Eq(targetPath), gomock.Any())
+				nodeTestEnv.mockMounter.EXPECT().Unmount(gomock.Eq(ctx), gomock.Eq(targetPath), gomock.Any())
 				_, err := nodeTestEnv.server.NodeUnpublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume failed: %v", err)
@@ -275,6 +275,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 
 				nodeTestEnv.mockMounter.EXPECT().IsMountPoint(gomock.Eq(targetPath)).Return(true, nil)
 				nodeTestEnv.mockMounter.EXPECT().Unmount(
+					gomock.Eq(ctx),
 					gomock.Eq(targetPath),
 					gomock.Eq(credentialprovider.CleanupContext{
 						VolumeID: volumeId,
@@ -341,7 +342,7 @@ func (d *dummyMounter) Mount(ctx context.Context, bucketName string, target stri
 	return nil
 }
 
-func (d *dummyMounter) Unmount(target string, ctx credentialprovider.CleanupContext) error {
+func (d *dummyMounter) Unmount(ctx context.Context, target string, cleanupCtx credentialprovider.CleanupContext) error {
 	return nil
 }
 


### PR DESCRIPTION
`SystemdMounter` was creating a background context in the constructor and using it when a context needed – which is not a good practice as main reason for contexts are cancellation and timeouts but creating a background context kills that benefit. Now, `mounter.Unmount` accepts context as a first argument.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
