### PR TITLE
Add EKS CW Observability addon to e2e clusters

### DIFF
--- a/tests/e2e-kubernetes/scripts/eksctl-patch.json
+++ b/tests/e2e-kubernetes/scripts/eksctl-patch.json
@@ -7,7 +7,8 @@
       "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
       "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
       "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
-      "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+      "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
     ]
   },
   {
@@ -24,6 +25,18 @@
           "Resource": "*"
         }
       ]
+    }
+  },
+  {
+    "op": "add",
+    "path": "/addons",
+    "value": []
+  },
+  {
+    "op": "add",
+    "path": "/addons/-",
+    "value": {
+      "name": "amazon-cloudwatch-observability"
     }
   }
 ]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add EKS CW Observability addon to e2e clusters in order for better troubleshooting E2E test failures

- Pre-create log groups with 30 day retention before cluster creation

*Manual Testing*: Manually verified that logs are now enabled and created with 30 day retention in personal clusters


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
