### PR TITLE
Install EKS Pod Identity Agent and include MOUNTER_KIND

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -182,6 +182,7 @@ jobs:
       - name: Run E2E Tests (PodMounter)
         env:
           ACTION: "run_tests"
+          MOUNTER_KIND: "pod"
         run: |
           tests/e2e-kubernetes/scripts/run.sh
       - name: Post e2e cleanup (PodMounter)

--- a/tests/e2e-kubernetes/scripts/eksctl-patch.json
+++ b/tests/e2e-kubernetes/scripts/eksctl-patch.json
@@ -38,6 +38,13 @@
     }
   },
   {
+    "op": "add",
+    "path": "/addons/-",
+    "value": {
+      "name": "eks-pod-identity-agent"
+    }
+  },
+  {
     "op": "replace",
     "path": "/cloudWatch/clusterLogging",
     "value": {


### PR DESCRIPTION
*Description of changes:*

These changes correct the setup of test cluster to avoid skipping E2E tests related to Pod Sharing and EKS Pod Identity.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
