### PR TITLE
Support alternative partitions in e2e tests

### DIFF
--- a/tests/controller/suite_test.go
+++ b/tests/controller/suite_test.go
@@ -27,7 +27,7 @@ const s3CSIDriver = "s3.csi.aws.com"
 const ebsCSIDriver = "ebs.csi.aws.com"
 
 const defaultNamespace = "default"
-const defaultContainerImage = "busybox:latest"
+const defaultContainerImage = "public.ecr.aws/docker/library/busybox:stable-musl"
 
 // Configuration values passed for `mppod.Config` while creating a controller to use in tests.
 const mountpointNamespace = "mount-s3"

--- a/tests/e2e-kubernetes/testsuites/performance.go
+++ b/tests/e2e-kubernetes/testsuites/performance.go
@@ -121,7 +121,6 @@ func (t *s3CSIPerformanceTestSuite) DefineTests(driver storageframework.TestDriv
 				nodeSelector["kubernetes.io/hostname"] = nodeName
 			}
 			pod := e2epod.MakePod(f.Namespace.Name, nodeSelector, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
-			pod.Spec.Containers[0].Image = "ubuntu:22.04"
 			var err error
 			pod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
 			framework.ExpectNoError(err)

--- a/tests/e2e-kubernetes/testsuites/util.go
+++ b/tests/e2e-kubernetes/testsuites/util.go
@@ -266,7 +266,7 @@ func createServiceAccount(ctx context.Context, f *framework.Framework) (*v1.Serv
 }
 
 func awsConfig(ctx context.Context) aws.Config {
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(DefaultRegion))
 	framework.ExpectNoError(err)
 	return cfg
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Removes hard-coded `aws` partition, and uses sts getCallerIdentity to retrieve an ARN which can be used to extract the current partition. Additionally, replaces busybox from dockerhub with busybox from ecr public.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
