### PR TITLE
Replace centos with ubuntu in examples

### DIFF
--- a/examples/kubernetes/static_provisioning/aws_max_attempts.yaml
+++ b/examples/kubernetes/static_provisioning/aws_max_attempts.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/caching.yaml
+++ b/examples/kubernetes/static_provisioning/caching.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/kms_sse.yaml
+++ b/examples/kubernetes/static_provisioning/kms_sse.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/multiple_buckets_one_pod.yaml
+++ b/examples/kubernetes/static_provisioning/multiple_buckets_one_pod.yaml
@@ -75,7 +75,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; echo 'Hello from the container!' >> /data2/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/multiple_pods_one_pv.yaml
+++ b/examples/kubernetes/static_provisioning/multiple_pods_one_pv.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: s3-app
-        image: centos
+        image: ubuntu
         command: ["/bin/sh"]
         args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
         volumeMounts:

--- a/examples/kubernetes/static_provisioning/non_root.yaml
+++ b/examples/kubernetes/static_provisioning/non_root.yaml
@@ -44,7 +44,7 @@ spec:
     runAsGroup: 2000
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/s3_express_specify_az.yaml
+++ b/examples/kubernetes/static_provisioning/s3_express_specify_az.yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/static_provisioning.yaml
+++ b/examples/kubernetes/static_provisioning/static_provisioning.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
       volumeMounts:

--- a/examples/kubernetes/static_provisioning/static_provisioning_with_shared_cache.yaml
+++ b/examples/kubernetes/static_provisioning/static_provisioning_with_shared_cache.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: ubuntu
       command: ["/bin/sh"]
       args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; echo 'Shared cache test' >> /data/shared_cache_test.txt; cat /data/shared_cache_test.txt; tail -f /dev/null"]
       volumeMounts:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Current examples are failing to be deployed with error: `docker.io/library/centos:latest: not found`

[CentOS looks like to be deprecated](https://hub.docker.com/_/centos). Replace it with `ubuntu` image. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
