### PR TITLE
Ensure idempotence in post_test step of e2e-tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -238,5 +238,6 @@ jobs:
               --repository-name ${REPOSITORY_NAME} \
               --image-tag ${TAG_PASSED}-linux-${ARCH}-amazon \
               --image-manifest "$MANIFEST" \
-              --region ${AWS_REGION}
+              --region ${AWS_REGION} 2>&1 | grep -q "ImageAlreadyExistsException" || \
+              { err=$?; [ $err -eq 1 ] || exit $err; }
           done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The changes in the [previous PR](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/410) correctly tagged the architecture specific images but failed when being executed more than once. This change fixes this by suppressing `ImageAlreadyExistsException`.

Tested the E2E tests workflow in my fork.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
