### PR TITLE
Create `mppod/watcher` package for watching Mountpoint Pods

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/mounter"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/version"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod/watcher"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
 	"k8s.io/client-go/kubernetes"
@@ -40,6 +42,8 @@ const (
 	grpcServerMaxReceiveMessageSize = 1024 * 1024 * 2 // 2MB
 
 	unixSocketPerm = os.FileMode(0700) // only owner can write and read.
+
+	podWatcherResyncPeriod = 15 * time.Second
 )
 
 var usePodMounter = os.Getenv("MOUNTER_KIND") == "pod"
@@ -51,6 +55,8 @@ type Driver struct {
 	NodeID   string
 
 	NodeServer *node.S3NodeServer
+
+	stopCh chan struct{}
 }
 
 func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error) {
@@ -81,9 +87,17 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 
 	credProvider := credentialprovider.New(clientset.CoreV1(), credentialprovider.RegionFromIMDSOnce)
 
+	stopCh := make(chan struct{})
+
 	var mounterImpl mounter.Mounter
 	if usePodMounter {
-		mounterImpl, err = mounter.NewPodMounter(clientset.CoreV1(), credProvider, mountpointPodNamespace, mount.New(""), nil, kubernetesVersion)
+		podWatcher := watcher.New(clientset, mountpointPodNamespace, podWatcherResyncPeriod)
+		err = podWatcher.Start(stopCh)
+		if err != nil {
+			klog.Fatalf("Failed to start Pod watcher: %v\n", err)
+		}
+
+		mounterImpl, err = mounter.NewPodMounter(podWatcher, credProvider, mount.New(""), nil, kubernetesVersion)
 		if err != nil {
 			klog.Fatalln(err)
 		}
@@ -102,6 +116,7 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 		Endpoint:   endpoint,
 		NodeID:     nodeID,
 		NodeServer: nodeServer,
+		stopCh:     stopCh,
 	}, nil
 }
 
@@ -155,6 +170,10 @@ func (d *Driver) Run() error {
 
 func (d *Driver) Stop() {
 	klog.Infof("Stopping server")
+	if d.stopCh != nil {
+		close(d.stopCh)
+		d.stopCh = nil
+	}
 	d.Srv.Stop()
 }
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -43,7 +43,7 @@ const (
 
 	unixSocketPerm = os.FileMode(0700) // only owner can write and read.
 
-	podWatcherResyncPeriod = 15 * time.Second
+	podWatcherResyncPeriod = time.Minute
 )
 
 var usePodMounter = os.Getenv("MOUNTER_KIND") == "pod"

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -11,10 +11,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/watch"
-	k8sv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 
@@ -24,6 +21,7 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod/watcher"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util"
 )
 
@@ -40,25 +38,23 @@ type mountSyscall func(target string, args mountpoint.Args) (fd int, err error)
 
 // A PodMounter is a [Mounter] that mounts Mountpoint on pre-created Kubernetes Pod running in the same node.
 type PodMounter struct {
-	client                 k8sv1.CoreV1Interface
-	mountpointPodNamespace string
-	mount                  mount.Interface
-	kubeletPath            string
-	mountSyscall           mountSyscall
-	kubernetesVersion      string
-	credProvider           *credentialprovider.Provider
+	podWatcher        *watcher.Watcher
+	mount             mount.Interface
+	kubeletPath       string
+	mountSyscall      mountSyscall
+	kubernetesVersion string
+	credProvider      *credentialprovider.Provider
 }
 
 // NewPodMounter creates a new [PodMounter] with given Kubernetes client.
