### PR TITLE
Ensure CloudFormation stacks are deleted in cluster clean up

### DIFF
--- a/tests/e2e-kubernetes/scripts/eksctl.sh
+++ b/tests/e2e-kubernetes/scripts/eksctl.sh
@@ -115,6 +115,9 @@ function eksctl_delete_cluster() {
   FORCE=${4:-false}
 
   if ! eksctl_cluster_exists "${BIN}" "${CLUSTER_NAME}"; then
+    # Try to delete CloudFormation stack even if the cluster does not exists just in case
+    # if the stack is stuck in `ROLLBACK_COMPLETE` status.
+    eksctl_delete_cluster_cf_stack "${CLUSTER_NAME}" "${REGION}"
     return 0
   fi
 
@@ -125,35 +128,7 @@ function eksctl_delete_cluster() {
   fi
 
   ${BIN} delete cluster "${CLUSTER_NAME}"
-  STACK_NAME="eksctl-${CLUSTER_NAME}-cluster"
-  aws cloudformation delete-stack --region ${REGION} --stack-name ${STACK_NAME}
-
-  # GuardDury creates resources (namely an endpoint and a security group), which are not handled by eks cfn stack and prevents it from being deleted
-  # https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring-agent-resource-clean-up.html#clean-up-guardduty-agent-resources-process
-  VPC_ID=$(aws cloudformation describe-stacks --region ${REGION} --stack-name ${STACK_NAME} | jq -r '.["Stacks"][0]["Outputs"][] | select(.["OutputKey"]=="VPC") | .["OutputValue"]' || true)
-  if [ -n "$VPC_ID" ]; then
-    ENDPOINT=$(aws ec2 describe-vpc-endpoints --region ${REGION} | jq -r --arg VPC_ID "$VPC_ID" '.["VpcEndpoints"][] | select(.["VpcId"]==$VPC_ID and .["Tags"][0]["Key"]=="GuardDutyManaged" and .["Tags"][0]["Value"]=="true") | .["VpcEndpointId"]')
-    if [ -n "$ENDPOINT" ]; then
-      aws ec2 delete-vpc-endpoints --region ${REGION} --vpc-endpoint-ids ${ENDPOINT}
-    fi
-
-    # https://github.com/eksctl-io/eksctl/issues/7589
-    ENIS=$(aws ec2 describe-network-interfaces --region ${REGION} | jq -r --arg VPC_ID "$VPC_ID" '.["NetworkInterfaces"][] | select(.["VpcId"]==$VPC_ID) | .NetworkInterfaceId')
-    if [ -n "$ENIS" ]; then
-      echo "${ENIS}" | while IFS= read -r ENI_ID ; do
-        delete_eni ${REGION} ${ENI_ID}
-      done
-    fi
-
-    SECURITY_GROUP=$(aws ec2 describe-security-groups --region ${REGION} | jq -r --arg VPC_ID "$VPC_ID" '.["SecurityGroups"][] | select(.["VpcId"]==$VPC_ID and .["GroupName"]!="default") | .["GroupId"]')
-    if [ -n "$SECURITY_GROUP" ]; then
-      # security group deletion only succeeds after a certain step of stack deletion was passed (namely subnets deletion),
-      # after which stack deletion is blocked because of the security group, so we retry here until this step is completed
-      delete_security_group ${REGION} ${SECURITY_GROUP}
-    fi
-  fi
-
-  aws cloudformation wait stack-delete-complete --region ${REGION} --stack-name ${STACK_NAME}
+  eksctl_delete_cluster_cf_stack "${CLUSTER_NAME}" "${REGION}"
 }
 
 function eksctl_cluster_exists() {
@@ -193,6 +168,61 @@ function create_log_group_if_absent() {
       aws logs put-retention-policy --region ${REGION} --log-group-name "$log_group" --retention-in-days "$RETENTION_DAYS"
     fi
   done
+}
+
+function eksctl_is_cluster_cf_stack_exists() {
+    STACK_NAME=${1}
+    REGION=${2}
+
+    if aws cloudformation describe-stacks --region ${REGION} --stack-name ${STACK_NAME} &>/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function eksctl_delete_cluster_cf_stack() {
+    CLUSTER_NAME=${1}
+    REGION=${2}
+
+    STACK_NAME="eksctl-${CLUSTER_NAME}-cluster"
+
+    # Check if stack exists before attempting to delete
+    if ! eksctl_is_cluster_cf_stack_exists "${STACK_NAME}" "${REGION}"; then
+        echo "CloudFormation stack ${STACK_NAME} does not exist, skipping cleanup"
+        return 0
+    fi
+
+    aws cloudformation delete-stack --region ${REGION} --stack-name ${STACK_NAME}
+
+    # GuardDury creates resources (namely an endpoint and a security group), which are not handled by eks cfn stack and prevents it from being deleted
+    # https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring-agent-resource-clean-up.html#clean-up-guardduty-agent-resources-process
+    VPC_ID=$(aws cloudformation describe-stacks --region ${REGION} --stack-name ${STACK_NAME} | jq -r '.["Stacks"][0]["Outputs"][] | select(.["OutputKey"]=="VPC") | .["OutputValue"]' || true)
+    if [ -n "$VPC_ID" ]; then
+      ENDPOINT=$(aws ec2 describe-vpc-endpoints --region ${REGION} | jq -r --arg VPC_ID "$VPC_ID" '.["VpcEndpoints"][] | select(.["VpcId"]==$VPC_ID and .["Tags"][0]["Key"]=="GuardDutyManaged" and .["Tags"][0]["Value"]=="true") | .["VpcEndpointId"]')
+      if [ -n "$ENDPOINT" ]; then
+        aws ec2 delete-vpc-endpoints --region ${REGION} --vpc-endpoint-ids ${ENDPOINT}
+      fi
+
+      if [ -n "$VPC_ID" ]; then
+        # https://github.com/eksctl-io/eksctl/issues/7589
+        ENIS=$(aws ec2 describe-network-interfaces --region ${REGION} | jq -r --arg VPC_ID "$VPC_ID" '.["NetworkInterfaces"][] | select(.["VpcId"]==$VPC_ID) | .NetworkInterfaceId')
+        if [ -n "$ENIS" ]; then
+          echo "${ENIS}" | while IFS= read -r ENI_ID ; do
+            delete_eni ${REGION} ${ENI_ID}
+          done
+        fi
+
+        SECURITY_GROUP=$(aws ec2 describe-security-groups --region ${REGION} | jq -r --arg VPC_ID "$VPC_ID" '.["SecurityGroups"][] | select(.["VpcId"]==$VPC_ID and .["GroupName"]!="default") | .["GroupId"]')
+        if [ -n "$SECURITY_GROUP" ]; then
+            # security group deletion only succeeds after a certain step of stack deletion was passed (namely subnets deletion),
+            # after which stack deletion is blocked because of the security group, so we retry here until this step is completed
+            delete_security_group ${REGION} ${SECURITY_GROUP}
+        fi
+      fi
+    fi
+
+    aws cloudformation wait stack-delete-complete --region ${REGION} --stack-name ${STACK_NAME}
 }
 
 function delete_security_group() {


### PR DESCRIPTION
The CI [seems to be broken](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/14110780306/job/39538720856?pr=421) because for `s3-csi-cluster-eksctl-amazonlinux2-x86` cluster, the EKS cluster does not exist but the CloudFormation stack exists and stuck in `ROLLBACK_COMPLETE` status. Current CI script doesn't try to remove the CF stack if the cluster does not exist, this PR updates `eksctl_delete_cluster` to try to delete the CF stack even if the cluster does not exist.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
