### PR TITLE
Allow overriding Mountpoint Pod's `serviceAccountName` at volume-level 

### DIFF
--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -234,7 +234,7 @@ func (r *Reconciler) spawnMountpointPod(
 
 	log.Info("Spawning Mountpoint Pod")
 
-	mpPod := r.mountpointPodCreator.Create(workloadPod, pvc)
+	mpPod := r.mountpointPodCreator.Create(workloadPod, pv)
 	if mpPod.Name != name {
 		err := fmt.Errorf("Mountpoint Pod name mismatch %s vs %s", mpPod.Name, name)
 		log.Error(err, "Name mismatch on Mountpoint Pod")

--- a/pkg/driver/node/volumecontext/volume_context.go
+++ b/pkg/driver/node/volumecontext/volume_context.go
@@ -6,6 +6,8 @@ const (
 	AuthenticationSource = "authenticationSource"
 	STSRegion            = "stsRegion"
 
+	MountpointPodServiceAccountName = "mountpointPodServiceAccountName"
+
 	CSIServiceAccountName   = "csi.storage.k8s.io/serviceAccount.name"
 	CSIServiceAccountTokens = "csi.storage.k8s.io/serviceAccount.tokens"
 	CSIPodNamespace         = "csi.storage.k8s.io/pod.namespace"

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -6,6 +6,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/volumecontext"
 )
 
 // Labels populated on spawned Mountpoint Pods.
@@ -50,7 +52,7 @@ func (c *Creator) Create(pod *corev1.Pod, pv *corev1.PersistentVolume) *corev1.P
 	node := pod.Spec.NodeName
 	name := MountpointPodNameFor(string(pod.UID), pv.Name)
 
-	return &corev1.Pod{
+	mpPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: c.config.Namespace,
@@ -123,4 +125,28 @@ func (c *Creator) Create(pod *corev1.Pod, pv *corev1.PersistentVolume) *corev1.P
 			},
 		},
 	}
+
+	volumeAttributes := extractVolumeAttributes(pv)
+
+	if saName := volumeAttributes[volumecontext.MountpointPodServiceAccountName]; saName != "" {
+		mpPod.Spec.ServiceAccountName = saName
+	}
+
+	return mpPod
+}
+
+// extractVolumeAttributes extracts volume attributes from given `pv`.
+// It always returns a non-nil map, and it's safe to use even though `pv` doesn't contain any volume attributes.
+func extractVolumeAttributes(pv *corev1.PersistentVolume) map[string]string {
+	csiSpec := pv.Spec.CSI
+	if csiSpec == nil {
+		return map[string]string{}
+	}
+
+	volumeAttributes := csiSpec.VolumeAttributes
+	if volumeAttributes == nil {
+		return map[string]string{}
+	}
+
+	return volumeAttributes
 }

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -42,13 +42,13 @@ func NewCreator(config Config) *Creator {
 	return &Creator{config: config}
 }
 
-// Create returns a new Mountpoint Pod spec to schedule for given `pod` and `pvc`.
+// Create returns a new Mountpoint Pod spec to schedule for given `pod` and `pv`.
 //
 // It automatically assigns Mountpoint Pod to `pod`'s node.
-// The name of the Mountpoint Pod is consistently generated from `pod` and `pvc` using `MountpointPodNameFor` function.
-func (c *Creator) Create(pod *corev1.Pod, pvc *corev1.PersistentVolumeClaim) *corev1.Pod {
+// The name of the Mountpoint Pod is consistently generated from `pod` and `pv` using `MountpointPodNameFor` function.
+func (c *Creator) Create(pod *corev1.Pod, pv *corev1.PersistentVolume) *corev1.Pod {
 	node := pod.Spec.NodeName
-	name := MountpointPodNameFor(string(pod.UID), pvc.Spec.VolumeName)
+	name := MountpointPodNameFor(string(pod.UID), pv.Name)
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -57,7 +57,7 @@ func (c *Creator) Create(pod *corev1.Pod, pvc *corev1.PersistentVolumeClaim) *co
 			Labels: map[string]string{
 				LabelMountpointVersion: c.config.MountpointVersion,
 				LabelPodUID:            string(pod.UID),
-				LabelVolumeName:        pvc.Spec.VolumeName,
+				LabelVolumeName:        pv.Name,
 				LabelCSIDriverVersion:  c.config.CSIDriverVersion,
 			},
 		},

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -39,65 +39,99 @@ func TestCreatingMountpointPods(t *testing.T) {
 		CSIDriverVersion: csiDriverVersion,
 	})
 
