### PR TITLE
Store licenses of Go dependencies in the container image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/credentials
 bin/
 tests/bin
+LICENSES/
 go.work
 go.work.sum
 .github/artifacts/benchmark-data.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ARG TARGETARCH
 WORKDIR /go/src/github.com/awslabs/mountpoint-s3-csi-driver
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
-    TARGETARCH=${TARGETARCH} make bin
+    TARGETARCH=${TARGETARCH} make generate_licenses bin
 
 # `eks-distro-minimal-base-csi` includes `libfuse` and mount utils such as `umount`.
 # We need to make sure to use same Amazon Linux version here and while producing Mountpoint to not have glibc compatibility issues.
@@ -63,6 +63,9 @@ COPY --from=mp_builder /mountpoint-s3 /mountpoint-s3
 # TODO: These won't be necessary with containerization.
 COPY --from=mp_builder /lib64/libfuse.so.2 /mountpoint-s3/bin/
 COPY --from=mp_builder /lib64/libgcc_s.so.1 /mountpoint-s3/bin/
+
+# Copy licenses of CSI Driver's dependencies
+COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/LICENSES /LICENSES
 
 # Copy CSI Driver binaries
 COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/aws-s3-csi-driver /bin/aws-s3-csi-driver

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -52,7 +52,7 @@ ARG TARGETARCH
 WORKDIR /go/src/github.com/awslabs/mountpoint-s3-csi-driver
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
-    TARGETARCH=${TARGETARCH} make bin
+    TARGETARCH=${TARGETARCH} make generate_licenses bin
 
 #
 # Build the final image
@@ -70,6 +70,9 @@ COPY --from=mp_builder /mountpoint-s3/target/release/mount-s3 /mountpoint-s3/bin
 # TODO: These won't be necessary with containerization.
 COPY --from=mp_builder /lib64/libfuse.so.2 /mountpoint-s3/bin/
 COPY --from=mp_builder /lib64/libgcc_s.so.1 /mountpoint-s3/bin/
+
+# Copy licenses of CSI Driver's dependencies
+COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/LICENSES /LICENSES
 
 # Copy CSI Driver binaries
 COPY --from=builder /go/src/github.com/awslabs/mountpoint-s3-csi-driver/bin/aws-s3-csi-driver /bin/aws-s3-csi-driver

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,10 @@ push_image:
 login_registry:
 	aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin ${REGISTRY}
 
+.PHONY: download_go_deps
+download_go_deps:
+	go mod download
+
 .PHONY: bin
 bin:
 	mkdir -p bin
@@ -175,8 +179,12 @@ check_style:
 	test -z "$$(gofmt -d . | tee /dev/stderr)"
 
 .PHONY: check_licenses
-check_licenses:
-	go mod download && go tool github.com/google/go-licenses check --allowed_licenses ${ALLOWED_LICENSES} ./...
+check_licenses: download_go_deps
+	go tool github.com/google/go-licenses check --allowed_licenses ${ALLOWED_LICENSES} ./...
+
+.PHONY: generate_licenses
+generate_licenses: download_go_deps
+	go tool github.com/google/go-licenses save --save_path="./LICENSES" --force ./...
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This PR uses `go-licenses save` to generate licenses, copyright notices and source codes (depending on the license type) and stores them in the container image.

<details>
<summary>`docker export .. | tar t | rg -i LICENSE`</summary>