-func NewPodMounter(client k8sv1.CoreV1Interface, credProvider *credentialprovider.Provider, mountpointPodNamespace string, mount mount.Interface, mountSyscall mountSyscall, kubernetesVersion string) (*PodMounter, error) {
+func NewPodMounter(podWatcher *watcher.Watcher, credProvider *credentialprovider.Provider, mount mount.Interface, mountSyscall mountSyscall, kubernetesVersion string) (*PodMounter, error) {
 	return &PodMounter{
-		client:                 client,
-		mountpointPodNamespace: mountpointPodNamespace,
-		mount:                  mount,
-		kubeletPath:            util.KubeletPath(),
-		mountSyscall:           mountSyscall,
-		kubernetesVersion:      kubernetesVersion,
-		credProvider:           credProvider,
+		podWatcher:        podWatcher,
+		credProvider:      credProvider,
+		mount:             mount,
+		kubeletPath:       util.KubeletPath(),
+		mountSyscall:      mountSyscall,
+		kubernetesVersion: kubernetesVersion,
 	}, nil
 }
 
@@ -95,6 +91,7 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 	// but we should still update the credentials for it by calling `credProvider.Provide`.
 	pod, podPath, err := pm.waitForMountpointPod(ctx, podID, volumeName)
 	if err != nil {
+		klog.Errorf("Failed to wait for Mountpoint Pod to be ready for %q: %v", target, err)
 		return fmt.Errorf("Failed to wait for Mountpoint Pod to be ready for %q: %w", target, err)
 	}
 
@@ -210,6 +207,7 @@ func (pm *PodMounter) Unmount(ctx context.Context, target string, credentialCtx 
 	// but we should still unmount it and clean the credentials.
 	_, podPath, err := pm.waitForMountpointPod(ctx, podID, volumeName)
 	if err != nil {
+		klog.Errorf("Failed to wait for Mountpoint Pod to be ready for %q: %v", target, err)
 		return fmt.Errorf("Failed to wait for Mountpoint Pod for %q: %w", target, err)
 	}
 
@@ -247,49 +245,14 @@ func (pm *PodMounter) IsMountPoint(target string) (bool, error) {
 func (pm *PodMounter) waitForMountpointPod(ctx context.Context, podID, volumeName string) (*corev1.Pod, string, error) {
 	podName := mppod.MountpointPodNameFor(podID, volumeName)
 
-	// Pod already exists and in `Running` state
-	// TODO: Should we do caching here?
-	pod, err := pm.client.Pods(pm.mountpointPodNamespace).Get(ctx, podName, metav1.GetOptions{})
-	if err == nil && pod.Status.Phase == corev1.PodRunning {
-		return pod, pm.podPath(pod), nil
-	}
-
-	// Pod does not exists or not `Running` yet, watch for the Pod until it's `Running`.
-
-	klog.V(4).Infof("Waiting for Mountpoint Pod %s to running", podName)
-
-	watcher, err := pm.client.Pods(pm.mountpointPodNamespace).Watch(ctx, metav1.SingleObject(metav1.ObjectMeta{Name: podName}))
+	pod, err := pm.podWatcher.Wait(ctx, podName)
 	if err != nil {
 		return nil, "", err
 	}
-	defer watcher.Stop()
 
-	var foundPod *corev1.Pod
+	klog.V(4).Infof("Mountpoint Pod %s/%s is running with id %s", pod.Namespace, podName, pod.UID)
 
-	for event := range watcher.ResultChan() {
-		if event.Type != watch.Added &&
-			event.Type != watch.Modified {
-			continue
-		}
-
-		pod, ok := event.Object.(*corev1.Pod)
-		if !ok {
-			continue
-		}
-
-		if pod.Status.Phase == corev1.PodRunning {
-			foundPod = pod
-			break
-		}
-	}
-
-	if foundPod == nil {
-		return nil, "", errors.New("Failed to get Mountpoint Pod")
-	}
-
-	klog.V(4).Infof("Mountpoint Pod %s/%s is running with id %s", foundPod.Namespace, podName, foundPod.UID)
-
-	return foundPod, pm.podPath(foundPod), nil
+	return pod, pm.podPath(pod), nil
 }
 
 // waitForMount waits until Mountpoint is successfully mounted at `target`.

--- a/pkg/podmounter/mppod/watcher/watcher.go
+++ b/pkg/podmounter/mppod/watcher/watcher.go
@@ -1,0 +1,122 @@
+// Package watcher provides utilities for watching Mountpoint Pods in the cluster.
+package watcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ErrPodNotFound returned when the Mountpoint Pod could not be found in the cluster.
+var ErrPodNotFound = errors.New("mppod/watcher: mountpoint pod not found")
+
+// ErrPodNotReady returned when the Mountpoint Pod was found but is not ready.
+var ErrPodNotReady = errors.New("mppod/watcher: mountpoint pod not ready")
+
+// ErrCacheDesync returned when the Pod informer cache failed to synchronize within the specified timeout.
+var ErrCacheDesync = errors.New("mppod/watcher: failed to sync pod informer cache within the timeout")
+
+// Watcher provides functionality to watch and wait for Mountpoint Pods in the cluster.
+// It uses the Kubernetes informer to watch and cache Pod events.
+type Watcher struct {
+	informer cache.SharedIndexInformer
+	lister   listerv1.PodNamespaceLister
+}
+
+// New creates a new [Watcher] with the given Kubernetes client, Mountpoint Pod namespace, and resync duration.
+func New(client kubernetes.Interface, namespace string, defaultResync time.Duration) *Watcher {
+	factory := informers.NewSharedInformerFactoryWithOptions(client, defaultResync, informers.WithNamespace(namespace))
+	informer := factory.Core().V1().Pods().Informer()
+	lister := factory.Core().V1().Pods().Lister().Pods(namespace)
+	return &Watcher{informer, lister}
+}
+
+// Start begins watching for Pod events in the cluster.
+// It returns [ErrCacheDesync] if the informer cache fails to sync before [stopCh] is cancalled.
+// The provided [stopCh] can be used to stop the watching process.
+func (w *Watcher) Start(stopCh <-chan struct{}) error {
+	go w.informer.Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, w.informer.HasSynced) {
+		return ErrCacheDesync
+	}
+	return nil
+}
+
+// Wait blocks until the specified Mountpoint Pod is found and ready, or until the context is cancelled.
+func (w *Watcher) Wait(ctx context.Context, name string) (*corev1.Pod, error) {
+	// Set a watcher for Pod create & update events
+	var podFound atomic.Bool
+	podChan := make(chan *corev1.Pod, 1)
+	handle, err := w.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			pod := obj.(*corev1.Pod)
+			if pod.Name == name {
+				podFound.Store(true)
+				if w.isPodReady(pod) {
+					podChan <- pod
+				}
+			}
+		},
+		UpdateFunc: func(old, new interface{}) {
+			pod := new.(*corev1.Pod)
+			if pod.Name == name {
+				podFound.Store(true)
+				if w.isPodReady(pod) {
+					podChan <- pod
+				}
+			}
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler for %s: %w", name, err)
+	}
+
+	// Ensure to remove event handler at the end
+	defer w.informer.RemoveEventHandler(handle)
+
+	// Check if the Pod already exists
+	pod, err := w.lister.Get(name)
+	if err == nil {
+		podFound.Store(true)
+		if w.isPodReady(pod) {
+			// Pod already exists and ready
+			return pod, nil
+		}
+	}
+
+	if err != nil && !apierrors.IsNotFound(err) {
+		// We got a different error than "not found", just propagate it
+		return nil, fmt.Errorf("failed to get pod %s: %w", name, err)
+	}
+
+	// Pod does not exists or not ready yet. We set a watcher for create & update events,
+	// and will receive the Pod from `podChan` once its ready.
+	select {
+	case pod := <-podChan:
+		// Pod found and ready
+		return pod, nil
+	case <-ctx.Done():
+		// We didn't received the Pod within the timeout
+
+		if podFound.Load() {
+			// Pod was found, but was not ready
+			return nil, ErrPodNotReady
+		}
+
+		return nil, ErrPodNotFound
+	}
+}
+
+// isPodReady returns whether the given Mountpoint Pod is ready.
+func (w *Watcher) isPodReady(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodRunning
+}

--- a/pkg/podmounter/mppod/watcher/watcher_test.go
+++ b/pkg/podmounter/mppod/watcher/watcher_test.go
@@ -1,0 +1,154 @@
+package watcher_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod/watcher"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestGettingAlreadyScheduledAndReadyPod(t *testing.T) {
+	client := fake.NewClientset()
+
+	mpPod := createMountpointPod(t, client, testMountpointPodName)
+	mpPod.run()
+
+	mpPodWatcher := createAndStartWatcher(t, client)
+
+	pod, err := mpPodWatcher.Wait(context.Background(), mpPod.pod.Name)
+	assert.NoError(t, err)
+	assert.Equals(t, mpPod.pod, pod)
+}
+
+func TestGettingScheduledButNotYetReadyPod(t *testing.T) {
+	client := fake.NewClientset()
+
+	mpPod := createMountpointPod(t, client, testMountpointPodName)
+
+	mpPodWatcher := createAndStartWatcher(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	pod, err := mpPodWatcher.Wait(ctx, testMountpointPodName)
+	assert.Equals(t, watcher.ErrPodNotReady, err)
+	if pod != nil {
+		t.Fatalf("Pod should be nil if `watcher.ErrPodNotReady` error returned, but got %#v", pod)
+	}
+
+	mpPod.run()
+
+	pod, err = mpPodWatcher.Wait(context.Background(), testMountpointPodName)
+	assert.NoError(t, err)
+	assert.Equals(t, mpPod.pod, pod)
+}
+
+func TestGettingNotYetScheduledPod(t *testing.T) {
+	client := fake.NewClientset()
+
+	mpPodWatcher := createAndStartWatcher(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	pod, err := mpPodWatcher.Wait(ctx, testMountpointPodName)
+	assert.Equals(t, watcher.ErrPodNotFound, err)
+	if pod != nil {
+		t.Fatalf("Pod should be nil if `watcher.ErrPodNotFound` error returned, but got %#v", pod)
+	}
+
+	mpPod := createMountpointPod(t, client, testMountpointPodName)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	pod, err = mpPodWatcher.Wait(ctx, testMountpointPodName)
+	assert.Equals(t, watcher.ErrPodNotReady, err)
+	if pod != nil {
+		t.Fatalf("Pod should be nil if `watcher.ErrPodNotReady` error returned, but got %#v", pod)
+	}
+
+	mpPod.run()
+
+	pod, err = mpPodWatcher.Wait(context.Background(), testMountpointPodName)
+	assert.NoError(t, err)
+	assert.Equals(t, mpPod.pod, pod)
+}
+
+func TestGettingPodsConcurrently(t *testing.T) {
+	client := fake.NewClientset()
+
+	mpPodWatcher := createAndStartWatcher(t, client)
+
+	foundPods := make(chan *corev1.Pod)
+	for i := 0; i < 5; i++ {
+		go func() {
+			pod, err := mpPodWatcher.Wait(context.Background(), testMountpointPodName)
+			assert.NoError(t, err)
+			foundPods <- pod
+		}()
+	}
+
+	mpPod := createMountpointPod(t, client, testMountpointPodName)
+	mpPod.run()
+
+	for i := 0; i < 5; i++ {
+		foundPod := <-foundPods
+		assert.Equals(t, mpPod.pod, foundPod)
+	}
+}
+
+func createAndStartWatcher(t *testing.T, client kubernetes.Interface) *watcher.Watcher {
+	mpPodWatcher := watcher.New(client, testMountpointPodNamespace, 10*time.Second)
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() {
+		close(stopCh)
+	})
+
+	err := mpPodWatcher.Start(stopCh)
+	assert.NoError(t, err)
+
+	return mpPodWatcher
+}
+
+const testMountpointPodName = "mp-pod"
+const testMountpointPodNamespace = "mount-s3-test"
+
+type mountpointPod struct {
+	t      *testing.T
+	client kubernetes.Interface
+	pod    *corev1.Pod
+}
+
+func createMountpointPod(t *testing.T, client kubernetes.Interface, name string) *mountpointPod {
+	t.Helper()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID(uuid.New().String()),
+			Name: name,
+		},
+	}
+	pod, err := client.CoreV1().Pods(testMountpointPodNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	return &mountpointPod{t, client, pod}
+}
+
+func (mp *mountpointPod) run() {
+	mp.t.Helper()
+	mp.pod.Status.Phase = corev1.PodRunning
+	var err error
+	mp.pod, err = mp.client.CoreV1().Pods(testMountpointPodNamespace).UpdateStatus(context.Background(), mp.pod, metav1.UpdateOptions{})
+	assert.NoError(mp.t, err)
+}


### PR DESCRIPTION
This PR introduces `mppod/watcher` package for properly watching Mountpoint Pods using Kubernetes [informers](https://pkg.go.dev/k8s.io/client-go/informers). Informers does caching and handles transient errors from the control plane.

Also fixes the potential race conditions mentioned in https://github.com/awslabs/mountpoint-s3-csi-driver/pull/368/files#r1950851325. The `Wait` method set up a watcher first, and then checks if the Pod already seen by doing a `Get` and if not, it just listens events from the watcher.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
