### PR TITLE
Fix performance tests failing on missing `apt`

### DIFF
--- a/tests/e2e-kubernetes/testsuites/performance.go
+++ b/tests/e2e-kubernetes/testsuites/performance.go
@@ -40,6 +40,7 @@ const (
 	FioCfgHostDir = "fio/"
 	OutputPath    = "csi-test-artifacts/output.json"
 	FioCfgPodFile = "/c.fio"
+	ubuntuImage   = "public.ecr.aws/docker/library/ubuntu:22.04"
 )
 
 type s3CSIPerformanceTestSuite struct {
@@ -121,6 +122,7 @@ func (t *s3CSIPerformanceTestSuite) DefineTests(driver storageframework.TestDriv
 				nodeSelector["kubernetes.io/hostname"] = nodeName
 			}
 			pod := e2epod.MakePod(f.Namespace.Name, nodeSelector, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			pod.Spec.Containers[0].Image = ubuntuImage
 			var err error
 			pod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
 			framework.ExpectNoError(err)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixes https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/13467948148/job/37637382907

Tested with
```
rm ~/china-logs.log && AWS_PROFILE=china KUBE_TEST_REPO_LIST=./kube_image_configs.yaml GOPROXY=direct KUBECONFIG=~/.kube/config go test -ginkgo.vv -timeout 120m --bucket-region=cn-north-1 --imds-available true --performance=true > ~/china-logs.log
```

```
Ran 31 of 72 Specs in 1968.885 seconds
SUCCESS! -- 31 Passed | 0 Failed | 0 Pending | 41 Skipped
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
