### PR TITLE
Run `modernize` analyzer

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -147,7 +147,7 @@ func (d *Driver) Run() error {
 		}
 	}
 
-	logErr := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	logErr := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		resp, err := handler(ctx, req)
 		if err != nil {
 			klog.Errorf("GRPC error: %v", err)

--- a/pkg/driver/node/envprovider/provider.go
+++ b/pkg/driver/node/envprovider/provider.go
@@ -3,6 +3,7 @@ package envprovider
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 )
@@ -86,9 +87,7 @@ func (env Environment) Set(key Key, value Value) {
 // Merge adds all key-value pairs from the given environment to the current environment.
 // If a key exists in both environments, the value from the given environment takes precedence.
 func (env Environment) Merge(other Environment) {
-	for key, value := range other {
-		env[key] = value
-	}
+	maps.Copy(env, other)
 }
 
 // format formats given key and value to be used as an environment variable.

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -295,7 +295,7 @@ func TestPodMounter(t *testing.T) {
 				mpPod.receiveMountOptions(testCtx.ctx)
 			}()
 
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
 					VolumeID: testCtx.volumeID,
 					PodID:    testCtx.podUID,

--- a/pkg/driver/node/mounter/systemd_mounter_test.go
+++ b/pkg/driver/node/mounter/systemd_mounter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
 	"github.com/golang/mock/gomock"
 	"k8s.io/mount-utils"
+	"slices"
 )
 
 type mounterTestEnv struct {
@@ -108,10 +109,8 @@ func TestS3MounterMount(t *testing.T) {
 			options:    []string{"--aws-max-attempts=10"},
 			before: func(t *testing.T, env *mounterTestEnv) {
 				env.mockRunner.EXPECT().StartService(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, config *system.ExecConfig) (string, error) {
-					for _, e := range config.Env {
-						if e == "AWS_MAX_ATTEMPTS=10" {
-							return "success", nil
-						}
+					if slices.Contains(config.Env, "AWS_MAX_ATTEMPTS=10") {
+						return "success", nil
 					}
 					t.Fatal("Bad env")
 					return "", nil

--- a/pkg/podmounter/mppod/mppod.go
+++ b/pkg/podmounter/mppod/mppod.go
@@ -13,5 +13,5 @@ import (
 // ideally multiple implementation of this function shouldn't co-exists in the same cluster
 // unless there is a clean install of the CSI Driver.
 func MountpointPodNameFor(podUID string, volumeName string) string {
-	return fmt.Sprintf("mp-%x", sha256.Sum224([]byte(fmt.Sprintf("%s%s", podUID, volumeName))))
+	return fmt.Sprintf("mp-%x", sha256.Sum224(fmt.Appendf(nil, "%s%s", podUID, volumeName)))
 }

--- a/pkg/podmounter/mppod/watcher/watcher.go
+++ b/pkg/podmounter/mppod/watcher/watcher.go
@@ -57,7 +57,7 @@ func (w *Watcher) Wait(ctx context.Context, name string) (*corev1.Pod, error) {
 	var podFound atomic.Bool
 	podChan := make(chan *corev1.Pod, 1)
 	handle, err := w.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			pod := obj.(*corev1.Pod)
 			if pod.Name == name {
 				podFound.Store(true)
@@ -66,7 +66,7 @@ func (w *Watcher) Wait(ctx context.Context, name string) (*corev1.Pod, error) {
 				}
 			}
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new any) {
 			pod := new.(*corev1.Pod)
 			if pod.Name == name {
 				podFound.Store(true)

--- a/pkg/podmounter/mppod/watcher/watcher_test.go
+++ b/pkg/podmounter/mppod/watcher/watcher_test.go
@@ -90,7 +90,7 @@ func TestGettingPodsConcurrently(t *testing.T) {
 	mpPodWatcher := createAndStartWatcher(t, client)
 
 	foundPods := make(chan *corev1.Pod)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		go func() {
 			pod, err := mpPodWatcher.Wait(context.Background(), testMountpointPodName)
 			assert.NoError(t, err)
@@ -101,7 +101,7 @@ func TestGettingPodsConcurrently(t *testing.T) {
 	mpPod := createMountpointPod(t, client, testMountpointPodName)
 	mpPod.run()
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		foundPod := <-foundPods
 		assert.Equals(t, mpPod.pod, foundPod)
 	}

--- a/pkg/system/systemd.go
+++ b/pkg/system/systemd.go
@@ -30,13 +30,13 @@ type DbusConn interface {
 
 // DbusObject is a wrapper for dbus.BusObject external type
 type DbusObject interface {
-	Go(method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call
+	Go(method string, flags dbus.Flags, ch chan *dbus.Call, args ...any) *dbus.Call
 }
 
 // DbusProperty is used for dbus arguments that are arrays of key value pairs
 type DbusProperty struct {
 	Name  string
-	Value interface{}
+	Value any
 }
 
 type DbusPropertySet struct {
@@ -122,8 +122,8 @@ func (sc *SystemdOsConnection) StartTransientUnit(ctx context.Context, name stri
 	return job, err
 }
 
-func (sc *SystemdOsConnection) callDbus(ctx context.Context, method string, ret interface{},
-	args ...interface{}) error {
+func (sc *SystemdOsConnection) callDbus(ctx context.Context, method string, ret any,
+	args ...any) error {
 
 	ch := make(chan *dbus.Call, 1)
 	sc.Object.Go(method, 0, ch, args...)

--- a/pkg/system/systemd_test.go
+++ b/pkg/system/systemd_test.go
@@ -69,11 +69,11 @@ func TestSystemdConnection(t *testing.T) {
 				}
 				mockObject.EXPECT().Go(gomock.Eq("org.freedesktop.systemd1.Manager.ListUnits"),
 					gomock.Any(), gomock.Any()).Do(
-					func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) {
+					func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...any) {
 						go func() {
 							ch <- &dbus.Call{
 								Err:  nil,
-								Body: []interface{}{testUnits},
+								Body: []any{testUnits},
 							}
 						}()
 					})
@@ -95,11 +95,11 @@ func TestSystemdConnection(t *testing.T) {
 				unitName := "test-unit-1.service"
 				mockObject.EXPECT().Go(gomock.Eq("org.freedesktop.systemd1.Manager.StopUnit"),
 					gomock.Any(), gomock.Any(), gomock.Eq(unitName), gomock.Eq("fail")).Do(
-					func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) {
+					func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...any) {
 						go func() {
 							ch <- &dbus.Call{
 								Err:  nil,
-								Body: []interface{}{unitName},
+								Body: []any{unitName},
 							}
 						}()
 					})
@@ -114,7 +114,7 @@ func TestSystemdConnection(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				mockObject.EXPECT().Go(gomock.Eq("org.freedesktop.systemd1.Manager.ListUnits"),
 					gomock.Any(), gomock.Any()).Do(
-					func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) {
+					func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...any) {
 						go func() {
 							ch <- &dbus.Call{
 								Err: errors.New("ListUnits test error"),
@@ -133,10 +133,10 @@ func TestSystemdConnection(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				mockObject.EXPECT().Go(gomock.Eq("org.freedesktop.systemd1.Manager.ListUnits"),
 					gomock.Any(), gomock.Any()).Do(
-					func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) {
+					func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...any) {
 						go func() {
 							ch <- &dbus.Call{
-								Body: []interface{}{1, 2, 3},
+								Body: []any{1, 2, 3},
 							}
 						}()
 					})
@@ -158,10 +158,10 @@ func TestSystemdConnection(t *testing.T) {
 				}
 				mockObject.EXPECT().Go(gomock.Eq("org.freedesktop.systemd1.Manager.ListUnits"),
 					gomock.Any(), gomock.Any()).Do(
-					func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) {
+					func(method string, flags dbus.Flags, ch chan *dbus.Call, args ...any) {
 						go func() {
 							ch <- &dbus.Call{
-								Body: []interface{}{testUnits},
+								Body: []any{testUnits},
 							}
 						}()
 					})
@@ -240,38 +240,38 @@ func TestSystemdSupervisorWatchers(t *testing.T) {
 		go func() {
 			ch <- &dbus.Signal{
 				Name: system.UnitNewMethod,
-				Body: []interface{}{serviceName, dbus.ObjectPath(servicePath)},
+				Body: []any{serviceName, dbus.ObjectPath(servicePath)},
 			}
 			ch <- &dbus.Signal{
 				Name: system.UnitNewMethod,
-				Body: []interface{}{}, // Missing body
+				Body: []any{}, // Missing body
 			}
 			ch <- &dbus.Signal{
 				Name: system.UnitNewMethod,
-				Body: []interface{}{5, dbus.ObjectPath(servicePath)}, // Bad unit name type
+				Body: []any{5, dbus.ObjectPath(servicePath)}, // Bad unit name type
 			}
 			ch <- &dbus.Signal{
 				Name: system.UnitNewMethod,
-				Body: []interface{}{serviceName, 7}, // Bad path type
+				Body: []any{serviceName, 7}, // Bad path type
 			}
 			ch <- &dbus.Signal{
 				Name: system.PropertiesChangedMethod,
 				Path: dbus.ObjectPath("badpath"), // Bad path
-				Body: []interface{}{"", map[string]dbus.Variant{"ActiveState": dbus.MakeVariant("active")}},
+				Body: []any{"", map[string]dbus.Variant{"ActiveState": dbus.MakeVariant("active")}},
 			}
 			ch <- &dbus.Signal{
 				Name: system.PropertiesChangedMethod,
 				// Missing path
-				Body: []interface{}{"", map[string]dbus.Variant{"ActiveState": dbus.MakeVariant("active")}},
+				Body: []any{"", map[string]dbus.Variant{"ActiveState": dbus.MakeVariant("active")}},
 			}
 			ch <- &dbus.Signal{
 				Name: system.PropertiesChangedMethod,
-				Body: []interface{}{"", map[string]dbus.Variant{"ActiveState": dbus.MakeVariant("active")}},
+				Body: []any{"", map[string]dbus.Variant{"ActiveState": dbus.MakeVariant("active")}},
 			}
 			ch <- &dbus.Signal{
 				Name: system.PropertiesChangedMethod,
 				Path: dbus.ObjectPath(servicePath),
-				Body: []interface{}{"", map[string]dbus.Variant{
+				Body: []any{"", map[string]dbus.Variant{
 					"ActiveState":    dbus.MakeVariant("active"),
 					"ExecMainCode":   dbus.MakeVariant(int32(1)),
 					"ExecMainStatus": dbus.MakeVariant(int32(2)),
@@ -279,7 +279,7 @@ func TestSystemdSupervisorWatchers(t *testing.T) {
 			}
 			ch <- &dbus.Signal{
 				Name: system.UnitRemovedMethod,
-				Body: []interface{}{serviceName, dbus.ObjectPath(servicePath)},
+				Body: []any{serviceName, dbus.ObjectPath(servicePath)},
 			}
 		}()
 	})

--- a/pkg/util/testutil/assert/assert.go
+++ b/pkg/util/testutil/assert/assert.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Equals fails the test if `want` and `got` are not equal.
-func Equals(t *testing.T, want interface{}, got interface{}) {
+func Equals(t *testing.T, want any, got any) {
 	t.Helper()
 	if diff := cmp.Diff(want, got, cmpopts.EquateErrors()); diff != "" {
 		t.Errorf("Assertion failure (-want +got):\n%s", diff)


### PR DESCRIPTION
Run newly added `modernize` analyzer from `gopls` v0.18, namely, `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...`, to use modern Go features.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
