### PR TITLE
Allow access to AWS System Manager from CI nodes

### DIFF
--- a/tests/e2e-kubernetes/scripts/eksctl-patch.json
+++ b/tests/e2e-kubernetes/scripts/eksctl-patch.json
@@ -6,7 +6,8 @@
       "arn:aws:iam::aws:policy/AmazonS3FullAccess",
       "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
       "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
-      "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+      "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+      "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
     ]
   },
   {

--- a/tests/e2e-kubernetes/scripts/kops-patch.yaml
+++ b/tests/e2e-kubernetes/scripts/kops-patch.yaml
@@ -1,4 +1,9 @@
 spec:
+  externalPolicies:
+    node:
+    - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    master:
+    - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
   additionalPolicies:
     node: |
       [


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add a managed policy to enable AWS Systems Manager service core functionality: 
https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html

___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
