### PR TITLE
Add `PodMounter` manifests behind `experimental.podMounter` Helm feature-flag

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.experimental.podMounter -}}
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: s3-csi-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: s3-csi-controller
+      {{- include "aws-mountpoint-s3-csi-driver.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app: s3-csi-controller
+        {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 8 }}
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+        {{- with .Values.controller.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      serviceAccountName: {{ .Values.controller.serviceAccount.name }}
+      priorityClassName: system-cluster-critical
+      {{- with .Values.controller.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+        # TODO: Should we add some default tolerations for controller?
+        {{- with .Values.controller.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: s3-csi-controller
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "/bin/aws-s3-csi-controller"
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            {{- with .Values.controller.seLinuxOptions }}
+            seLinuxOptions:
+              user: {{ .user }}
+              type: {{ .type }}
+              role: {{ .role }}
+              level: {{ .level }}
+            {{- end }}
+          # TODO: Healthcheck for the controller.
+          {{- with .Values.controller.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: MOUNTPOINT_IMAGE
+              value: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+            - name: MOUNTPOINT_IMAGE_PULL_POLICY
+              value: {{ .Values.image.pullPolicy }}
+            - name: MOUNTPOINT_NAMESPACE
+              value: {{ .Values.mountpointPod.namespace }}
+
+{{- end -}}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/mount-s3-namespace.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/mount-s3-namespace.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.experimental.podMounter -}}
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.mountpointPod.namespace }}
+  labels:
+    name: {{ .Values.mountpointPod.namespace }}
+    # TODO: Check if we can enable some pod security standards?
+    # pod-security.kubernetes.io/enforce: restricted
+    # pod-security.kubernetes.io/enforce-version: v1.30
+    # pod-security.kubernetes.io/warn: restricted
+    # pod-security.kubernetes.io/warn-version: latest
+
+{{- end -}}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -1,4 +1,3 @@
-# Source: aws-mountpoint-s3-csi-driver/templates/node.yaml
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -46,6 +45,9 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+
+      {{ if not .Values.experimental.podMounter -}}
+      # This `install-mountpoint` is only needed with `SystemdMounter` and not with `PodMounter`.
       initContainers:
         - name: install-mountpoint
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
@@ -68,12 +70,18 @@ spec:
           volumeMounts:
             - name: mp-install
               mountPath: /target
+      {{- end }}
+
       containers:
         - name: s3-plugin
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           securityContext:
+            {{ if .Values.experimental.podMounter -}}
+            privileged: true
+            {{- else -}}
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            {{- end }}
             {{- with .Values.node.seLinuxOptions }}
             seLinuxOptions:
               user: {{ .user }}
@@ -101,6 +109,12 @@ spec:
                   fieldPath: spec.nodeName
             - name: HOST_PLUGIN_DIR
               value: {{ trimSuffix "/" .Values.node.kubeletPath }}/plugins/s3.csi.aws.com/
+            {{- if .Values.experimental.podMounter }}
+            - name: MOUNTER_KIND
+              value: pod
+            - name: MOUNTPOINT_NAMESPACE
+              value: {{ .Values.mountpointPod.namespace }}
+            {{- end -}}
             {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
@@ -124,11 +138,15 @@ spec:
           volumeMounts:
             - name: kubelet-dir
               mountPath: {{ .Values.node.kubeletPath }}
+              {{ if .Values.experimental.podMounter -}}
+              mountPropagation: Bidirectional
+              {{- else -}}
               # Currently we spawn Mountpoint instances on the host using systemd,
               # "HostToContainer" allows any newly created mounts inside kubelet path to propagated to the container.
               # Thanks to this, we can do "is mount point?" checks for volumes provided by the CSI Driver
               # without needing to mount "/proc/mounts" from host.
               mountPropagation: HostToContainer
+              {{- end }}
             - name: plugin-dir
               mountPath: /csi
             - name: systemd-bus

--- a/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.experimental.podMounter -}}
+
+{{- if .Values.controller.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.controller.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+  {{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-controller-role
+  namespace: {{ .Values.mountpointPod.namespace }}
+  labels:
+    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "create", "watch", "delete", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-controller-role-binding
+  namespace: {{ .Values.mountpointPod.namespace }}
+  labels:
+    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: s3-csi-driver-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-controller-cluster-role
+  labels:
+    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims", "persistentvolumes"]
+    verbs: ["get", "watch", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-controller-cluster-role-binding
+  labels:
+    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: s3-csi-driver-controller-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}
+
+{{- end -}}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-node.yaml
@@ -41,4 +41,35 @@ roleRef:
   name: s3-csi-driver-cluster-role
   apiGroup: rbac.authorization.k8s.io
 
+{{- if .Values.experimental.podMounter }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-node-mountpoint-pod-namespace-role
+  namespace: {{ .Values.mountpointPod.namespace }}
+  labels:
+    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-node-mountpoint-pod-namespace-role-binding
+  namespace: {{ .Values.mountpointPod.namespace }}
+  labels:
+    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.node.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: s3-csi-driver-node-mountpoint-pod-namespace-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}
+
 {{- end -}}

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -50,6 +50,7 @@ node:
                   - hybrid
   podInfoOnMountCompat:
     enable: false
+
 sidecars:
   nodeDriverRegistrar:
     image:
@@ -77,6 +78,15 @@ sidecars:
         name: plugin-dir
     resources: {}
 
+controller:
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    name: s3-csi-driver-controller-sa
+
+mountpointPod:
+  namespace: mount-s3
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -87,3 +97,6 @@ awsAccessSecret:
   keyId: key_id
   accessKey: access_key
   sessionToken: session_token
+
+experimental:
+  podMounter: false


### PR DESCRIPTION
This PR adds Kubernetes manifests changes to the Helm chart behind `experimental.podMounter` feature-flag. 

Unless you pass `experimental.podMounter`, it won't change anything semantically:
```bash
# Render current working copy
$ helm template ./charts/aws-mountpoint-s3-csi-driver > main-rendered
# Render latest released Helm chart, v1.12.0
$ helm template aws-mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver > v1.12.0-rendered
```

`diff v1.12.0-rendered main-rendered`:
```diff
44d43
< # Source: aws-mountpoint-s3-csi-driver/templates/node.yaml
91a91,92
>
>       # This `install-mountpoint` is only needed with `SystemdMounter` and not with `PodMounter`.
111a113
>
```

and to compare when you enable `experimental.podMounter`:
```bash
$ helm template ./charts/aws-mountpoint-s3-csi-driver --set experimental.podMounter=true > pod-mounter-rendered
```

<details>
<summary>`diff main-rendered pod-mounter-rendered`</summary>

```diff
1a2,27
> # Source: aws-mountpoint-s3-csi-driver/templates/mount-s3-namespace.yaml
> apiVersion: v1
> kind: Namespace
> metadata:
>   name: mount-s3
>   labels:
>     name: mount-s3
>     # TODO: Check if we can enable some pod security standards?
>     # pod-security.kubernetes.io/enforce: restricted
>     # pod-security.kubernetes.io/enforce-version: v1.30
>     # pod-security.kubernetes.io/warn: restricted
>     # pod-security.kubernetes.io/warn-version: latest
> ---
> # Source: aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
> apiVersion: v1
> kind: ServiceAccount
> metadata:
>   name: s3-csi-driver-controller-sa
>   namespace: default
>   labels:
>     app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
>     app.kubernetes.io/instance: release-name
>     helm.sh/chart: aws-mountpoint-s3-csi-driver-1.12.0
>     app.kubernetes.io/component: csi-driver
>     app.kubernetes.io/managed-by: Helm
> ---
14a41,56
> # Source: aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
> kind: ClusterRole
> apiVersion: rbac.authorization.k8s.io/v1
> metadata:
>   name: s3-csi-driver-controller-cluster-role
>   labels:
>     app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
>     app.kubernetes.io/instance: release-name
>     helm.sh/chart: aws-mountpoint-s3-csi-driver-1.12.0
>     app.kubernetes.io/component: csi-driver
>     app.kubernetes.io/managed-by: Helm
> rules:
>   - apiGroups: [""]
>     resources: ["pods", "persistentvolumeclaims", "persistentvolumes"]
>     verbs: ["get", "watch", "list"]
> ---
26a69,88
> # Source: aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
> kind: ClusterRoleBinding
> apiVersion: rbac.authorization.k8s.io/v1
> metadata:
>   name: s3-csi-driver-controller-cluster-role-binding
>   labels:
>     app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
>     app.kubernetes.io/instance: release-name
>     helm.sh/chart: aws-mountpoint-s3-csi-driver-1.12.0
>     app.kubernetes.io/component: csi-driver
>     app.kubernetes.io/managed-by: Helm
> subjects:
>   - kind: ServiceAccount
>     name: s3-csi-driver-controller-sa
>     namespace: default
> roleRef:
>   kind: ClusterRole
>   name: s3-csi-driver-controller-cluster-role
>   apiGroup: rbac.authorization.k8s.io
> ---
40a103,157
>   apiGroup: rbac.authorization.k8s.io
> ---
> # Source: aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
> kind: Role
> apiVersion: rbac.authorization.k8s.io/v1
> metadata:
>   name: s3-csi-driver-controller-role
>   namespace: mount-s3
>   labels:
>     app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
>     app.kubernetes.io/instance: release-name
>     helm.sh/chart: aws-mountpoint-s3-csi-driver-1.12.0
>     app.kubernetes.io/component: csi-driver
>     app.kubernetes.io/managed-by: Helm
> rules:
>   - apiGroups: [""]
>     resources: ["pods"]
>     verbs: ["get", "create", "watch", "delete", "list"]
> ---
> # Source: aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-node.yaml
> kind: Role
> apiVersion: rbac.authorization.k8s.io/v1
> metadata:
>   name: s3-csi-driver-node-mountpoint-pod-namespace-role
>   namespace: mount-s3
>   labels:
>     app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
>     app.kubernetes.io/instance: release-name
>     helm.sh/chart: aws-mountpoint-s3-csi-driver-1.12.0
>     app.kubernetes.io/component: csi-driver
>     app.kubernetes.io/managed-by: Helm
> rules:
>   - apiGroups: [""]
>     resources: ["pods"]
>     verbs: ["get", "list", "watch"]
> ---
> # Source: aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
> kind: RoleBinding
> apiVersion: rbac.authorization.k8s.io/v1
> metadata:
>   name: s3-csi-driver-controller-role-binding
>   namespace: mount-s3
>   labels:
>     app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
>     app.kubernetes.io/instance: release-name
>     helm.sh/chart: aws-mountpoint-s3-csi-driver-1.12.0
>     app.kubernetes.io/component: csi-driver
>     app.kubernetes.io/managed-by: Helm
> subjects:
>   - kind: ServiceAccount
>     name: s3-csi-driver-controller-sa
>     namespace: default
> roleRef:
>   kind: Role
>   name: s3-csi-driver-controller-role
42a160,180
> # Source: aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-node.yaml
> kind: RoleBinding
> apiVersion: rbac.authorization.k8s.io/v1
> metadata:
>   name: s3-csi-driver-node-mountpoint-pod-namespace-role-binding
>   namespace: mount-s3
>   labels:
>     app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
>     app.kubernetes.io/instance: release-name
>     helm.sh/chart: aws-mountpoint-s3-csi-driver-1.12.0
>     app.kubernetes.io/component: csi-driver
>     app.kubernetes.io/managed-by: Helm
> subjects:
>   - kind: ServiceAccount
>     name: s3-csi-driver-sa
>     namespace: default
> roleRef:
>   kind: Role
>   name: s3-csi-driver-node-mountpoint-pod-namespace-role
>   apiGroup: rbac.authorization.k8s.io
> ---
92,112c230
<       # This `install-mountpoint` is only needed with `SystemdMounter` and not with `PodMounter`.
<       initContainers:
<         - name: install-mountpoint
<           image: public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.12.0
<           securityContext:
<             readOnlyRootFilesystem: true
<             allowPrivilegeEscalation: false
<             seLinuxOptions:
<               user: system_u
<               type: super_t
<               role: system_r
<               level: s0
<           imagePullPolicy: IfNotPresent
<           command:
<             - "/bin/install-mp"
<           env:
<             - name: MOUNTPOINT_INSTALL_DIR
<               value: /target
<           volumeMounts:
<             - name: mp-install
<               mountPath: /target
---
>       
118,119c236
<             readOnlyRootFilesystem: true
<             allowPrivilegeEscalation: false
---
>             privileged: true
144a262,265
>             - name: MOUNTER_KIND
>               value: pod
>             - name: MOUNTPOINT_NAMESPACE
>               value: mount-s3
166,170c287
<               # Currently we spawn Mountpoint instances on the host using systemd,
<               # "HostToContainer" allows any newly created mounts inside kubelet path to propagated to the container.
<               # Thanks to this, we can do "is mount point?" checks for volumes provided by the CSI Driver
<               # without needing to mount "/proc/mounts" from host.
<               mountPropagation: HostToContainer
---
>               mountPropagation: Bidirectional
275a393,445
> # Source: aws-mountpoint-s3-csi-driver/templates/controller.yaml
> kind: Deployment
> apiVersion: apps/v1
> metadata:
>   name: s3-csi-controller
>   namespace: default
>   labels:
>     app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
>     app.kubernetes.io/instance: release-name
>     helm.sh/chart: aws-mountpoint-s3-csi-driver-1.12.0
>     app.kubernetes.io/component: csi-driver
>     app.kubernetes.io/managed-by: Helm
> spec:
>   replicas: 1
>   selector:
>     matchLabels:
>       app: s3-csi-controller
>       app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
>       app.kubernetes.io/instance: release-name
>   template:
>     metadata:
>       labels:
>         app: s3-csi-controller
>         app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
>         app.kubernetes.io/instance: release-name
>         helm.sh/chart: aws-mountpoint-s3-csi-driver-1.12.0
>         app.kubernetes.io/component: csi-driver
>         app.kubernetes.io/managed-by: Helm
>     spec:
>       nodeSelector:
>         kubernetes.io/os: linux
>       serviceAccountName: s3-csi-driver-controller-sa
>       priorityClassName: system-cluster-critical
>       tolerations:
>         # TODO: Should we add some default tolerations for controller?
>       containers:
>         - name: s3-csi-controller
>           image: public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.12.0
>           imagePullPolicy: IfNotPresent
>           command:
>             - "/bin/aws-s3-csi-controller"
>           securityContext:
>             readOnlyRootFilesystem: true
>             allowPrivilegeEscalation: false
>           # TODO: Healthcheck for the controller.
>           env:
>             - name: MOUNTPOINT_IMAGE
>               value: public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.12.0
>             - name: MOUNTPOINT_IMAGE_PULL_POLICY
>               value: IfNotPresent
>             - name: MOUNTPOINT_NAMESPACE
>               value: mount-s3
> ---
```

</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

