### PR TITLE
EKS Pod Identity support for pod level credentials

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/csidriver.yaml
@@ -12,6 +12,8 @@ spec:
   tokenRequests:
     - audience: "sts.amazonaws.com"
       expirationSeconds: 3600
+    {{- if .Values.experimental.podMounter }}
     - audience: "pods.eks.amazonaws.com"
       expirationSeconds: 3600
+    {{- end }}
   requiresRepublish: true

--- a/charts/aws-mountpoint-s3-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/csidriver.yaml
@@ -12,4 +12,6 @@ spec:
   tokenRequests:
     - audience: "sts.amazonaws.com"
       expirationSeconds: 3600
+    - audience: "pods.eks.amazonaws.com"
+      expirationSeconds: 3600
   requiresRepublish: true

--- a/pkg/driver/node/credentialprovider/provider_pod.go
+++ b/pkg/driver/node/credentialprovider/provider_pod.go
@@ -48,56 +48,51 @@ func (c *Provider) provideFromPod(ctx context.Context, provideCtx ProvideContext
 		return nil, status.Errorf(codes.InvalidArgument, "Failed to parse service account tokens: %v", err)
 	}
 
-	// stsToken := tokens[serviceAccountTokenAudienceSTS]
-	stsToken := tokens[serviceAccountTokenAudiencePodIdentity]
-	if stsToken == nil {
-		klog.Errorf("credentialprovider: `authenticationSource` configured to `pod` but no service account tokens for %s received. Please make sure to enable `podInfoOnMountCompat`, see "+podLevelCredentialsDocsPage, serviceAccountTokenAudiencePodIdentity)
-		return nil, status.Errorf(codes.InvalidArgument, "Missing service account token for %s", serviceAccountTokenAudiencePodIdentity)
-	}
-
-	// roleARN, err := c.findPodServiceAccountRole(ctx, provideCtx)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// region, err := c.stsRegion(provideCtx)
-	// if err != nil {
-	// 	return nil, status.Errorf(codes.InvalidArgument, "Failed to detect STS AWS Region, please explicitly set the AWS Region, see "+stsConfigDocsPage)
-	// }
-
-	// defaultRegion := os.Getenv(envprovider.EnvDefaultRegion)
-	// if defaultRegion == "" {
-	// 	defaultRegion = region
-	// }
-
 	podID := provideCtx.PodID
 	volumeID := provideCtx.VolumeID
 	if podID == "" {
 		return nil, status.Error(codes.InvalidArgument, "Missing Pod info. Please make sure to enable `podInfoOnMountCompat`, see "+podLevelCredentialsDocsPage)
 	}
 
-	tokenName := podLevelServiceAccountTokenName(podID, volumeID)
-
-	err := renameio.WriteFile(filepath.Join(provideCtx.WritePath, tokenName), []byte(stsToken.Token), CredentialFilePerm)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Failed to write service account token: %v", err)
+	stsToken := tokens[serviceAccountTokenAudienceSTS]
+	if stsToken == nil {
+		klog.Errorf("credentialprovider: `authenticationSource` configured to `pod` but no service account tokens for %s received. Please make sure to enable `podInfoOnMountCompat`, see "+podLevelCredentialsDocsPage, serviceAccountTokenAudienceSTS)
+		return nil, status.Errorf(codes.InvalidArgument, "Missing service account token for %s", serviceAccountTokenAudienceSTS)
 	}
 
+	tokenName := podLevelServiceAccountTokenName(podID, volumeID)
+	err := renameio.WriteFile(filepath.Join(provideCtx.WritePath, tokenName), []byte(stsToken.Token), CredentialFilePerm)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Failed to write service account STS token: %v", err)
+	}
 	tokenFile := filepath.Join(provideCtx.EnvPath, tokenName)
