### PR TITLE
Ensure to not assign new workload to Mountpoint Pod if its created with a different CSI Driver version or annotated with "no-new-workload"

### DIFF
--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -725,7 +725,7 @@ func (r *Reconciler) findIRSAServiceAccountRole(ctx context.Context, pod *corev1
 	sa := &corev1.ServiceAccount{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: getServiceAccountName(pod)}, sa)
 	if err != nil {
-		return "", fmt.Errorf("Failed to find workload pod's service account %s", getServiceAccountName(pod))
+		return "", fmt.Errorf("Failed to find workload pod's service account %s: %w", getServiceAccountName(pod), err)
 	}
 
 	if sa.Annotations == nil {

--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -401,17 +401,18 @@ func (r *Reconciler) assignWorkloadToAnExistingMountpointPod(ctx context.Context
 	found := false
 
 	for mpPodName := range s3pa.Spec.MountpointS3PodAttachments {
+		mpPodLog := log.WithValues("mountpointPodName", mpPodName)
 		mpPod, err := r.getMountpointPod(ctx, mpPodName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				log.Info("Mountpoint Pod is not found - not suitable for assigning new workload", "mountpointPodName", mpPodName)
+				mpPodLog.Info("Mountpoint Pod is not found - not suitable for assigning new workload")
 				continue
 			}
 			return Requeue, err
 		}
 
-		if !r.shouldAssignNewWorkloadToMountpointPod(mpPod) {
-			log.Info("Mountpoint Pod is not suitable for assigning new workload", "mountpointPodName", mpPodName)
+		if !r.shouldAssignNewWorkloadToMountpointPod(mpPod, mpPodLog) {
+			mpPodLog.Info("Mountpoint Pod is not suitable for assigning new workload")
 			continue
 		}
 
@@ -420,7 +421,7 @@ func (r *Reconciler) assignWorkloadToAnExistingMountpointPod(ctx context.Context
 			AttachmentTime: metav1.NewTime(time.Now().UTC()),
 		})
 		found = true
-		log.Info("Found a suitable Mountpoint Pod to assign new workload", "mountpointPodName", mpPodName)
+		mpPodLog.Info("Found a suitable Mountpoint Pod to assign new workload")
 		break
 	}
 
@@ -647,12 +648,24 @@ func (r *Reconciler) getMountpointPod(ctx context.Context, name string) (*corev1
 }
 
 // shouldAssignNewWorkloadToMountpointPod returns whether a new workload should be assigned to the Mountpoint Pod `mpPod`.
-func (r *Reconciler) shouldAssignNewWorkloadToMountpointPod(mpPod *corev1.Pod) bool {
-	if mpPod.Annotations == nil {
-		return true
+func (r *Reconciler) shouldAssignNewWorkloadToMountpointPod(mpPod *corev1.Pod, log logr.Logger) bool {
+	if mpPod.Annotations != nil {
+		if mpPod.Annotations[mppod.AnnotationNeedsUnmount] == "true" {
+			log.Info("Mountpoint Pod is annotated as 'needs-unmount' - not suitable for a new workload")
+			return false
+		}
 	}
 
-	return mpPod.Annotations[mppod.AnnotationNeedsUnmount] != "true"
+	if mpPod.Labels != nil {
+		if mpPod.Labels[mppod.LabelCSIDriverVersion] != r.mountpointPodConfig.CSIDriverVersion {
+			log.Info("Mountpoint Pod is created with a different CSI Driver version - not suitable for a new workload",
+				"mountpointPodCreatedByCSIDriverVersion", mpPod.Labels[mppod.LabelCSIDriverVersion],
+				"currentCSIDriverVersion", r.mountpointPodConfig.CSIDriverVersion)
+			return false
+		}
+	}
+
+	return true
 }
 
 // errPVCIsNotBoundToAPV is returned when given PVC is not bound to a PV yet.

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -18,11 +18,24 @@ const (
 	LabelMountpointVersion = "s3.csi.aws.com/mountpoint-version"
 	LabelVolumeName        = "s3.csi.aws.com/volume-name"
 	LabelVolumeId          = "s3.csi.aws.com/volume-id"
-	LabelCSIDriverVersion  = "s3.csi.aws.com/mounted-by-csi-driver-version"
+	// LabelCSIDriverVersion specifies the CSI Driver's version used during creation of the Mountpoint Pod.
+	// The controller checks this label against the current CSI Driver version before assigning a new workload to the Mountpoint Pod,
+	// if they differ, the controller won't send new workload to the Mountpoint Pod and instead creates a new one.
+	LabelCSIDriverVersion = "s3.csi.aws.com/mounted-by-csi-driver-version"
 )
 
+// Known list of annotations on Mountpoint Pods.
 const (
+	// AnnotationNeedsUnmount means the Mountpoint Pod scheduled for unmount.
+	// Its the controller's responsibility to annotate a Mountpoint Pod as "needs-unmount" once
+	// it has no workloads assigned to it. The controller ensures to not send new workload after the Mountpoint Pod
+	// annotated with this annotation.
+	// Its the node's responsibility to observe this annotation and perform unmount procedure for the Mountpoint Pod.
 	AnnotationNeedsUnmount = "s3.csi.aws.com/needs-unmount"
+	// AnnotationNoNewWorkload means the Mountpoint Pod shouldn't get a new workload assigned to it.
+	// The existing workloads won't affected with this annotation, and would keep running until termination as per their regular lifecycle.
+	// The controller ensures to not send new workload after the Mountpoint Pod annotated with this annotation.
+	AnnotationNoNewWorkload = "s3.csi.aws.com/no-new-workload"
 )
 
 const CommunicationDirSizeLimit = 10 * 1024 * 1024 // 10MB

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -704,15 +704,10 @@ var _ = Describe("Mountpoint Controller", func() {
 						s3pa = waitForS3PodAttachmentWithFields(expectedFields, s3pa.ResourceVersion, func(g Gomega, s3pa *crdv1beta.MountpointS3PodAttachment) {
 							Expect(findMountpointPodNameForWorkload(s3pa, string(pod3.UID))).ToNot(BeEmpty())
 						})
-						Expect(len(s3pa.Spec.MountpointS3PodAttachments)).To(Equal(2))
-						Expect(findMountpointPodNameForWorkload(s3pa, string(pod1.UID))).NotTo(BeEmpty())
-						Expect(findMountpointPodNameForWorkload(s3pa, string(pod2.UID))).NotTo(BeEmpty())
-						Expect(findMountpointPodNameForWorkload(s3pa, string(pod3.UID))).NotTo(BeEmpty())
 
 						// Verify `pod3` has been assigned to a new Mountpoint Pod
 						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol)
 						Expect(mpPod1.Name).NotTo(Equal(mpPod3.Name))
-						Expect(mpPod2.Name).To(Equal(mpPod2.Name))
 					})
 
 					It("should schedule a new Mountpoint Pod if existing Mountpoint Pod has been created by a different CSI Driver version", func() {
@@ -752,7 +747,6 @@ var _ = Describe("Mountpoint Controller", func() {
 						// Verify `pod3` has been assigned to a new Mountpoint Pod
 						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol)
 						Expect(mpPod1.Name).NotTo(Equal(mpPod3.Name))
-						Expect(mpPod2.Name).To(Equal(mpPod2.Name))
 					})
 
 					It("should schedule a new Mountpoint Pod if existing Mountpoint Pod annotated as 'no-new-workload'", func() {
@@ -791,7 +785,6 @@ var _ = Describe("Mountpoint Controller", func() {
 						// Verify `pod3` has been assigned to a new Mountpoint Pod
 						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol)
 						Expect(mpPod1.Name).NotTo(Equal(mpPod3.Name))
-						Expect(mpPod2.Name).To(Equal(mpPod2.Name))
 					})
 				})
 			})

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -707,6 +707,46 @@ var _ = Describe("Mountpoint Controller", func() {
 						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol)
 						Expect(mpPod1.Name).NotTo(Equal(mpPod3.Name))
 					})
