### PR TITLE
Feature/volume attributes level identity

### DIFF
--- a/pkg/driver/node/credentialprovider/provider.go
+++ b/pkg/driver/node/credentialprovider/provider.go
@@ -34,6 +34,7 @@ const (
 	AuthenticationSourceUnspecified AuthenticationSource = ""
 	AuthenticationSourceDriver      AuthenticationSource = "driver"
 	AuthenticationSourcePod         AuthenticationSource = "pod"
+	AuthenticationSourceAttr        AuthenticationSource = "attr"
 )
 
 // A Provider provides methods for accessing AWS credentials.
@@ -66,6 +67,10 @@ type ProvideContext struct {
 	PodNamespace         string
 	ServiceAccountTokens string
 	ServiceAccountName   string
+	// Authentication values in volume attributes
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
 	// StsRegion is the `stsRegion` parameter passed via volume attribute.
 	StsRegion string
 	// BucketRegion is the `--region` parameter passed via mount options.
@@ -99,6 +104,9 @@ func (c *Provider) Provide(ctx context.Context, provideCtx ProvideContext) (envp
 	case AuthenticationSourcePod:
 		env, err := c.provideFromPod(ctx, provideCtx)
 		return env, AuthenticationSourcePod, err
+	case AuthenticationSourceAttr:
+		env, err := c.provideFromAttr(provideCtx)
+		return env, AuthenticationSourceAttr, err
 	case AuthenticationSourceUnspecified, AuthenticationSourceDriver:
 		env, err := c.provideFromDriver(provideCtx)
 		return env, AuthenticationSourceDriver, err

--- a/pkg/driver/node/credentialprovider/provider_attr.go
+++ b/pkg/driver/node/credentialprovider/provider_attr.go
@@ -1,0 +1,22 @@
+package credentialprovider
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/envprovider"
+)
+
+// provideFromAttr provides driver-level AWS credentials.
+func (c *Provider) provideFromAttr(provideCtx ProvideContext) (envprovider.Environment, error) {
+	klog.V(4).Infof("credentialprovider: Using volume attributes identity, provide context: %+v", provideCtx)
+	if (provideCtx.AccessKeyID != "" && provideCtx.SecretAccessKey != "") || provideCtx.SessionToken != "" {
+		return envprovider.Environment{
+			envprovider.EnvAccessKeyID:     provideCtx.AccessKeyID,
+			envprovider.EnvSecretAccessKey: provideCtx.SecretAccessKey,
+			envprovider.EnvSessionToken:    provideCtx.SessionToken,
+		}, nil
+	}
+	return nil, status.Error(codes.InvalidArgument, "Missing credentials. Please make sure volume attributes identity")
+}

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -268,6 +268,9 @@ func credentialProvideContextFromPublishRequest(req *csi.NodePublishVolumeReques
 		ServiceAccountName:   volumeCtx[volumecontext.CSIServiceAccountName],
 		StsRegion:            volumeCtx[volumecontext.STSRegion],
 		BucketRegion:         bucketRegion,
+		AccessKeyID:          volumeCtx[volumecontext.AccessKeyID],
+		SecretAccessKey:      volumeCtx[volumecontext.SecretAccessKey],
+		SessionToken:         volumeCtx[volumecontext.SessionToken],
 	}
 }
 

--- a/pkg/driver/node/volumecontext/volume_context.go
+++ b/pkg/driver/node/volumecontext/volume_context.go
@@ -3,6 +3,9 @@ package volumecontext
 
 const (
 	BucketName           = "bucketName"
+	AccessKeyID          = "accessKeyId"
+	SecretAccessKey      = "secretAccessKey"
+	SessionToken         = "sessionToken"
 	AuthenticationSource = "authenticationSource"
 	STSRegion            = "stsRegion"
 


### PR DESCRIPTION
More granular setting of accessKeyId and secretAccessKey

```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: s3-pv
spec:
  capacity:
    storage: 1200Gi # ignored, required
  accessModes:
    - ReadWriteMany # supported options: ReadWriteMany / ReadOnlyMany
  storageClassName: "" # Required for static provisioning
  claimRef: # To ensure no other PVCs can claim this PV
    namespace: default # Namespace is required even though it's in "default" namespace.
    name: s3-pvc # Name of your PVC
  mountOptions:
    - allow-delete
    - force-path-style
    - region us-east-1
    - endpoint-url https://play.min.io
  csi:
    driver: s3.csi.aws.com # required
    volumeHandle: s3-csi-driver-volume # Must be unique
    volumeAttributes:
      bucketName: builds
      accessKeyId: Q3AM3UQ867SPQQA43P2F
      secretAccessKey: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
      authenticationSource: attr
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: s3-pvc
spec:
  accessModes:
    - ReadWriteMany # Supported options: ReadWriteMany / ReadOnlyMany
  storageClassName: "" # Required for static provisioning
  resources:
    requests:
      storage: 1200Gi # Ignored, required
  volumeName: s3-pv # Name of your PV
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: s3-app
  labels:
    app: s3-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: s3-app
  template:
    metadata:
      labels:
        app: s3-app
    spec:
      containers:
      - name: s3-app
        image: ubuntu
        command: ["/bin/sh"]
        args: ["-c", "echo 'Hello from the container!' >> /data/$(date -u).txt; tail -f /dev/null"]
        volumeMounts:
        - name: persistent-storage
          mountPath: /data
        ports:
        - containerPort: 80
      volumes:
      - name: persistent-storage
        persistentVolumeClaim:
          claimName: s3-pvc
```