+
+	eksToken := tokens[serviceAccountTokenAudiencePodIdentity]
+	if eksToken == nil {
+		klog.Errorf("credentialprovider: `authenticationSource` configured to `pod` but no service account tokens for %s received. Please make sure to enable `podInfoOnMountCompat`, see "+podLevelCredentialsDocsPage, serviceAccountTokenAudiencePodIdentity)
+		return nil, status.Errorf(codes.InvalidArgument, "Missing service account token for %s", serviceAccountTokenAudiencePodIdentity)
+	}
+
+	tokenNameEKS := eksPodIdentityServiceAccountTokenName(podID, volumeID)
+	err = renameio.WriteFile(filepath.Join(provideCtx.WritePath, tokenNameEKS), []byte(eksToken.Token), CredentialFilePerm)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Failed to write service account EKS Pod Identity token: %v", err)
+	}
+	tokenFileEKS := filepath.Join(provideCtx.EnvPath, tokenNameEKS)
 
 	podNamespace := provideCtx.PodNamespace
 	podServiceAccount := provideCtx.ServiceAccountName
 	cacheKey := podNamespace + "/" + podServiceAccount
 
-	eksPodIdentityCredentialsEnvironment, eksPodIdentityCredentialsEnvironmentError := c.createEKSPodIdentityCredentialsEnvironment(tokenFile)
+	irsaCredentialsEnvironment, irsaCredentialsEnvironmentError := c.createIRSACredentialsEnvironment(ctx, provideCtx, tokenFile)
+	eksPodIdentityCredentialsEnvironment, eksPodIdentityCredentialsEnvironmentError := c.createEKSPodIdentityCredentialsEnvironment(tokenFileEKS)
+
+	if irsaCredentialsEnvironmentError != nil && eksPodIdentityCredentialsEnvironmentError != nil {
+		klog.Error("IRSA and EKS Pod Identity failed")                                                                                                                    // TODO: Improve error message
+		return nil, status.Errorf(codes.Internal, "IRSA and EKS Pod Identity failed: %v, %v", irsaCredentialsEnvironmentError, eksPodIdentityCredentialsEnvironmentError) // TODO: Improve error message
+	}
 
 	env := envprovider.Environment{
-		// envprovider.EnvRoleARN:              roleARN,
-		// envprovider.EnvWebIdentityTokenFile: filepath.Join(provideCtx.EnvPath, tokenName),
-
-		// envprovider.EnvRegion:        region,
-		// envprovider.EnvDefaultRegion: defaultRegion,
-
 		envprovider.EnvEC2MetadataDisabled: "true",
 
 		// TODO: These were needed with `systemd` but probably won't be necessary with containerization.
@@ -105,12 +100,19 @@ func (c *Provider) provideFromPod(ctx context.Context, provideCtx ProvideContext
 		envprovider.EnvConfigFile:            filepath.Join(provideCtx.EnvPath, "disable-config"),
 		envprovider.EnvSharedCredentialsFile: filepath.Join(provideCtx.EnvPath, "disable-credentials"),
 	}
+
+	if irsaCredentialsEnvironmentError != nil {
+		klog.Error("irsaCredentialsEnvironmentError") // TODO: Improve error message
+	} else {
+		env.Merge(irsaCredentialsEnvironment)
+	}
+
 	if eksPodIdentityCredentialsEnvironmentError != nil {
-		klog.Error("eksPodIdentityCredentialsEnvironmentError")
-		return nil, status.Errorf(codes.Internal, "eksPodIdentityCredentialsEnvironmentError: %v", err)
+		klog.Error("eksPodIdentityCredentialsEnvironmentError") // TODO: Improve error message
 	} else {
 		env.Merge(eksPodIdentityCredentialsEnvironment)
 	}
+
 	return env, nil
 }
 
