### PR TITLE
Temporarily disable provenance on Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 		-t=$(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) \
 		--build-arg=GOPROXY=$(GOPROXY) \
 		--build-arg=VERSION=$(VERSION) \
-		--provenance=true \
+		--provenance=false \
 		.
 	touch $@
 


### PR DESCRIPTION
We enabled provenance on our Docker images recently via https://github.com/awslabs/mountpoint-s3-csi-driver/pull/398, but then we realized our current release procedure doesn't handle it properly. We're disabling it back until we update our release procedure to properly support it.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
