### PR TITLE
Ensure we clear AWS Region environment variables in our tests

### DIFF
--- a/pkg/driver/node/credentialprovider/provider_test.go
+++ b/pkg/driver/node/credentialprovider/provider_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/credentialprovider/awsprofile/awsprofiletest"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/envprovider"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
 )
 
@@ -40,7 +41,7 @@ const testPodNamespace = "test-ns"
 const testIMDSRegion = "us-east-1"
 
 func dummyRegionProvider() (string, error) {
-	return "us-east-1", nil
+	return testIMDSRegion, nil
 }
 
 const testEnvPath = "/test-env"
@@ -234,6 +235,8 @@ func TestProvidingDriverLevelCredentials(t *testing.T) {
 }
 
 func TestProvidingPodLevelCredentials(t *testing.T) {
+	testutil.CleanRegionEnv(t)
+
 	t.Run("correct values", func(t *testing.T) {
 		clientset := fake.NewSimpleClientset(serviceAccount(testPodServiceAccount, testPodNamespace, map[string]string{
 			"eks.amazonaws.com/role-arn": testRoleARN,
@@ -378,6 +381,8 @@ func TestProvidingPodLevelCredentials(t *testing.T) {
 }
 
 func TestDetectingRegionToUseForPodLevelCredentials(t *testing.T) {
+	testutil.CleanRegionEnv(t)
+
 	clientset := fake.NewSimpleClientset(serviceAccount(testPodServiceAccount, testPodNamespace, map[string]string{
 		"eks.amazonaws.com/role-arn": testRoleARN,
 	}))
@@ -562,6 +567,8 @@ func TestDetectingRegionToUseForPodLevelCredentials(t *testing.T) {
 }
 
 func TestProvidingPodLevelCredentialsForDifferentPods(t *testing.T) {
+	testutil.CleanRegionEnv(t)
+
 	clientset := fake.NewSimpleClientset(
 		serviceAccount("test-sa-1", testPodNamespace, map[string]string{
 			"eks.amazonaws.com/role-arn": "arn:aws:iam::123456789012:role/Test1",
@@ -632,6 +639,8 @@ func TestProvidingPodLevelCredentialsForDifferentPods(t *testing.T) {
 }
 
 func TestProvidingPodLevelCredentialsWithSlashInIDs(t *testing.T) {
+	testutil.CleanRegionEnv(t)
+
 	clientset := fake.NewSimpleClientset(serviceAccount(testPodServiceAccount, testPodNamespace, map[string]string{
 		"eks.amazonaws.com/role-arn": testRoleARN,
 	}))
@@ -698,6 +707,8 @@ func TestProvidingPodLevelCredentialsWithSlashInIDs(t *testing.T) {
 }
 
 func TestCleanup(t *testing.T) {
+	testutil.CleanRegionEnv(t)
+
 	t.Run("cleanup driver level", func(t *testing.T) {
 		// Provide/create long-term credentials first
 		setEnvForLongTermCredentials(t)

--- a/pkg/driver/node/envprovider/provider_test.go
+++ b/pkg/driver/node/envprovider/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/envprovider"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
 )
 
@@ -44,6 +45,8 @@ func TestGettingRegion(t *testing.T) {
 }
 
 func TestProvidingDefaultEnvironmentVariables(t *testing.T) {
+	testutil.CleanRegionEnv(t)
+
 	testCases := []struct {
 		name string
 		env  map[string]string

--- a/pkg/util/testutil/env.go
+++ b/pkg/util/testutil/env.go
@@ -1,0 +1,12 @@
+package testutil
+
+import "testing"
+
+// CleanRegionEnv ensures that no AWS Region environment variables are set in the test case `t`.
+// The calling process of `go test` may contain environment variables like `AWS_REGION` and `AWS_DEFAULT_REGION`,
+// which could be inherited by our test cases and cause unexpected test failures.
+// This function provides a clean environment for the test case `t` by removing these variables.
+func CleanRegionEnv(t *testing.T) {
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_REGION", "")
+}


### PR DESCRIPTION
Fixes https://github.com/awslabs/mountpoint-s3-csi-driver/issues/359. I introduced some buggy tests that was assuming a clean environment, and was failing if that was not the case. As shared by @renanmagagnin, the tests were failing if you have `AWS_REGION` environment variable set in your terminal. 

I detected these test cases by running with `AWS_REGION="fail" AWS_DEFAULT_REGION="fail" make test` and updated them to call `testutil.CleanRegionEnv` to have a clean environment.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