@@ -155,9 +157,41 @@ func (c *Provider) findPodServiceAccountRole(ctx context.Context, provideCtx Pro
 
 // podLevelServiceAccountTokenName returns service account token name for Pod-level identity.
 // It escapes from slashes to make this token name path-safe.
-func podLevelServiceAccountTokenName(podID string, volumeID string) string {
+func podLevelServiceAccountTokenName(podID string, volumeID string) string { // TODO: Consider reusability with eksPodIdentityServiceAccountTokenName or at least renaming this one.
 	id := escapedVolumeIdentifier(podID, volumeID)
 	return id + ".token"
+}
+
+// eksPodIdentityServiceAccountTokenName returns service account token name for Pod-level identity with EKS Pod Identity.
+// It escapes from slashes to make this token name path-safe.
+func eksPodIdentityServiceAccountTokenName(podID string, volumeID string) string {
+	id := escapedVolumeIdentifier(podID, volumeID)
+	return id + "-eks-pod-identity.token"
+}
+
+// createIRSACredentialsEnvironment creates an environment with the environment variables needed for pod-level authentication with IRSA
+func (c *Provider) createIRSACredentialsEnvironment(ctx context.Context, provideCtx ProvideContext, tokenFile string) (envprovider.Environment, error) {
+	roleARN, err := c.findPodServiceAccountRole(ctx, provideCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	region, err := c.stsRegion(provideCtx)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Failed to detect STS AWS Region, please explicitly set the AWS Region, see "+stsConfigDocsPage)
+	}
+
+	defaultRegion := os.Getenv(envprovider.EnvDefaultRegion)
+	if defaultRegion == "" {
+		defaultRegion = region
+	}
+
+	return envprovider.Environment{
+		envprovider.EnvRoleARN:              roleARN,
+		envprovider.EnvWebIdentityTokenFile: tokenFile,
+		envprovider.EnvRegion:               region,
+		envprovider.EnvDefaultRegion:        defaultRegion,
+	}, nil
 }
 
 // createEKSPodIdentityCredentialsEnvironment creates an environment with the environment variables needed for pod-level authentication with EKS Pod Identity

--- a/pkg/driver/node/credentialprovider/provider_pod.go
+++ b/pkg/driver/node/credentialprovider/provider_pod.go
@@ -19,8 +19,10 @@ import (
 )
 
 const (
-	serviceAccountTokenAudienceSTS = "sts.amazonaws.com"
-	serviceAccountRoleAnnotation   = "eks.amazonaws.com/role-arn"
+	serviceAccountTokenAudienceSTS         = "sts.amazonaws.com"
+	serviceAccountTokenAudiencePodIdentity = "pods.eks.amazonaws.com"
+	serviceAccountRoleAnnotation           = "eks.amazonaws.com/role-arn"
+	podIdentityCredURI                     = "http://169.254.170.23/v1/credentials"
 )
 
 const podLevelCredentialsDocsPage = "https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#pod-level-credentials"
@@ -46,26 +48,27 @@ func (c *Provider) provideFromPod(ctx context.Context, provideCtx ProvideContext
 		return nil, status.Errorf(codes.InvalidArgument, "Failed to parse service account tokens: %v", err)
 	}
 
-	stsToken := tokens[serviceAccountTokenAudienceSTS]
+	// stsToken := tokens[serviceAccountTokenAudienceSTS]
+	stsToken := tokens[serviceAccountTokenAudiencePodIdentity]
 	if stsToken == nil {
-		klog.Errorf("credentialprovider: `authenticationSource` configured to `pod` but no service account tokens for %s received. Please make sure to enable `podInfoOnMountCompat`, see "+podLevelCredentialsDocsPage, serviceAccountTokenAudienceSTS)
-		return nil, status.Errorf(codes.InvalidArgument, "Missing service account token for %s", serviceAccountTokenAudienceSTS)
+		klog.Errorf("credentialprovider: `authenticationSource` configured to `pod` but no service account tokens for %s received. Please make sure to enable `podInfoOnMountCompat`, see "+podLevelCredentialsDocsPage, serviceAccountTokenAudiencePodIdentity)
+		return nil, status.Errorf(codes.InvalidArgument, "Missing service account token for %s", serviceAccountTokenAudiencePodIdentity)
 	}
 
-	roleARN, err := c.findPodServiceAccountRole(ctx, provideCtx)
-	if err != nil {
-		return nil, err
-	}
+	// roleARN, err := c.findPodServiceAccountRole(ctx, provideCtx)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	region, err := c.stsRegion(provideCtx)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Failed to detect STS AWS Region, please explicitly set the AWS Region, see "+stsConfigDocsPage)
-	}
+	// region, err := c.stsRegion(provideCtx)
+	// if err != nil {
+	// 	return nil, status.Errorf(codes.InvalidArgument, "Failed to detect STS AWS Region, please explicitly set the AWS Region, see "+stsConfigDocsPage)
+	// }
 
-	defaultRegion := os.Getenv(envprovider.EnvDefaultRegion)
-	if defaultRegion == "" {
-		defaultRegion = region
-	}
+	// defaultRegion := os.Getenv(envprovider.EnvDefaultRegion)
+	// if defaultRegion == "" {
+	// 	defaultRegion = region
+	// }
 
 	podID := provideCtx.PodID
 	volumeID := provideCtx.VolumeID
@@ -75,21 +78,25 @@ func (c *Provider) provideFromPod(ctx context.Context, provideCtx ProvideContext
 
 	tokenName := podLevelServiceAccountTokenName(podID, volumeID)
 
-	err = renameio.WriteFile(filepath.Join(provideCtx.WritePath, tokenName), []byte(stsToken.Token), CredentialFilePerm)
+	err := renameio.WriteFile(filepath.Join(provideCtx.WritePath, tokenName), []byte(stsToken.Token), CredentialFilePerm)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to write service account token: %v", err)
 	}
+
+	tokenFile := filepath.Join(provideCtx.EnvPath, tokenName)
 
 	podNamespace := provideCtx.PodNamespace
 	podServiceAccount := provideCtx.ServiceAccountName
 	cacheKey := podNamespace + "/" + podServiceAccount
 
-	return envprovider.Environment{
-		envprovider.EnvRoleARN:              roleARN,
-		envprovider.EnvWebIdentityTokenFile: filepath.Join(provideCtx.EnvPath, tokenName),
+	eksPodIdentityCredentialsEnvironment, eksPodIdentityCredentialsEnvironmentError := c.createEKSPodIdentityCredentialsEnvironment(tokenFile)
 
-		envprovider.EnvRegion:        region,
-		envprovider.EnvDefaultRegion: defaultRegion,
+	env := envprovider.Environment{
+		// envprovider.EnvRoleARN:              roleARN,
+		// envprovider.EnvWebIdentityTokenFile: filepath.Join(provideCtx.EnvPath, tokenName),
+
+		// envprovider.EnvRegion:        region,
+		// envprovider.EnvDefaultRegion: defaultRegion,
 
 		envprovider.EnvEC2MetadataDisabled: "true",
 
@@ -97,7 +104,14 @@ func (c *Provider) provideFromPod(ctx context.Context, provideCtx ProvideContext
 		envprovider.EnvMountpointCacheKey:    cacheKey,
 		envprovider.EnvConfigFile:            filepath.Join(provideCtx.EnvPath, "disable-config"),
 		envprovider.EnvSharedCredentialsFile: filepath.Join(provideCtx.EnvPath, "disable-credentials"),
-	}, nil
+	}
+	if eksPodIdentityCredentialsEnvironmentError != nil {
+		klog.Error("eksPodIdentityCredentialsEnvironmentError")
+		return nil, status.Errorf(codes.Internal, "eksPodIdentityCredentialsEnvironmentError: %v", err)
+	} else {
+		env.Merge(eksPodIdentityCredentialsEnvironment)
+	}
+	return env, nil
 }
 
 // cleanupFromPod removes any credential files that were created for pod-level authentication authentication via [Provider.provideFromPod].
@@ -144,4 +158,12 @@ func (c *Provider) findPodServiceAccountRole(ctx context.Context, provideCtx Pro
 func podLevelServiceAccountTokenName(podID string, volumeID string) string {
 	id := escapedVolumeIdentifier(podID, volumeID)
 	return id + ".token"
+}
+
+// createEKSPodIdentityCredentialsEnvironment creates an environment with the environment variables needed for pod-level authentication with EKS Pod Identity
+func (c *Provider) createEKSPodIdentityCredentialsEnvironment(tokenFile string) (envprovider.Environment, error) {
+	return envprovider.Environment{
+		envprovider.EnvPodIdentityCredURI:   podIdentityCredURI,
+		envprovider.EnvPodIdentityTokenFile: tokenFile,
+	}, nil
 }

--- a/pkg/driver/node/credentialprovider/provider_test.go
+++ b/pkg/driver/node/credentialprovider/provider_test.go
@@ -332,6 +332,8 @@ func TestProvidingPodLevelCredentials(t *testing.T) {
 	testutil.CleanRegionEnv(t)
 
 	t.Run("correct values for EKS Pod Identity", func(t *testing.T) {
+		t.Setenv("MOUNTER_KIND", "pod")
+
 		clientset := fake.NewSimpleClientset(serviceAccount(testPodServiceAccount, testPodNamespace, map[string]string{}))
 		provider := credentialprovider.New(clientset.CoreV1(), dummyRegionProvider)
 

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -790,13 +790,6 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 					expectFailToMount(enablePodLevelIdentity(ctx), sa.Name, nil)
 				})
 
-				It("should fail to mount if pod's service account does not have an associated role", func(ctx context.Context) {
-					sa, removeSA := createServiceAccount(ctx, f)
-					deferCleanup(removeSA)
-
-					expectFailToMount(enablePodLevelIdentity(ctx), sa.Name, nil)
-				})
-
 				It("should use up to date role associated with pod's service account", func(ctx context.Context) {
 					mountOptions := []string{"allow-delete", fmt.Sprintf("region %s", DefaultRegion)}
 					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, mountOptions)

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -365,7 +365,7 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 			role, removeRole := createRole(ctx, f, eksPodIdentityRoleTrustPolicyDocument(), policyName, iamPolicyEKSClusterPolicy)
 			deferCleanup(removeRole)
 
-			removeAssociation := createPodIdentityAssociation(ctx, f, sa, *role.Arn)
+			_, removeAssociation := createPodIdentityAssociation(ctx, f, sa, *role.Arn)
 			deferCleanup(removeAssociation)
 
 			pod := csiDriverPod(ctx, f)
@@ -595,6 +595,7 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 					// TODO:
 					// 1. Trigger a manual `TokenRequest` or wait for it's own lifecylce
 					// 2. Assert new token file is written to the Pod
+					// TODO: Also implement for pod-level EKS Pod Identity
 				})
 
 				It("should use up to date role associated with pod's service account", func(ctx context.Context) {
@@ -625,8 +626,15 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 					expectReadOnly(pod)
 				})
 
-				It("should not use csi driver's service account tokens", func(ctx context.Context) {
+				It("should not use csi driver's service account STS tokens", func(ctx context.Context) {
 					updateCSIDriversServiceAccountRole(ctx, iamPolicyS3FullAccess)
+
+					pod, _ := createPodWithServiceAccountAndPolicy(ctx, iamPolicyS3ReadOnlyAccess, true, false)
+					expectReadOnly(pod)
+				})
+
+				It("should not use csi driver's service account EKS tokens", func(ctx context.Context) {
+					updateCSIDriversServiceAccountRoleEKSPodIdentity(ctx, iamPolicyS3FullAccess)
 
 					pod, _ := createPodWithServiceAccountAndPolicy(ctx, iamPolicyS3ReadOnlyAccess, true, false)
 					expectReadOnly(pod)
@@ -695,6 +703,188 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 					framework.ExpectNoError(err)
 
 					expectFullAccess(pod)
+				})
+			})
+
+			FContext("EKS Pod Identity", Ordered, func() {
+				BeforeEach(func(ctx context.Context) {
+					if !IsPodMounter {
+						Skip("Pod Mounter is not enabled, skipping EKS Pod Identity tests")
+					}
+					if eksPodIdentityAgentDaemonSet == nil {
+						Skip("EKS Pod Identity Agent is not configured, skipping EKS Pod Identity tests")
+					}
+				})
+
+				assignPolicyToServiceAccount := func(ctx context.Context, sa *v1.ServiceAccount, policyName string) (*v1.ServiceAccount, *types.PodIdentityAssociation) {
+					role, removeRole := createRole(ctx, f, eksPodIdentityRoleTrustPolicyDocument(), policyName, iamPolicyEKSClusterPolicy)
+					deferCleanup(removeRole)
+
+					association, removeAssociation := createPodIdentityAssociation(ctx, f, sa, *role.Arn)
+					deferCleanup(removeAssociation)
+
+					return sa, association
+				}
+
+				createServiceAccountWithPolicy := func(ctx context.Context, policyName string) (*v1.ServiceAccount, *types.PodIdentityAssociation) {
+					sa, removeSA := createServiceAccount(ctx, f)
+					deferCleanup(removeSA)
+
+					return assignPolicyToServiceAccount(ctx, sa, policyName)
+				}
+
+				createPodWithServiceAccountAndPolicy := func(ctx context.Context, policyName string, allowDelete bool, asNonRoot bool) (*v1.Pod, *v1.ServiceAccount) {
+					By("Creating Pod with ServiceAccount")
+
+					mountOptions := []string{fmt.Sprintf("region %s", DefaultRegion)}
+					if allowDelete {
+						mountOptions = append(mountOptions, "allow-delete")
+					}
+					if asNonRoot {
+						mountOptions = append(mountOptions,
+							"allow-other",
+							fmt.Sprintf("uid=%d", defaultNonRootUser),
+							fmt.Sprintf("gid=%d", defaultNonRootGroup))
+					}
+					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, mountOptions)
+					deferCleanup(vol.CleanupResource)
+
+					sa, _ := createServiceAccountWithPolicy(ctx, policyName)
+
+					var podModifiers []func(*v1.Pod)
+					podModifiers = append(podModifiers, func(pod *v1.Pod) {
+						pod.Spec.ServiceAccountName = sa.Name
+					})
+					if asNonRoot {
+						podModifiers = append(podModifiers, podModifierNonRoot)
+					}
+
+					pod := createPod(ctx, vol, podModifiers...)
+
+					waitUntilRoleIsAssumableWithEKS(ctx, f, sa, pod)
+
+					return pod, sa
+				}
+
+				It("should use pod's service account's read-only role", func(ctx context.Context) {
+					pod, _ := createPodWithServiceAccountAndPolicy(ctx, iamPolicyS3ReadOnlyAccess, false, false)
+					expectReadOnly(pod)
+				})
+
+				It("should use pod's service account's full access role", func(ctx context.Context) {
+					pod, _ := createPodWithServiceAccountAndPolicy(ctx, iamPolicyS3FullAccess, true, false)
+					expectFullAccess(pod)
+				})
+
+				It("should use pod's service account's full access role as non-root", func(ctx context.Context) {
+					pod, _ := createPodWithServiceAccountAndPolicy(ctx, iamPolicyS3FullAccess, true, true)
+					expectFullAccess(pod)
+				})
+
+				It("should fail to mount if pod's service account's role does not allow s3::ListObjectsV2", func(ctx context.Context) {
+					sa, _ := createServiceAccountWithPolicy(ctx, iamPolicyS3NoAccess)
+					expectFailToMount(enablePodLevelIdentity(ctx), sa.Name, nil)
+				})
+
+				It("should fail to mount if pod's service account does not have an associated role", func(ctx context.Context) {
+					sa, removeSA := createServiceAccount(ctx, f)
+					deferCleanup(removeSA)
+
+					expectFailToMount(enablePodLevelIdentity(ctx), sa.Name, nil)
+				})
+
+				It("should use up to date role associated with pod's service account", func(ctx context.Context) {
+					mountOptions := []string{"allow-delete", fmt.Sprintf("region %s", DefaultRegion)}
+					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, mountOptions)
+					deferCleanup(vol.CleanupResource)
+
+					// Create a SA with full access role
+					sa, association := createServiceAccountWithPolicy(ctx, iamPolicyS3FullAccess)
+
+					pod, err := createPodWithServiceAccount(ctx, f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{vol.Pvc}, sa.Name)
+					framework.ExpectNoError(err)
+
+					expectFullAccess(pod)
+
+					// Delete association
+					deletePodIdentityAssociation(ctx, sa, association.AssociationId)
+
+					// Associate SA with read-only access role
+					sa, _ = assignPolicyToServiceAccount(ctx, sa, iamPolicyS3ReadOnlyAccess)
+
+					// Re-create the pod
+					framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+					pod, err = createPodWithServiceAccount(ctx, f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{vol.Pvc}, sa.Name)
+					framework.ExpectNoError(err)
+					defer func() {
+						framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+					}()
+
+					// The pod should only have a read-only access now
+					expectReadOnly(pod)
+				})
+
+				It("should not use csi driver's service account STS tokens", func(ctx context.Context) {
+					updateCSIDriversServiceAccountRole(ctx, iamPolicyS3FullAccess)
+
+					pod, _ := createPodWithServiceAccountAndPolicy(ctx, iamPolicyS3ReadOnlyAccess, true, false)
+					expectReadOnly(pod)
+				})
+
+				It("should not use csi driver's service account EKS tokens", func(ctx context.Context) {
+					updateCSIDriversServiceAccountRoleEKSPodIdentity(ctx, iamPolicyS3FullAccess)
+
+					pod, _ := createPodWithServiceAccountAndPolicy(ctx, iamPolicyS3ReadOnlyAccess, true, false)
+					expectReadOnly(pod)
+				})
+
+				It("should not use driver-level kubernetes secrets", func(ctx context.Context) {
+					updateDriverLevelKubernetesSecret(ctx, iamPolicyS3FullAccess)
+
+					pod, _ := createPodWithServiceAccountAndPolicy(ctx, iamPolicyS3ReadOnlyAccess, true, false)
+					expectReadOnly(pod)
+				})
+
+				It("should not mix different pod's service account tokens even when they are using the same volume", func(ctx context.Context) {
+					mountOptions := []string{"allow-delete", fmt.Sprintf("region %s", DefaultRegion)}
+					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, mountOptions)
+					deferCleanup(vol.CleanupResource)
+
+					saFullAccess, _ := createServiceAccountWithPolicy(ctx, iamPolicyS3FullAccess)
+					saReadOnlyAccess, _ := createServiceAccountWithPolicy(ctx, iamPolicyS3ReadOnlyAccess)
+
+					podFullAccess, err := createPodWithServiceAccount(ctx, f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{vol.Pvc}, saFullAccess.Name)
+					framework.ExpectNoError(err)
+					deferCleanup(func(ctx context.Context) error { return e2epod.DeletePodWithWait(ctx, f.ClientSet, podFullAccess) })
+
+					podReadOnlyAccess, err := createPodWithServiceAccount(ctx, f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{vol.Pvc}, saReadOnlyAccess.Name)
+					framework.ExpectNoError(err)
+					deferCleanup(func(ctx context.Context) error { return e2epod.DeletePodWithWait(ctx, f.ClientSet, podReadOnlyAccess) })
+
+					expectReadOnly(podReadOnlyAccess)
+					expectFullAccess(podFullAccess)
+
+					// Write a file on full-access pod and expect it to be readable by read-only pod,
+					// but writes from read-only pod should still fail.
+					writtenFile := expectWriteToSucceed(podFullAccess)
+					expectReadToSucceed(podReadOnlyAccess, writtenFile)
+					expectWriteToFail(podReadOnlyAccess)
+				})
+
+				It("should not use pod's service account's role if 'authenticationSource' is 'driver'", func(ctx context.Context) {
+					updateDriverLevelKubernetesSecret(ctx, iamPolicyS3ReadOnlyAccess)
+
+					mountOptions := []string{"allow-delete", fmt.Sprintf("region %s", DefaultRegion)}
+					vol := createVolumeResourceWithMountOptions(enableDriverLevelIdentity(ctx), l.config, pattern, mountOptions)
+					deferCleanup(vol.CleanupResource)
+
+					sa, _ := createServiceAccountWithPolicy(ctx, iamPolicyS3FullAccess)
+
+					pod, err := createPodWithServiceAccount(ctx, f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{vol.Pvc}, sa.Name)
+					framework.ExpectNoError(err)
+					deferCleanup(func(ctx context.Context) error { return e2epod.DeletePodWithWait(ctx, f.ClientSet, pod) })
+
+					expectReadOnly(pod)
 				})
 			})
 		})
