### PR TITLE
Run tests with both `SystemdMounter` and `PodMounter` in CI

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -117,12 +117,14 @@ jobs:
           ACTION: "update_kubeconfig"
         run: |
           tests/e2e-kubernetes/scripts/run.sh
-      - name: Install the driver
+
+      # Test SystemdMounter
+      - name: Install the driver (SystemdMounter)
         env:
           ACTION: "install_driver"
         run: |
           tests/e2e-kubernetes/scripts/run.sh
-      - name: Run E2E Tests
+      - name: Run E2E Tests (SystemdMounter)
         env:
           ACTION: "run_tests"
         run: |
@@ -153,18 +155,45 @@ jobs:
         run: |
           tests/e2e-kubernetes/scripts/format_benchmark_data.py ${{ env.BENCHMARK_ARTIFACTS_FOLDER }}/benchmark-data.json ${{ env.BENCHMARK_ARTIFACTS_FOLDER }}/quicksight-data.json
           aws s3 cp ${{ env.BENCHMARK_ARTIFACTS_FOLDER }} ${{ env.BENCHMARK_BUCKET }} --recursive
-      - name: Post e2e cleanup
+      - name: Post e2e cleanup (SystemdMounter)
         if: always()
         env:
           ACTION: "e2e_cleanup"
         run: |
           tests/e2e-kubernetes/scripts/run.sh
-      - name: Uninstall the driver
+      - name: Uninstall the driver (SystemdMounter)
         if: always()
         env:
           ACTION: "uninstall_driver"
         run: |
           tests/e2e-kubernetes/scripts/run.sh
+
+      # Test PodMounter
+      - name: Install the driver (PodMounter)
+        env:
+          ACTION: "install_driver"
+          MOUNTER_KIND: "pod"
+        run: |
+          tests/e2e-kubernetes/scripts/run.sh
+      - name: Run E2E Tests (PodMounter)
+        env:
+          ACTION: "run_tests"
+        run: |
+          tests/e2e-kubernetes/scripts/run.sh
+      - name: Post e2e cleanup (PodMounter)
+        if: always()
+        env:
+          ACTION: "e2e_cleanup"
+        run: |
+          tests/e2e-kubernetes/scripts/run.sh
+      - name: Uninstall the driver (PodMounter)
+        if: always()
+        env:
+          ACTION: "uninstall_driver"
+        run: |
+          tests/e2e-kubernetes/scripts/run.sh
+
+      # Everything is tested, delete the cluster
       - name: Delete cluster
         if: always()
         env:

--- a/tests/e2e-kubernetes/scripts/helm.sh
+++ b/tests/e2e-kubernetes/scripts/helm.sh
@@ -36,6 +36,14 @@ function helm_install_driver() {
   REPOSITORY=${4}
   TAG=${5}
   KUBECONFIG=${6}
+  MOUNTER_KIND=${7}
+
+  if [ "$MOUNTER_KIND" = "pod" ]; then
+    USE_POD_MOUNTER=true
+  else
+    USE_POD_MOUNTER=false
+  fi
+
   helm_uninstall_driver \
     "$HELM_BIN" \
     "$KUBECTL_BIN" \
@@ -48,6 +56,7 @@ function helm_install_driver() {
     --set image.pullPolicy=Always \
     --set node.serviceAccount.create=true \
     --set node.podInfoOnMountCompat.enable=true \
+    --set experimental.podMounter=${USE_POD_MOUNTER} \
     --kubeconfig ${KUBECONFIG}
   $KUBECTL_BIN rollout status daemonset s3-csi-node -n kube-system --timeout=60s --kubeconfig $KUBECONFIG
   $KUBECTL_BIN get pods -A --kubeconfig $KUBECONFIG

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -74,6 +74,8 @@ EKSCTL_VERSION=${EKSCTL_VERSION:-0.202.0}
 EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-${BASE_DIR}/eksctl-patch.json}
 CI_ROLE_ARN=${CI_ROLE_ARN:-""}
 
+MOUNTER_KIND=${MOUNTER_KIND:-systemd}
+
 mkdir -p ${TEST_DIR}
 mkdir -p ${BIN_DIR}
 export PATH="$PATH:${BIN_DIR}"
@@ -194,7 +196,8 @@ elif [[ "${ACTION}" == "install_driver" ]]; then
     "$HELM_RELEASE_NAME" \
     "${REGISTRY}/${IMAGE_NAME}" \
     "${TAG}" \
-    "${KUBECONFIG}"
+    "${KUBECONFIG}" \
+    "${MOUNTER_KIND}"
 elif [[ "${ACTION}" == "run_tests" ]]; then
   set +e
   pushd tests/e2e-kubernetes


### PR DESCRIPTION
This PR updates CI configuration to run `PodMounter` tests after `SystemdMounter` tests by re-using the same cluster. It cleans the cluster by uninstalling the Helm chart, [deleting all test namespaces and resources](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/tests/e2e-kubernetes/scripts/run.sh#L163-L176).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