-	mpPod := creator.Create(&corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			UID: types.UID(testPodUID),
-		},
-		Spec: corev1.PodSpec{
-			NodeName: testNode,
-		},
-	}, &corev1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: testVolName,
-		},
-	})
+	verifyDefaultValues := func(mpPod *corev1.Pod) {
+		// This is a hash of `testPodUID` + `testVolName`
+		assert.Equals(t, "mp-8ef7856a0c7f1d5706bd6af93fdc4bc90b33cf2ceb6769b4afd62586", mpPod.Name)
+		assert.Equals(t, namespace, mpPod.Namespace)
+		assert.Equals(t, map[string]string{
+			mppod.LabelMountpointVersion: mountpointVersion,
+			mppod.LabelPodUID:            testPodUID,
+			mppod.LabelVolumeName:        testVolName,
+			mppod.LabelCSIDriverVersion:  csiDriverVersion,
+		}, mpPod.Labels)
 
-	// This is a hash of `testPodUID` + `testVolName`
-	assert.Equals(t, "mp-8ef7856a0c7f1d5706bd6af93fdc4bc90b33cf2ceb6769b4afd62586", mpPod.Name)
-	assert.Equals(t, namespace, mpPod.Namespace)
-	assert.Equals(t, map[string]string{
-		mppod.LabelMountpointVersion: mountpointVersion,
-		mppod.LabelPodUID:            testPodUID,
-		mppod.LabelVolumeName:        testVolName,
-		mppod.LabelCSIDriverVersion:  csiDriverVersion,
-	}, mpPod.Labels)
-
-	assert.Equals(t, priorityClassName, mpPod.Spec.PriorityClassName)
-	assert.Equals(t, corev1.RestartPolicyOnFailure, mpPod.Spec.RestartPolicy)
-	assert.Equals(t, []corev1.Volume{
-		{
-			Name: mppod.CommunicationDirName,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
+		assert.Equals(t, priorityClassName, mpPod.Spec.PriorityClassName)
+		assert.Equals(t, corev1.RestartPolicyOnFailure, mpPod.Spec.RestartPolicy)
+		assert.Equals(t, []corev1.Volume{
+			{
+				Name: mppod.CommunicationDirName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 			},
-		},
-	}, mpPod.Spec.Volumes)
-	assert.Equals(t, &corev1.Affinity{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					{
-						MatchFields: []corev1.NodeSelectorRequirement{{
-							Key:      metav1.ObjectNameField,
-							Operator: corev1.NodeSelectorOpIn,
-							Values:   []string{testNode},
-						}},
+		}, mpPod.Spec.Volumes)
+		assert.Equals(t, &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchFields: []corev1.NodeSelectorRequirement{{
+								Key:      metav1.ObjectNameField,
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{testNode},
+							}},
+						},
 					},
 				},
 			},
-		},
-	}, mpPod.Spec.Affinity)
-	assert.Equals(t, []corev1.Toleration{
-		{Operator: corev1.TolerationOpExists},
-	}, mpPod.Spec.Tolerations)
+		}, mpPod.Spec.Affinity)
+		assert.Equals(t, []corev1.Toleration{
+			{Operator: corev1.TolerationOpExists},
+		}, mpPod.Spec.Tolerations)
 
-	assert.Equals(t, image, mpPod.Spec.Containers[0].Image)
-	assert.Equals(t, imagePullPolicy, mpPod.Spec.Containers[0].ImagePullPolicy)
-	assert.Equals(t, []string{command}, mpPod.Spec.Containers[0].Command)
-	assert.Equals(t, []corev1.VolumeMount{
-		{
-			Name:      mppod.CommunicationDirName,
-			MountPath: "/" + mppod.CommunicationDirName,
-		},
-	}, mpPod.Spec.Containers[0].VolumeMounts)
+		assert.Equals(t, image, mpPod.Spec.Containers[0].Image)
+		assert.Equals(t, imagePullPolicy, mpPod.Spec.Containers[0].ImagePullPolicy)
+		assert.Equals(t, []string{command}, mpPod.Spec.Containers[0].Command)
+		assert.Equals(t, []corev1.VolumeMount{
+			{
+				Name:      mppod.CommunicationDirName,
+				MountPath: "/" + mppod.CommunicationDirName,
+			},
+		}, mpPod.Spec.Containers[0].VolumeMounts)
+
+	}
+
+	t.Run("Empty PV", func(t *testing.T) {
+		mpPod := creator.Create(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID(testPodUID),
+			},
+			Spec: corev1.PodSpec{
+				NodeName: testNode,
+			},
+		}, &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testVolName,
+			},
+		})
+
+		verifyDefaultValues(mpPod)
+	})
+
+	t.Run("With ServiceAccountName specified in PV", func(t *testing.T) {
+		mpPod := creator.Create(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID(testPodUID),
+			},
+			Spec: corev1.PodSpec{
+				NodeName: testNode,
+			},
+		}, &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testVolName,
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						VolumeAttributes: map[string]string{
+							"mountpointPodServiceAccountName": "mount-s3-sa",
+						},
+					},
+				},
+			},
+		})
+
+		verifyDefaultValues(mpPod)
+		assert.Equals(t, "mount-s3-sa", mpPod.Spec.ServiceAccountName)
+	})
 }

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -46,9 +46,9 @@ func TestCreatingMountpointPods(t *testing.T) {
 		Spec: corev1.PodSpec{
 			NodeName: testNode,
 		},
-	}, &corev1.PersistentVolumeClaim{
-		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: testVolName,
+	}, &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testVolName,
 		},
 	})
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