```
LICENSES/
LICENSES/github.com/
LICENSES/github.com/aws/
LICENSES/github.com/aws/aws-sdk-go-v2/
LICENSES/github.com/aws/aws-sdk-go-v2/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/NOTICE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/config/
LICENSES/github.com/aws/aws-sdk-go-v2/config/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/credentials/
LICENSES/github.com/aws/aws-sdk-go-v2/credentials/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/feature/
LICENSES/github.com/aws/aws-sdk-go-v2/feature/ec2/
LICENSES/github.com/aws/aws-sdk-go-v2/feature/ec2/imds/
LICENSES/github.com/aws/aws-sdk-go-v2/feature/ec2/imds/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/internal/
LICENSES/github.com/aws/aws-sdk-go-v2/internal/configsources/
LICENSES/github.com/aws/aws-sdk-go-v2/internal/configsources/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/internal/endpoints/
LICENSES/github.com/aws/aws-sdk-go-v2/internal/endpoints/v2/
LICENSES/github.com/aws/aws-sdk-go-v2/internal/endpoints/v2/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/internal/ini/
LICENSES/github.com/aws/aws-sdk-go-v2/internal/ini/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/internal/sync/
LICENSES/github.com/aws/aws-sdk-go-v2/internal/sync/singleflight/
LICENSES/github.com/aws/aws-sdk-go-v2/internal/sync/singleflight/LICENSE
LICENSES/github.com/aws/aws-sdk-go-v2/service/
LICENSES/github.com/aws/aws-sdk-go-v2/service/internal/
LICENSES/github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding/
LICENSES/github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/service/internal/presigned-url/
LICENSES/github.com/aws/aws-sdk-go-v2/service/internal/presigned-url/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/service/sso/
LICENSES/github.com/aws/aws-sdk-go-v2/service/sso/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/service/ssooidc/
LICENSES/github.com/aws/aws-sdk-go-v2/service/ssooidc/LICENSE.txt
LICENSES/github.com/aws/aws-sdk-go-v2/service/sts/
LICENSES/github.com/aws/aws-sdk-go-v2/service/sts/LICENSE.txt
LICENSES/github.com/aws/smithy-go/
LICENSES/github.com/aws/smithy-go/LICENSE
LICENSES/github.com/aws/smithy-go/NOTICE
LICENSES/github.com/aws/smithy-go/internal/
LICENSES/github.com/aws/smithy-go/internal/sync/
LICENSES/github.com/aws/smithy-go/internal/sync/singleflight/
LICENSES/github.com/aws/smithy-go/internal/sync/singleflight/LICENSE
LICENSES/github.com/awslabs/
LICENSES/github.com/awslabs/aws-s3-csi-driver/
LICENSES/github.com/awslabs/aws-s3-csi-driver/LICENSE
LICENSES/github.com/awslabs/aws-s3-csi-driver/NOTICE
LICENSES/github.com/beorn7/
LICENSES/github.com/beorn7/perks/
LICENSES/github.com/beorn7/perks/quantile/
LICENSES/github.com/beorn7/perks/quantile/LICENSE
LICENSES/github.com/cespare/
LICENSES/github.com/cespare/xxhash/
LICENSES/github.com/cespare/xxhash/v2/
LICENSES/github.com/cespare/xxhash/v2/LICENSE.txt
LICENSES/github.com/container-storage-interface/
LICENSES/github.com/container-storage-interface/spec/
LICENSES/github.com/container-storage-interface/spec/lib/
LICENSES/github.com/container-storage-interface/spec/lib/go/
LICENSES/github.com/container-storage-interface/spec/lib/go/csi/
LICENSES/github.com/container-storage-interface/spec/lib/go/csi/LICENSE
LICENSES/github.com/davecgh/
LICENSES/github.com/davecgh/go-spew/
LICENSES/github.com/davecgh/go-spew/spew/
LICENSES/github.com/davecgh/go-spew/spew/LICENSE
LICENSES/github.com/emicklei/
LICENSES/github.com/emicklei/go-restful/
LICENSES/github.com/emicklei/go-restful/v3/
LICENSES/github.com/emicklei/go-restful/v3/LICENSE
LICENSES/github.com/evanphx/
LICENSES/github.com/evanphx/json-patch/
LICENSES/github.com/evanphx/json-patch/v5/
LICENSES/github.com/evanphx/json-patch/v5/LICENSE
LICENSES/github.com/fsnotify/
LICENSES/github.com/fsnotify/fsnotify/
LICENSES/github.com/fsnotify/fsnotify/LICENSE
LICENSES/github.com/fxamacker/
LICENSES/github.com/fxamacker/cbor/
LICENSES/github.com/fxamacker/cbor/v2/
LICENSES/github.com/fxamacker/cbor/v2/LICENSE
LICENSES/github.com/go-logr/
LICENSES/github.com/go-logr/logr/
LICENSES/github.com/go-logr/logr/LICENSE
LICENSES/github.com/go-logr/zapr/
LICENSES/github.com/go-logr/zapr/LICENSE
LICENSES/github.com/go-openapi/
LICENSES/github.com/go-openapi/jsonpointer/
LICENSES/github.com/go-openapi/jsonpointer/LICENSE
LICENSES/github.com/go-openapi/jsonreference/
LICENSES/github.com/go-openapi/jsonreference/LICENSE
LICENSES/github.com/go-openapi/swag/
LICENSES/github.com/go-openapi/swag/LICENSE
LICENSES/github.com/godbus/
LICENSES/github.com/godbus/dbus/
LICENSES/github.com/godbus/dbus/v5/
LICENSES/github.com/godbus/dbus/v5/LICENSE
LICENSES/github.com/gogo/
LICENSES/github.com/gogo/protobuf/
LICENSES/github.com/gogo/protobuf/LICENSE
LICENSES/github.com/golang/
LICENSES/github.com/golang/groupcache/
LICENSES/github.com/golang/groupcache/lru/
LICENSES/github.com/golang/groupcache/lru/LICENSE
LICENSES/github.com/golang/mock/
LICENSES/github.com/golang/mock/gomock/
LICENSES/github.com/golang/mock/gomock/LICENSE
LICENSES/github.com/golang/protobuf/
LICENSES/github.com/golang/protobuf/LICENSE
LICENSES/github.com/google/
LICENSES/github.com/google/gnostic-models/
LICENSES/github.com/google/gnostic-models/LICENSE
LICENSES/github.com/google/go-cmp/
LICENSES/github.com/google/go-cmp/cmp/
LICENSES/github.com/google/go-cmp/cmp/LICENSE
LICENSES/github.com/google/gofuzz/
LICENSES/github.com/google/gofuzz/LICENSE
LICENSES/github.com/google/renameio/
LICENSES/github.com/google/renameio/LICENSE
LICENSES/github.com/google/uuid/
LICENSES/github.com/google/uuid/LICENSE
LICENSES/github.com/imdario/
LICENSES/github.com/imdario/mergo/
LICENSES/github.com/imdario/mergo/LICENSE
LICENSES/github.com/josharian/
LICENSES/github.com/josharian/intern/
LICENSES/github.com/josharian/intern/license.md
LICENSES/github.com/json-iterator/
LICENSES/github.com/json-iterator/go/
LICENSES/github.com/json-iterator/go/LICENSE
LICENSES/github.com/mailru/
LICENSES/github.com/mailru/easyjson/
LICENSES/github.com/mailru/easyjson/LICENSE
LICENSES/github.com/moby/
LICENSES/github.com/moby/sys/
LICENSES/github.com/moby/sys/mountinfo/
LICENSES/github.com/moby/sys/mountinfo/LICENSE
LICENSES/github.com/modern-go/
LICENSES/github.com/modern-go/concurrent/
LICENSES/github.com/modern-go/concurrent/LICENSE
LICENSES/github.com/modern-go/reflect2/
LICENSES/github.com/modern-go/reflect2/LICENSE
LICENSES/github.com/munnerz/
LICENSES/github.com/munnerz/goautoneg/
LICENSES/github.com/munnerz/goautoneg/LICENSE
LICENSES/github.com/pkg/
LICENSES/github.com/pkg/errors/
LICENSES/github.com/pkg/errors/LICENSE
LICENSES/github.com/prometheus/
LICENSES/github.com/prometheus/client_golang/
LICENSES/github.com/prometheus/client_golang/prometheus/
LICENSES/github.com/prometheus/client_golang/prometheus/LICENSE
LICENSES/github.com/prometheus/client_golang/prometheus/NOTICE
LICENSES/github.com/prometheus/client_model/
LICENSES/github.com/prometheus/client_model/go/
LICENSES/github.com/prometheus/client_model/go/LICENSE
LICENSES/github.com/prometheus/client_model/go/NOTICE
LICENSES/github.com/prometheus/common/
LICENSES/github.com/prometheus/common/LICENSE
LICENSES/github.com/prometheus/common/NOTICE
LICENSES/github.com/prometheus/procfs/
LICENSES/github.com/prometheus/procfs/LICENSE
LICENSES/github.com/prometheus/procfs/NOTICE
LICENSES/github.com/spf13/
LICENSES/github.com/spf13/pflag/
LICENSES/github.com/spf13/pflag/LICENSE
LICENSES/github.com/x448/
LICENSES/github.com/x448/float16/
LICENSES/github.com/x448/float16/LICENSE
LICENSES/go.uber.org/
LICENSES/go.uber.org/multierr/
LICENSES/go.uber.org/multierr/LICENSE.txt
LICENSES/go.uber.org/zap/
LICENSES/go.uber.org/zap/LICENSE
LICENSES/golang.org/
LICENSES/golang.org/x/
LICENSES/golang.org/x/exp/
LICENSES/golang.org/x/exp/maps/
LICENSES/golang.org/x/exp/maps/LICENSE
LICENSES/golang.org/x/net/
LICENSES/golang.org/x/net/LICENSE
LICENSES/golang.org/x/oauth2/
LICENSES/golang.org/x/oauth2/LICENSE
LICENSES/golang.org/x/sys/
LICENSES/golang.org/x/sys/unix/
LICENSES/golang.org/x/sys/unix/LICENSE
LICENSES/golang.org/x/term/
LICENSES/golang.org/x/term/LICENSE
LICENSES/golang.org/x/text/
LICENSES/golang.org/x/text/LICENSE
LICENSES/golang.org/x/time/
LICENSES/golang.org/x/time/rate/
LICENSES/golang.org/x/time/rate/LICENSE
LICENSES/gomodules.xyz/
LICENSES/gomodules.xyz/jsonpatch/
LICENSES/gomodules.xyz/jsonpatch/v2/
LICENSES/gomodules.xyz/jsonpatch/v2/LICENSE
LICENSES/google.golang.org/
LICENSES/google.golang.org/genproto/
LICENSES/google.golang.org/genproto/googleapis/
LICENSES/google.golang.org/genproto/googleapis/rpc/
LICENSES/google.golang.org/genproto/googleapis/rpc/status/
LICENSES/google.golang.org/genproto/googleapis/rpc/status/LICENSE
LICENSES/google.golang.org/grpc/
LICENSES/google.golang.org/grpc/LICENSE
LICENSES/google.golang.org/grpc/NOTICE.txt
LICENSES/google.golang.org/protobuf/
LICENSES/google.golang.org/protobuf/LICENSE
LICENSES/gopkg.in/
LICENSES/gopkg.in/inf.v0/
LICENSES/gopkg.in/inf.v0/LICENSE
LICENSES/gopkg.in/yaml.v2/
LICENSES/gopkg.in/yaml.v2/LICENSE
LICENSES/gopkg.in/yaml.v2/NOTICE
LICENSES/gopkg.in/yaml.v3/
LICENSES/gopkg.in/yaml.v3/LICENSE
LICENSES/gopkg.in/yaml.v3/NOTICE
LICENSES/k8s.io/
LICENSES/k8s.io/api/
LICENSES/k8s.io/api/LICENSE
LICENSES/k8s.io/apiextensions-apiserver/
LICENSES/k8s.io/apiextensions-apiserver/pkg/
LICENSES/k8s.io/apiextensions-apiserver/pkg/apis/
LICENSES/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/
LICENSES/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/LICENSE
LICENSES/k8s.io/apimachinery/
LICENSES/k8s.io/apimachinery/pkg/
LICENSES/k8s.io/apimachinery/pkg/LICENSE
LICENSES/k8s.io/apimachinery/third_party/
LICENSES/k8s.io/apimachinery/third_party/forked/
LICENSES/k8s.io/apimachinery/third_party/forked/golang/
LICENSES/k8s.io/apimachinery/third_party/forked/golang/LICENSE
LICENSES/k8s.io/client-go/
LICENSES/k8s.io/client-go/LICENSE
LICENSES/k8s.io/klog/
LICENSES/k8s.io/klog/v2/
LICENSES/k8s.io/klog/v2/LICENSE
LICENSES/k8s.io/kube-openapi/
LICENSES/k8s.io/kube-openapi/pkg/
LICENSES/k8s.io/kube-openapi/pkg/LICENSE
LICENSES/k8s.io/kube-openapi/pkg/internal/
LICENSES/k8s.io/kube-openapi/pkg/internal/third_party/
LICENSES/k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/
LICENSES/k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/
LICENSES/k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/LICENSE
LICENSES/k8s.io/kube-openapi/pkg/validation/
LICENSES/k8s.io/kube-openapi/pkg/validation/spec/
LICENSES/k8s.io/kube-openapi/pkg/validation/spec/LICENSE
LICENSES/k8s.io/mount-utils/
LICENSES/k8s.io/mount-utils/LICENSE
LICENSES/k8s.io/utils/
LICENSES/k8s.io/utils/LICENSE
LICENSES/k8s.io/utils/internal/
LICENSES/k8s.io/utils/internal/third_party/
LICENSES/k8s.io/utils/internal/third_party/forked/
LICENSES/k8s.io/utils/internal/third_party/forked/golang/
LICENSES/k8s.io/utils/internal/third_party/forked/golang/net/
LICENSES/k8s.io/utils/internal/third_party/forked/golang/net/LICENSE
LICENSES/sigs.k8s.io/
LICENSES/sigs.k8s.io/controller-runtime/
LICENSES/sigs.k8s.io/controller-runtime/LICENSE
LICENSES/sigs.k8s.io/json/
LICENSES/sigs.k8s.io/json/LICENSE
LICENSES/sigs.k8s.io/structured-merge-diff/
LICENSES/sigs.k8s.io/structured-merge-diff/v4/
LICENSES/sigs.k8s.io/structured-merge-diff/v4/LICENSE
LICENSES/sigs.k8s.io/yaml/
LICENSES/sigs.k8s.io/yaml/LICENSE
LICENSES/sigs.k8s.io/yaml/goyaml.v2/
LICENSES/sigs.k8s.io/yaml/goyaml.v2/LICENSE
LICENSES/sigs.k8s.io/yaml/goyaml.v2/NOTICE
mountpoint-s3/LICENSE
mountpoint-s3/THIRD_PARTY_LICENSES
usr/share/doc/bzip2-libs-1.0.6/LICENSE
usr/share/doc/cracklib-2.9.0/README-LICENSE
usr/share/doc/libdb-5.3.21/LICENSE
usr/share/doc/libevent-2.0.21/LICENSE
usr/share/doc/libffi-3.0.13/LICENSE
usr/share/doc/openldap-2.4.44/LICENSE
usr/share/doc/python-2.7.18/LICENSE
usr/share/doc/python-libs-2.7.18/LICENSE
usr/share/doc/ustr-1.0.4/LICENSE
usr/share/doc/ustr-1.0.4/LICENSE_BSD
usr/share/doc/ustr-1.0.4/LICENSE_LGPL
usr/share/doc/ustr-1.0.4/LICENSE_MIT
usr/share/licenses/
usr/share/licenses/chkconfig-1.7.4/
usr/share/licenses/chkconfig-1.7.4/COPYING
usr/share/licenses/device-mapper-libs-1.02.170/
usr/share/licenses/device-mapper-libs-1.02.170/COPYING
usr/share/licenses/device-mapper-libs-1.02.170/COPYING.LIB
usr/share/licenses/elfutils-libelf-0.176/
usr/share/licenses/elfutils-libelf-0.176/COPYING-GPLV2
usr/share/licenses/elfutils-libelf-0.176/COPYING-LGPLV3
usr/share/licenses/elfutils-libs-0.176/
usr/share/licenses/elfutils-libs-0.176/COPYING-GPLV2
usr/share/licenses/elfutils-libs-0.176/COPYING-LGPLV3
usr/share/licenses/gdbm-1.13/
usr/share/licenses/gdbm-1.13/COPYING
usr/share/licenses/glibc-2.26/
usr/share/licenses/glibc-2.26/COPYING
usr/share/licenses/glibc-2.26/COPYING.LIB
usr/share/licenses/glibc-2.26/LICENSES
usr/share/licenses/gmp-6.0.0/
usr/share/licenses/gmp-6.0.0/COPYING
usr/share/licenses/gmp-6.0.0/COPYING.LESSERv3
usr/share/licenses/gmp-6.0.0/COPYINGv2
usr/share/licenses/gmp-6.0.0/COPYINGv3
usr/share/licenses/krb5-libs-1.15.1/
usr/share/licenses/krb5-libs-1.15.1/LICENSE
usr/share/licenses/libcap-2.54/
usr/share/licenses/libcap-2.54/License
usr/share/licenses/libcurl-8.3.0/
usr/share/licenses/libcurl-8.3.0/COPYING
usr/share/licenses/libfdisk-2.30.2/
usr/share/licenses/libfdisk-2.30.2/COPYING
usr/share/licenses/libfdisk-2.30.2/COPYING.LGPLv2.1
usr/share/licenses/libgcc-7.3.1/
usr/share/licenses/libgcc-7.3.1/COPYING
usr/share/licenses/libgcc-7.3.1/COPYING.LIB
usr/share/licenses/libgcc-7.3.1/COPYING.RUNTIME
usr/share/licenses/libgcc-7.3.1/COPYING3
usr/share/licenses/libgcc-7.3.1/COPYING3.LIB
usr/share/licenses/libidn2-2.3.0/
usr/share/licenses/libidn2-2.3.0/COPYING
usr/share/licenses/libidn2-2.3.0/COPYING.LESSERv3
usr/share/licenses/libidn2-2.3.0/COPYING.unicode
usr/share/licenses/libidn2-2.3.0/COPYINGv2
usr/share/licenses/libmount-2.30.2/
usr/share/licenses/libmount-2.30.2/COPYING
usr/share/licenses/libmount-2.30.2/COPYING.LGPLv2.1
usr/share/licenses/libnghttp2-1.41.0/
usr/share/licenses/libnghttp2-1.41.0/COPYING
usr/share/licenses/libpsl-0.21.5/
usr/share/licenses/libpsl-0.21.5/COPYING
usr/share/licenses/libsemanage-2.5/
usr/share/licenses/libsemanage-2.5/COPYING
usr/share/licenses/libsepol-2.5/
usr/share/licenses/libsepol-2.5/COPYING
usr/share/licenses/libsmartcols-2.30.2/
usr/share/licenses/libsmartcols-2.30.2/COPYING
usr/share/licenses/libsmartcols-2.30.2/COPYING.LGPLv2.1
usr/share/licenses/libuuid-2.30.2/
usr/share/licenses/libuuid-2.30.2/COPYING
usr/share/licenses/libuuid-2.30.2/COPYING.BSD-3
usr/share/licenses/lz4-1.7.5/
usr/share/licenses/lz4-1.7.5/COPYING
usr/share/licenses/lz4-1.7.5/LICENSE
usr/share/licenses/ncurses-base-6.0/
usr/share/licenses/ncurses-base-6.0/COPYING
usr/share/licenses/nss-pem-1.0.3/
usr/share/licenses/nss-pem-1.0.3/COPYING
usr/share/licenses/openssl-libs-1.0.2k/
usr/share/licenses/openssl-libs-1.0.2k/LICENSE
usr/share/licenses/publicsuffix-list-dafsa-20240208/
usr/share/licenses/publicsuffix-list-dafsa-20240208/COPYING
usr/share/licenses/util-linux-2.30.2/
usr/share/licenses/util-linux-2.30.2/COPYING.BSD-3
usr/share/licenses/util-linux-2.30.2/COPYING.GPLv2
usr/share/licenses/util-linux-2.30.2/COPYING.LGPLv2.1
usr/share/licenses/util-linux-2.30.2/COPYING.UCB
```
</details>



---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