+
+					It("should schedule a new Mountpoint Pod if existing Mountpoint Pod has been created by a different CSI Driver version", func() {
+						vol := createVolume()
+						vol.bind()
+
+						pod1 := createPod(withPVC(vol.pvc))
+						pod2 := createPod(withPVC(vol.pvc))
+						pod3 := createPod(withPVC(vol.pvc))
+						pod1.schedule(testNode)
+						pod2.schedule(testNode)
+
+						expectedFields := defaultExpectedFields(testNode, vol.pv)
+						s3pa := waitForS3PodAttachmentWithFields(expectedFields, "")
+
+						Expect(len(s3pa.Spec.MountpointS3PodAttachments)).To(Equal(1))
+						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod1, vol)
+						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod2, vol)
+						Expect(mpPod1.Name).To(Equal(mpPod2.Name))
+
+						// Now patch `mpPod1` as it was created with a different CSI Driver version
+						differentCSIDriverVersion := "1.0.0.different"
+						mpPod1.label(mppod.LabelCSIDriverVersion, differentCSIDriverVersion)
+
+						// Schedule `pod3` to the same node
+						pod3.schedule(testNode)
+
+						// Wait until `pod3` is assigned
+						s3pa = waitForS3PodAttachmentWithFields(expectedFields, s3pa.ResourceVersion, func(g Gomega, s3pa *crdv1beta.MountpointS3PodAttachment) {
+							Expect(findMountpointPodNameForWorkload(s3pa, string(pod3.UID))).ToNot(BeEmpty())
+						})
+						Expect(len(s3pa.Spec.MountpointS3PodAttachments)).To(Equal(2))
+						Expect(findMountpointPodNameForWorkload(s3pa, string(pod1.UID))).NotTo(BeEmpty())
+						Expect(findMountpointPodNameForWorkload(s3pa, string(pod2.UID))).NotTo(BeEmpty())
+						Expect(findMountpointPodNameForWorkload(s3pa, string(pod3.UID))).NotTo(BeEmpty())
+
+						// Verify `pod3` has been assigned to a new Mountpoint Pod
+						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol)
+						Expect(mpPod1.Name).NotTo(Equal(mpPod3.Name))
+						Expect(mpPod2.Name).To(Equal(mpPod2.Name))
+					})
 				})
 			})
 
@@ -935,6 +975,20 @@ func (p *testPod) succeed() {
 
 	waitForObject(p.Pod, func(g Gomega, pod *corev1.Pod) {
 		g.Expect(pod.Status.Phase).To(Equal(corev1.PodSucceeded))
+	})
+}
+
+// label adds given `key` and `value` as a label to `testPod`.
+func (p *testPod) label(key, value string) {
+	patch := client.MergeFrom(p.DeepCopy())
+	if p.Labels == nil {
+		p.Labels = make(map[string]string)
+	}
+	p.Labels[key] = value
+
+	Expect(k8sClient.Patch(ctx, p.Pod, patch)).To(Succeed())
+	waitForObject(p.Pod, func(g Gomega, pod *corev1.Pod) {
+		g.Expect(pod.Labels).To(HaveKeyWithValue(key, value))
 	})
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
