### PR TITLE
Move `mount`, `unmount` and `isMountPoint` functionalities to `github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint/mounter`

### DIFF
--- a/pkg/driver/node/mounter/mounter.go
+++ b/pkg/driver/node/mounter/mounter.go
@@ -3,19 +3,12 @@ package mounter
 
 import (
 	"context"
-	"fmt"
 	"os"
-
-	"k8s.io/klog/v2"
-	"k8s.io/mount-utils"
 
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/system"
 )
-
-// https://github.com/awslabs/mountpoint-s3/blob/9ed8b6243f4511e2013b2f4303a9197c3ddd4071/mountpoint-s3/src/cli.rs#L421
-const mountpointDeviceName = "mountpoint-s3"
 
 type ServiceRunner interface {
 	StartService(ctx context.Context, config *system.ExecConfig) (string, error)
@@ -38,30 +31,4 @@ func MountS3Path() string {
 		mountS3Path = defaultMountS3Path
 	}
 	return mountS3Path
-}
-
-// isMountPoint returns whether given `target` is a `mount-s3` mount.
-// We implement additional check on top of `mounter.IsMountPoint` because we need
-// to verify not only that the target is a mount point but also that it is specifically a mount-s3 mount point.
-// This is achieved by calling the `mounter.List()` method to enumerate all mount points.
-func isMountPoint(mounter mount.Interface, target string) (bool, error) {
-	if _, err := os.Stat(target); os.IsNotExist(err) {
-		return false, err
-	}
-
-	mountPoints, err := mounter.List()
-	if err != nil {
-		return false, fmt.Errorf("Failed to list mounts: %w", err)
-	}
-	for _, mp := range mountPoints {
-		if mp.Path == target {
-			if mp.Device != mountpointDeviceName {
-				klog.V(4).Infof("IsMountPoint: %s is not a `mount-s3` mount. Expected device type to be %s but got %s, skipping unmount", target, mountpointDeviceName, mp.Device)
-				continue
-			}
-
-			return true, nil
-		}
-	}
-	return false, nil
 }

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -76,7 +76,7 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 
 	podID := credentialCtx.PodID
 
