### PR TITLE
node/mounter: add a more robust check for corrupted mounts

### DIFF
--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -319,7 +319,7 @@ func (pm *PodMounter) closeFUSEDevFD(fd int) {
 // If the target dir does not exists it tries to create it.
 // If the target dir is corrupted (decided with `mount.IsCorruptedMnt`) it tries to unmount it to have a clean mount.
 func (pm *PodMounter) verifyOrSetupMountTarget(target string) error {
-	_, err := os.Stat(target)
+	err := verifyMountPointStatx(target)
 	if err == nil {
 		return nil
 	}

--- a/pkg/driver/node/mounter/pod_mounter_darwin.go
+++ b/pkg/driver/node/mounter/pod_mounter_darwin.go
@@ -2,10 +2,17 @@ package mounter
 
 import (
 	"errors"
+	"os"
 
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
 )
 
 func (pm *PodMounter) mountSyscallDefault(_ string, _ mountpoint.Args) (int, error) {
 	return 0, errors.New("Only supported on Linux")
+}
+
+func verifyMountPointStatx(path string) error {
+	// statx is a Linux-specific syscall, let's simulate with os.Stat
+	_, err := os.Stat(path)
+	return err
 }


### PR DESCRIPTION
Checking for corrupted mounts with kubernetes/mount-utils package has an issue with networked filesystems, especially ones based on FUSE. Namely, a check based on os.Stat() often returns results cached by the OS kernel, and thus return a valid result even if the underlying filesystem is not responsive anymore, because its userspace part hang.

There are at least two approaches to fix it:
  1. Use a more powerful `statx` syscall on linux with a AT_STATX_FORCE_SYNC flag set. That explicitly asks for not getting results from cache and is more likely to detect a corrupted mount.
  2. Use ReadDir. That one I simply verified empirically to work better than os.Stat. It tends to not serve results from cache, and has an additional perk than it trips if the mount point is not a directory.

<strike>
This patch implements solution (2.). The 1st one is theoretically even more robust, but includes relying on an OS-specific syscall that is also not supported for all kernels as it's relatively new.

This check was proven to work in practice when s3 fuse mountpoint breaks and starts returning an ENOTCONN error!

P.S. kubernetes/mount-utils already relies on statx too, except it explicitly asks for cached results whenever possible... which is less likely to work for networked filesystems.
 ref: https://github.com/kubernetes/mount-utils/blob/fa592385ec1796a726846a2a26f61e3968b5a184/mount_linux.go#L432
</strike>

    edit: since ReadDir might bring undesired side effects of reading large
    directiories periodically, this PR now implements option (1.) -- statx.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
