### PR TITLE
Enable control plane CloudWatch logging for testing EKS clusters

### DIFF
--- a/tests/e2e-kubernetes/scripts/eksctl-patch.json
+++ b/tests/e2e-kubernetes/scripts/eksctl-patch.json
@@ -19,9 +19,7 @@
       "Statement": [
         {
           "Effect": "Allow",
-          "Action": [
-            "s3express:*"
-          ],
+          "Action": ["s3express:*"],
           "Resource": "*"
         }
       ]
@@ -37,6 +35,14 @@
     "path": "/addons/-",
     "value": {
       "name": "amazon-cloudwatch-observability"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/cloudWatch/clusterLogging",
+    "value": {
+      "enableTypes": ["api", "audit", "authenticator"],
+      "logRetentionInDays": 30
     }
   }
 ]


### PR DESCRIPTION
This is to debug some transient errors such as https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/14379730344/job/40320438436#step:11:4427.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
