### PR TITLE
Ensure `util.ReplaceFile` is safe to call concurrently

### DIFF
--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -5,12 +5,25 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 // ReplaceFile safely replaces a file with a new file by copying to a temporary location first
 // then renaming.
 func ReplaceFile(destPath string, sourcePath string, perm fs.FileMode) error {
-	tmpDest := destPath + ".tmp"
+	destDir, destBase := filepath.Dir(destPath), filepath.Base(destPath)
+
+	destFile, err := os.CreateTemp(destDir, destBase+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("replace-file: failed to create a temporary file at the destination directory %q: %w", destPath, err)
+	}
+	defer destFile.Close()
+
+	// `os.CreateTemp` always creates files with 0600 permission, we need to change it before we write to it.
+	err = destFile.Chmod(perm)
+	if err != nil {
+		return fmt.Errorf("replace-file: failed to change temporary file %q's permissions: %w", destFile.Name(), err)
+	}
 
 	sourceFile, err := os.Open(sourcePath)
 	if err != nil {
@@ -18,21 +31,15 @@ func ReplaceFile(destPath string, sourcePath string, perm fs.FileMode) error {
 	}
 	defer sourceFile.Close()
 
-	destFile, err := os.OpenFile(tmpDest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
-	if err != nil {
-		return err
-	}
-	defer destFile.Close()
-
 	buf := make([]byte, 64*1024)
 	_, err = io.CopyBuffer(destFile, sourceFile, buf)
 	if err != nil {
 		return err
 	}
 
-	err = os.Rename(tmpDest, destPath)
+	err = os.Rename(destFile.Name(), destPath)
 	if err != nil {
-		return fmt.Errorf("Failed to rename file %s: %w", destPath, err)
+		return fmt.Errorf("replace-file: failed to rename file %s: %w", destPath, err)
 	}
 
 	return nil

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -1,0 +1,106 @@
+package util_test
+
+import (
+	"crypto/rand"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestReplaceFile(t *testing.T) {
+	expectContentAndPerm := func(t *testing.T, path string, contentWant []byte, permWant fs.FileMode) {
+		gotStat, err := os.Stat(path)
+		assert.NoError(t, err)
+
+		assert.Equals(t, permWant, gotStat.Mode().Perm())
+
+		contentGot, err := os.ReadFile(path)
+		assert.NoError(t, err)
+
+		assert.Equals(t, contentWant, contentGot)
+	}
+
+	createFileWithRandomBytes := func(t *testing.T, path string, perm fs.FileMode, size int) []byte {
+		content := make([]byte, size)
+		_, err := rand.Read(content)
+		assert.NoError(t, err)
+
+		source := filepath.Join(path)
+		err = os.WriteFile(source, content, perm)
+		assert.NoError(t, err)
+
+		return content
+	}
+
+	t.Run("Non-existent dest", func(t *testing.T) {
+		basedir := t.TempDir()
+
+		source := filepath.Join(basedir, "source")
+		content := createFileWithRandomBytes(t, source, 0600, 2*64*1024)
+
+		dest := filepath.Join(basedir, "dest")
+
+		err := util.ReplaceFile(dest, source, 0644)
+		assert.NoError(t, err)
+
+		expectContentAndPerm(t, dest, content, 0644)
+	})
+
+	t.Run("Existing dest", func(t *testing.T) {
+		basedir := t.TempDir()
+
+		source := filepath.Join(basedir, "source")
+		content := createFileWithRandomBytes(t, source, 0600, 2*64*1024)
+
+		dest := filepath.Join(basedir, "dest")
+		createFileWithRandomBytes(t, dest, 0644, 1024)
+
+		err := util.ReplaceFile(dest, source, 0644)
+		assert.NoError(t, err)
+
+		expectContentAndPerm(t, dest, content, 0644)
+	})
+
+	t.Run("Existing dest with different permissions", func(t *testing.T) {
+		basedir := t.TempDir()
+
+		source := filepath.Join(basedir, "source")
+		content := createFileWithRandomBytes(t, source, 0600, 2*64*1024)
+
+		dest := filepath.Join(basedir, "dest")
+		createFileWithRandomBytes(t, dest, 0777, 1024)
+
+		err := util.ReplaceFile(dest, source, 0644)
+		assert.NoError(t, err)
+
+		expectContentAndPerm(t, dest, content, 0644)
+	})
+
+	t.Run("Concurrently", func(t *testing.T) {
+		basedir := t.TempDir()
+
+		source := filepath.Join(basedir, "source")
+		content := createFileWithRandomBytes(t, source, 0600, 2*64*1024)
+
+		dest := filepath.Join(basedir, "dest")
+
+		var wg sync.WaitGroup
+		for range 32 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				err := util.ReplaceFile(dest, source, 0644)
+				assert.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+
+		expectContentAndPerm(t, dest, content, 0644)
+	})
+}


### PR DESCRIPTION
Previously, `util.ReplaceFile` was using the same staging path (`dest + ".tmp"`) while performing the copy, but this can cause problems if its called concurrently with the same destination path as can be seen in https://github.com/awslabs/mountpoint-s3-csi-driver/issues/418. This PR uses [`os.CreateTemp`](https://pkg.go.dev/os#CreateTemp) to create temporary files at the target directory which ensures the filename to be unique. Therefore, concurrent operations to the same file will succeed – though the last writer would win (i.e., overrides others changes) – where previously getting `no such file or directory` errors.

Ideally, calls to `Node{Unpublish, Publish}Volume` needs to be syntonized as well, but until that's implemented this should address the issues with copying driver-level service account tokens concurrently. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
