### PR TITLE
PodMounter: Fix ReadOnlyMany access mode

### DIFF
--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -137,6 +137,12 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 		return fmt.Errorf("Failed to mount %s: %w", target, err)
 	}
 
+	// Remove the read-only argument from the list as mount-s3 does not support it when using FUSE
+	// file descriptor (we already pass MS_RDONLY flag during mount syscall in `pod_mounter_linux.go`)
+	if args.Has(mountpoint.ArgReadOnly) {
+		args.Remove(mountpoint.ArgReadOnly)
+	}
+
 	// This will set to false in the success condition. This is set to `true` by default to
 	// ensure we don't leave `target` mounted if Mountpoint is not started to serve requests for it.
 	unmount := true

--- a/pkg/driver/node/mounter/pod_mounter_linux.go
+++ b/pkg/driver/node/mounter/pod_mounter_linux.go
@@ -47,8 +47,6 @@ func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (
 
 	if args.Has(mountpoint.ArgReadOnly) {
 		flags |= syscall.MS_RDONLY
-		// Remove the read-only argument from the list as mount-s3 does not support it when using FUSE file descriptor
-		args.Remove(mountpoint.ArgReadOnly)
 	}
 
 	if args.Has(mountpoint.ArgAllowOther) || args.Has(mountpoint.ArgAllowRoot) {

--- a/pkg/driver/node/mounter/pod_mounter_linux.go
+++ b/pkg/driver/node/mounter/pod_mounter_linux.go
@@ -47,6 +47,8 @@ func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (
 
 	if args.Has(mountpoint.ArgReadOnly) {
 		flags |= syscall.MS_RDONLY
+		// Remove the read-only argument from the list as mount-s3 does not support it when using FUSE file descriptor
+		args.Remove(mountpoint.ArgReadOnly)
 	}
 
 	if args.Has(mountpoint.ArgAllowOther) || args.Has(mountpoint.ArgAllowRoot) {

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -178,7 +178,6 @@ func TestPodMounter(t *testing.T) {
 			assert.Equals(t, mountoptions.Options{
 				BucketName: testCtx.bucketName,
 				Args: []string{
-					"--read-only",
 					"--user-agent-prefix=" + mounter.UserAgent(credentialprovider.AuthenticationSourceDriver, testK8sVersion),
 				},
 				Env: envprovider.Default().List(),

--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -56,6 +56,7 @@ var CSITestSuites = []func() framework.TestSuite{
 	// testsuites.InitSnapshottableStressTestSuite,
 	// testsuites.InitVolumePerformanceTestSuite,
 	// testsuites.InitReadWriteOncePodTestSuite,
+	custom_testsuites.InitS3AccessModeTestSuite,
 	custom_testsuites.InitS3CSIMultiVolumeTestSuite,
 	custom_testsuites.InitS3MountOptionsTestSuite,
 	custom_testsuites.InitS3CSICredentialsTestSuite,

--- a/tests/e2e-kubernetes/testsuites/accessmode.go
+++ b/tests/e2e-kubernetes/testsuites/accessmode.go
@@ -1,0 +1,89 @@
+package custom_testsuites
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+type s3CSIAccessModeTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+func InitS3AccessModeTestSuite() storageframework.TestSuite {
+	return &s3CSIAccessModeTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "accessmode",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+func (t *s3CSIAccessModeTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *s3CSIAccessModeTestSuite) SkipUnsupportedTests(_ storageframework.TestDriver, _ storageframework.TestPattern) {
+}
+
+func (t *s3CSIAccessModeTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	type local struct {
+		resources []*storageframework.VolumeResource
+		config    *storageframework.PerTestConfig
+	}
+	var (
+		l local
+	)
+
+	f := framework.NewFrameworkWithCustomTimeouts("accessmode", storageframework.GetDriverTimeouts(driver))
+	f.NamespacePodSecurityLevel = admissionapi.LevelRestricted
+
+	cleanup := func(ctx context.Context) {
+		var errs []error
+		for _, resource := range l.resources {
+			errs = append(errs, resource.CleanupResource(ctx))
+		}
+		framework.ExpectNoError(errors.NewAggregate(errs), "while cleanup resource")
+	}
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		ginkgo.DeferCleanup(cleanup)
+	})
+
+	validateWriteToVolumeFails := func(ctx context.Context) {
+		resource := createVolumeResourceWithAccessMode(ctx, l.config, pattern, v1.ReadOnlyMany)
+		l.resources = append(l.resources, resource)
+		ginkgo.By("Creating pod with a volume")
+		pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelRestricted, "")
+		var err error
+		pod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+		framework.ExpectNoError(err)
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+		}()
+		volPath := "/mnt/volume1"
+		fileInVol := fmt.Sprintf("%s/file.txt", volPath)
+		seed := time.Now().UTC().UnixNano()
+		toWrite := 1024 // 1KB
+		ginkgo.By("Checking that write to a volume fails")
+		checkWriteToPathFails(f, pod, fileInVol, toWrite, seed)
+	}
+	ginkgo.It("should fail to write to ReadOnlyMany volume", func(ctx context.Context) {
+		validateWriteToVolumeFails(ctx)
+	})
+	ginkgo.It("S3 express -- should fail to write to ReadOnlyMany volume", func(ctx context.Context) {
+		l.config.Prefix = S3ExpressTestIdentifier
+		validateWriteToVolumeFails(ctx)
+	})
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Currently, PodMounter fails to work with `ReadOnlyMany` access mode with error:

```
Error: Mount options: --read-only are ignored with FUSE fd mount point.Mount options should be passed while performing `mount` syscall in the caller process.
```

Fix: Remove `--read-only` flag when it is set

Also, added e2e tests for ReadOnlyMany case to validate that the fix worked.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