-	isMountPoint, err := pm.mount.IsMountPoint(target)
+	isMountPoint, err := pm.IsMountPoint(target)
 	if err != nil {
 		err = pm.verifyOrSetupMountTarget(target, err)
 		if err != nil {
@@ -229,7 +229,7 @@ func (pm *PodMounter) Unmount(ctx context.Context, target string, credentialCtx 
 
 // IsMountPoint returns whether given `target` is a `mount-s3` mount.
 func (pm *PodMounter) IsMountPoint(target string) (bool, error) {
-	return pm.mount.IsMountPoint(target)
+	return pm.mount.CheckMountPoint(target)
 }
 
 // waitForMountpointPod waints until Mountpoint Pod for given `podID` and `volumeName` is in `Running` state.

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/mounter"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/mounter/mountertest"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
+	mpmounter "github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint/mounter"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint/mountoptions"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/podmounter/mppod/watcher"
@@ -119,7 +120,7 @@ func setup(t *testing.T) *testCtx {
 	err = podWatcher.Start(stopCh)
 	assert.NoError(t, err)
 
-	podMounter, err := mounter.NewPodMounter(podWatcher, credProvider, mount, mountSyscall, testK8sVersion)
+	podMounter, err := mounter.NewPodMounter(podWatcher, credProvider, mpmounter.NewWithMount(mount), mountSyscall, testK8sVersion)
 	assert.NoError(t, err)
 
 	testCtx.podMounter = podMounter

--- a/pkg/driver/node/mounter/systemd_mounter.go
+++ b/pkg/driver/node/mounter/systemd_mounter.go
@@ -13,19 +13,21 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/envprovider"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
+	mpmounter "github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint/mounter"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/system"
 )
 
 type SystemdMounter struct {
 	Runner            ServiceRunner
 	Mounter           mount.Interface
+	MpMounter         *mpmounter.Mounter
 	MpVersion         string
 	MountS3Path       string
 	kubernetesVersion string
 	credProvider      *credentialprovider.Provider
 }
 
-func NewSystemdMounter(credProvider *credentialprovider.Provider, mpVersion string, kubernetesVersion string) (*SystemdMounter, error) {
+func NewSystemdMounter(credProvider *credentialprovider.Provider, mpMounter *mpmounter.Mounter, mpVersion string, kubernetesVersion string) (*SystemdMounter, error) {
 	runner, err := system.StartOsSystemdSupervisor()
 	if err != nil {
 		return nil, fmt.Errorf("failed to start systemd supervisor: %w", err)
@@ -33,6 +35,7 @@ func NewSystemdMounter(credProvider *credentialprovider.Provider, mpVersion stri
 	return &SystemdMounter{
 		Runner:            runner,
 		Mounter:           mount.New(""),
+		MpMounter:         mpMounter,
 		MpVersion:         mpVersion,
 		MountS3Path:       MountS3Path(),
 		kubernetesVersion: kubernetesVersion,
@@ -42,7 +45,7 @@ func NewSystemdMounter(credProvider *credentialprovider.Provider, mpVersion stri
 
 // IsMountPoint returns whether given `target` is a `mount-s3` mount.
 func (m *SystemdMounter) IsMountPoint(target string) (bool, error) {
-	return isMountPoint(m.Mounter, target)
+	return m.MpMounter.IsMountPoint(target)
 }
 
 // Mount mounts the given bucket at the target path using provided credentials.
@@ -69,11 +72,11 @@ func (m *SystemdMounter) Mount(ctx context.Context, bucketName string, target st
 
 	cleanupDir := false
 
+	isMountPoint, err := m.MpMounter.IsMountPoint(target)
 	// check if the target path exists and is a directory
-	mountpointErr := verifyMountPointStatx(target)
-	if mountpointErr != nil {
+	if err != nil {
 		// does not exist, create the directory
-		if os.IsNotExist(mountpointErr) {
+		if os.IsNotExist(err) {
 			if err := os.MkdirAll(target, 0755); err != nil {
 				return fmt.Errorf("Failed to create target directory: %w", err)
 			}
@@ -85,23 +88,19 @@ func (m *SystemdMounter) Mount(ctx context.Context, bucketName string, target st
 					}
 				}
 			}()
-		}
-		// Corrupted mount, try unmounting
-		if mount.IsCorruptedMnt(mountpointErr) {
+			// Corrupted mount, try unmounting
+		} else if m.MpMounter.IsMountPointCorrupted(err) {
 			klog.V(4).Infof("Mount: Target path %q is a corrupted mount. Trying to unmount.", target)
 			if mntErr := m.Unmount(ctx, target, credentialprovider.CleanupContext{
 				WritePath: credentialCtx.WritePath,
 				PodID:     credentialCtx.PodID,
 				VolumeID:  credentialCtx.VolumeID,
 			}); mntErr != nil {
-				return fmt.Errorf("Unable to unmount the target %q : %v, %v", target, mountpointErr, mntErr)
+				return fmt.Errorf("Unable to unmount the target %q : %v, %v", target, err, mntErr)
 			}
+		} else {
+			return fmt.Errorf("Could not check if %q is a mount point: %v, %v", target, err, err)
 		}
-	}
-
-	isMountPoint, err := m.IsMountPoint(target)
-	if err != nil {
-		return fmt.Errorf("Could not check if %q is a mount point: %v, %v", target, mountpointErr, err)
 	}
 
 	credEnv, authenticationSource, err := m.credProvider.Provide(ctx, credentialCtx)

--- a/pkg/driver/node/mounter/systemd_mounter.go
+++ b/pkg/driver/node/mounter/systemd_mounter.go
@@ -99,7 +99,7 @@ func (m *SystemdMounter) Mount(ctx context.Context, bucketName string, target st
 				return fmt.Errorf("Unable to unmount the target %q : %v, %v", target, err, mntErr)
 			}
 		} else {
-			return fmt.Errorf("Could not check if %q is a mount point: %v, %v", target, err, err)
+			return fmt.Errorf("Could not check if %q is a mount point: %v", target, err)
 		}
 	}
 

--- a/pkg/driver/node/mounter/systemd_mounter.go
+++ b/pkg/driver/node/mounter/systemd_mounter.go
@@ -45,7 +45,7 @@ func NewSystemdMounter(credProvider *credentialprovider.Provider, mpMounter *mpm
 
 // IsMountPoint returns whether given `target` is a `mount-s3` mount.
 func (m *SystemdMounter) IsMountPoint(target string) (bool, error) {
-	return m.MpMounter.IsMountPoint(target)
+	return m.MpMounter.CheckMountPoint(target)
 }
 
 // Mount mounts the given bucket at the target path using provided credentials.
@@ -72,7 +72,7 @@ func (m *SystemdMounter) Mount(ctx context.Context, bucketName string, target st
 
 	cleanupDir := false
 
-	isMountPoint, err := m.MpMounter.IsMountPoint(target)
+	isMountPoint, err := m.IsMountPoint(target)
 	// check if the target path exists and is a directory
 	if err != nil {
 		// does not exist, create the directory

--- a/pkg/mountpoint/mounter/fd.go
+++ b/pkg/mountpoint/mounter/fd.go
@@ -1,0 +1,24 @@
+package mounter
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const dev = "/dev/fuse"
+
+// openFD opens FUSE device (`/dev/fuse`) with read-write mode to obtain
+// a file descriptor to use for mounting Mountpoint.
+func openFD() (int, error) {
+	fd, err := syscall.Open(dev, os.O_RDWR, 0)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open %s: %w", dev, err)
+	}
+	return fd, nil
+}
+
+// CloseFD closes given FUSE file descriptor.
+func CloseFD(fd int) error {
+	return syscall.Close(fd)
+}

--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -1,0 +1,104 @@
+// Package mounter provides functionalities for mounting and unmount Mountpoint instances.
+package mounter
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"k8s.io/klog/v2"
+	mountutils "k8s.io/mount-utils"
+)
+
+// ErrMissingTarget is returned when `Mount` is called with empty target.
+var ErrMissingTarget = errors.New("mounter: missing mount target")
+
+// fsName is the default Mountpoint device name.
+// https://github.com/awslabs/mountpoint-s3/blob/9ed8b6243f4511e2013b2f4303a9197c3ddd4071/mountpoint-s3/src/cli.rs#L421
+const fsName = "mountpoint-s3"
+
+// A Target represents a mount target to mount Mountpoint at.
+type Target = string
+
+// A Mounter provides utilities for mounting, unmounting, and querying whether a Mountpoint instance is mounted.
+type Mounter struct {
+	mount mountutils.Interface
+}
+
+// A MountOptions represents mount options to be passed to `mount` syscall.
+type MountOptions struct {
+	ReadOnly   bool
+	AllowOther bool
+}
+
+// New returns a new `Mounter` with default mount util.
+func New() *Mounter {
+	return NewWithMount(mountutils.New(""))
+}
+
+// NewWithMount returns a new `Mounter` with the given mount util.
+func NewWithMount(mount mountutils.Interface) *Mounter {
+	return &Mounter{mount}
+}
+
+// Mount performs `mount` syscall for Mountpoint at `target`.
+// It obtains a FUSE file descriptor, calls `mount` syscall at `target` with the obtained fd using provided `opts`,
+// and returns the fd for Mountpoint to communicate with the kernel.
+//
+// It's caller responsibility to call `Unmount` to unmount the registered file system at `target`.
+//
+// This requires `CAP_SYS_ADMIN` capability in the target namespace.
+func (m *Mounter) Mount(target Target, opts MountOptions) (int, error) {
+	if target == "" {
+		return 0, ErrMissingTarget
+	}
+	return mount(target, opts)
+}
+
+// Unmount unmounts Mountpoint at `target`.
+//
+// This requires `CAP_SYS_ADMIN` capability in the target namespace.
+func (m *Mounter) Unmount(target Target) error {
+	return m.mount.Unmount(target)
+}
+
+// IsMountPoint checks whether `target` is a Mountpoint mount.
+//
+// It returns an error if it encounters, some notable errors that requires callers to perform some operations are:
+//   - If `errors.Is(err, fs.ErrNotExist)` - it means the `target` does not exists, and the caller should create the target folder
+//   - If `mounter.IsMountPointCorrupted(err)` - it means the `target` is corrupted, and the caller should `Unmount` and `Mount` the file system
+//
+// We implement additional check on top of `mountutils.IsMountPoint()` because we need
+// to verify not only that the target is a mount point but also that it is specifically a Mountpoint mount point.
+// This is achieved by calling the `mountutils.List()` method to enumerate all mount points.
+func (m *Mounter) IsMountPoint(target Target) (bool, error) {
+	if _, err := os.Stat(target); err != nil && errors.Is(err, fs.ErrNotExist) {
+		return false, err
+	}
+
+	mountPoints, err := m.mount.List()
+	if err != nil {
+		return false, fmt.Errorf("failed to list mounts for %q: %w", target, err)
+	}
+
+	for _, mp := range mountPoints {
+		if mp.Path == target {
+			if mp.Device != fsName {
+				klog.Infof("mounter: %q is a %q mount, but %q is expected, ignoring", target, mp.Device, fsName)
+				continue
+			}
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// IsMountPointCorrupted returns whether an error returned from `IsMountPoint`
+// indicates the queried mount point is corrupted or not.
+//
+// If its corrupted, the mount point should be re-mounted.
+func (m *Mounter) IsMountPointCorrupted(err error) bool {
+	return mountutils.IsCorruptedMnt(err)
+}

--- a/pkg/mountpoint/mounter/mount_darwin.go
+++ b/pkg/mountpoint/mounter/mount_darwin.go
@@ -3,15 +3,13 @@ package mounter
 import (
 	"errors"
 	"os"
-
-	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
 )
 
-func (pm *PodMounter) mountSyscallDefault(_ string, _ mountpoint.Args) (int, error) {
+func mount(_ Target, _ MountOptions) (int, error) {
 	return 0, errors.New("Only supported on Linux")
 }
 
-func verifyMountPointStatx(path string) error {
+func statx(path string) error {
 	// statx is a Linux-specific syscall, let's simulate with os.Stat
 	_, err := os.Stat(path)
 	return err

--- a/pkg/mountpoint/mounter/mount_linux.go
+++ b/pkg/mountpoint/mounter/mount_linux.go
@@ -8,15 +8,12 @@ import (
 
 	"golang.org/x/sys/unix"
 	"k8s.io/klog/v2"
-
-	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
 )
 
-// mountSyscallDefault creates a FUSE file descriptor and performs a `mount` syscall with given `target` and mount arguments.
-func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (int, error) {
-	fd, err := syscall.Open("/dev/fuse", os.O_RDWR, 0)
+func mount(target Target, opts MountOptions) (int, error) {
+	fd, err := openFD()
 	if err != nil {
-		return 0, fmt.Errorf("failed to open /dev/fuse: %w", err)
+		return 0, err
 	}
 
 	// This will set false on a success condition and will stay true
@@ -25,7 +22,10 @@ func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (
 	closeFd := true
 	defer func() {
 		if closeFd {
-			pm.closeFUSEDevFD(fd)
+			err := CloseFD(fd)
+			if err != nil {
+				klog.ErrorS(err, "failed to close file descriptor", "fd", fd)
+			}
 		}
 	}()
 
@@ -37,25 +37,35 @@ func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (
 
 	options := []string{
 		fmt.Sprintf("fd=%d", fd),
+		// We only keep file type bits from the file mode of the target,
+		// this is also how libfuse decides on `rootmode`.
+		// Mountpoint has `--file-mode` and `--dir-mode` for permission bits on the files and directories,
+		// and that will be effective once Mountpoint is mounted.
 		fmt.Sprintf("rootmode=%o", stat.Mode&syscall.S_IFMT),
+		// Set `uid`/`gid` of the mount owner as this process
 		fmt.Sprintf("user_id=%d", os.Geteuid()),
 		fmt.Sprintf("group_id=%d", os.Getegid()),
+		// Instruct kernel to do its own permissions checks
 		"default_permissions",
 	}
 
-	var flags uintptr = uintptr(syscall.MS_NODEV | syscall.MS_NOSUID | syscall.MS_NOATIME)
+	// These flags matches with Mountpoint's and `fuser`s defaults
+	var flags uintptr = uintptr(
+		syscall.MS_NODEV | // Do not allow access to devices
+			syscall.MS_NOSUID | // Do not honor set-user-ID and set-group-ID bits or file capabilities when executing programs
+			syscall.MS_NOATIME) // Do not update access times
 
-	if args.Has(mountpoint.ArgReadOnly) {
+	if opts.ReadOnly {
 		flags |= syscall.MS_RDONLY
 	}
 
-	if args.Has(mountpoint.ArgAllowOther) || args.Has(mountpoint.ArgAllowRoot) {
+	if opts.AllowOther {
 		options = append(options, "allow_other")
 	}
 
 	optionsJoined := strings.Join(options, ",")
-	klog.V(4).Infof("Mounting %s with options %s", target, optionsJoined)
-	err = syscall.Mount(mountpointDeviceName, target, "fuse", flags, optionsJoined)
+	klog.Infof("Mounting %s with options %s", target, optionsJoined)
+	err = syscall.Mount(fsName, target, "fuse", flags, optionsJoined)
 	if err != nil {
 		return 0, fmt.Errorf("failed to mount %s: %w", target, err)
 	}
@@ -65,7 +75,7 @@ func (pm *PodMounter) mountSyscallDefault(target string, args mountpoint.Args) (
 	return fd, nil
 }
 
-func verifyMountPointStatx(path string) error {
+func statx(path string) error {
 	var stat unix.Statx_t
 	if err := unix.Statx(unix.AT_FDCWD, path, unix.AT_STATX_FORCE_SYNC, 0, &stat); err != nil {
 		if err == unix.ENOSYS {


### PR DESCRIPTION
This is part of the effort of consolidating Mountpoint related
functionalities in `github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint`
package.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