@@ -1015,7 +1205,7 @@ func overrideServiceAccountRole(ctx context.Context, f *framework.Framework, sa 
 	}
 }
 
-func createPodIdentityAssociation(ctx context.Context, f *framework.Framework, sa *v1.ServiceAccount, roleArn string) func(context.Context) error {
+func createPodIdentityAssociation(ctx context.Context, f *framework.Framework, sa *v1.ServiceAccount, roleArn string) (*types.PodIdentityAssociation, func(context.Context) error) {
 	framework.Logf("Creating Pod Identity Association for ServiceAccount %s with role %s", sa.Name, roleArn)
 
 	client := eks.NewFromConfig(awsConfig(ctx))
@@ -1030,19 +1220,25 @@ func createPodIdentityAssociation(ctx context.Context, f *framework.Framework, s
 	output, err := client.CreatePodIdentityAssociation(ctx, input)
 	framework.ExpectNoError(err)
 
-	return func(ctx context.Context) error {
-		framework.Logf("Deleting Pod Identity Association for ServiceAccount %s", sa.Name)
-		_, err := client.DeletePodIdentityAssociation(ctx, &eks.DeletePodIdentityAssociationInput{
-			AssociationId: output.Association.AssociationId,
-			ClusterName:   &ClusterName,
-		})
-
-		var rsf *types.ResourceNotFoundException
-		if goerrors.As(err, &rsf) {
-			return nil
-		}
-		return err
+	return output.Association, func(ctx context.Context) error {
+		return deletePodIdentityAssociation(ctx, sa, output.Association.AssociationId)
 	}
+}
+
+func deletePodIdentityAssociation(ctx context.Context, sa *v1.ServiceAccount, associationId *string) error {
+	client := eks.NewFromConfig(awsConfig(ctx))
+
+	framework.Logf("Deleting Pod Identity Association for ServiceAccount %s", sa.Name)
+	_, err := client.DeletePodIdentityAssociation(ctx, &eks.DeletePodIdentityAssociationInput{
+		AssociationId: associationId,
+		ClusterName:   &ClusterName,
+	})
+
+	var rsf *types.ResourceNotFoundException
+	if goerrors.As(err, &rsf) {
+		return nil
+	}
+	return err
 }
 
 //-- OIDC utils


### PR DESCRIPTION
*Description of changes:* With this change, we will support the configuration of pod level credentials with EKS Pod Identity. In EKS clusters, this is an alternative to IRSA with an easier configuration process.

*Key Changes:*

- Credential Provider
  - In `provider_pod.go` the precedence is given to IRSA credentials. If they are not configured, then EKS Pod Identity credentials are forwarded to the Mountpoint process instead.
  - Added unit tests

- Testing
  - Added E2E tests covering EKS Pod Identity setup scenarios with IAM roles of varying levels of S3 access
  - Added one pod level IRSA E2E test to make sure driver level EKS Pod Identity is not used instead
  - Added E2E tests covering setup scenario of IRSA and EKS Pod Identity
  - Manual testing performed on personal EKS cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
