### PR TITLE
Move `mountoptions` package to `github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint`

### DIFF
--- a/cmd/aws-s3-csi-mounter/csimounter/csimounter.go
+++ b/cmd/aws-s3-csi-mounter/csimounter/csimounter.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
-	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint/mountoptions"
 )
 
 var mountErrorFileperm = fs.FileMode(0600) // only owner readable and writeable

--- a/cmd/aws-s3-csi-mounter/csimounter/csimounter_test.go
+++ b/cmd/aws-s3-csi-mounter/csimounter/csimounter_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/awslabs/aws-s3-csi-driver/cmd/aws-s3-csi-mounter/csimounter"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/mounter/mountertest"
-	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint/mountoptions"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
 )
 

--- a/cmd/aws-s3-csi-mounter/main.go
+++ b/cmd/aws-s3-csi-mounter/main.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/awslabs/aws-s3-csi-driver/cmd/aws-s3-csi-mounter/csimounter"
-	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint/mountoptions"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod"
 )
 

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -19,7 +19,7 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/envprovider"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/targetpath"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
-	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint/mountoptions"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod/watcher"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util"

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/mounter"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/mounter/mountertest"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
-	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint/mountoptions"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod/watcher"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"

--- a/pkg/mountpoint/mountoptions/mount_options.go
+++ b/pkg/mountpoint/mountoptions/mount_options.go
@@ -1,5 +1,5 @@
 // Package mountoptions provides utilities for passing mount options between
-// Mountpoint and CSI Driver Node Pods running in the same node.
+// containers (e.g., Mountpoint and CSI Driver Node Pods) running in the same node.
 package mountoptions
 
 import (

--- a/pkg/mountpoint/mountoptions/mount_options_test.go
+++ b/pkg/mountpoint/mountoptions/mount_options_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mountoptions"
+	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint/mountoptions"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util/testutil/assert"
 )
 


### PR DESCRIPTION
This is part of the effort of consolidating Mountpoint related functionalities in `github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint` package.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
