### PR TITLE
Split end-to-end tests and controller tests into two GitHub workflows

### DIFF
--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -17,7 +17,7 @@ jobs:
     needs: ["build_matrix"]
     strategy:
       matrix:
-        kubernetes-version: ${{ fromJson(needs.build_matrix.outputs.matrix).*.'kubernetes-version' }}
+        kubernetes-version: ${{ fromJson(needs.build_matrix.outputs.matrix).*.kubernetes-version }}
     runs-on: ubuntu-latest
     env:
       # envtest doesn't support all versions, here K8S_VERSION is a full version like 1.28.13,

--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -1,0 +1,44 @@
+name: Controller tests
+
+on:
+  push:
+    branches: ["main", "feature/*"]
+  pull_request:
+    branches: ["main", "feature/*"]
+  merge_group:
+    types: ["checks_requested"]
+
+jobs:
+  build_matrix:
+    name: Build Matrix
+    uses: ./.github/workflows/build_matrix.yaml
+
+  test:
+    needs: ["build_matrix"]
+    strategy:
+      matrix:
+        kubernetes-version: ${{ fromJson(needs.build_matrix.outputs.matrix).*.['kubernetes-version'] }}
+    runs-on: ubuntu-latest
+    env:
+      # envtest doesn't support all versions, here K8S_VERSION is a full version like 1.28.13,
+      # and in order to get latest supported version by envtest we convert it to 1.28.
+      K8S_VERSION: "${{ matrix.kubernetes-version }}"
+      ENVTEST_K8S_VERSION: "${K8S_VERSION%.*}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+
+      - name: Install tools
+        env:
+          ACTION: "install_tools"
+        run: |
+          tests/e2e-kubernetes/scripts/run.sh
+
+      - name: Run Controller Tests
+        run: |
+          make e2e-controller

--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: ["main", "feature/*"]
   merge_group:
-    types: ["checks_requested"]
+    branches: ["main"]
 
 jobs:
   build_matrix:
@@ -17,7 +17,7 @@ jobs:
     needs: ["build_matrix"]
     strategy:
       matrix:
-        kubernetes-version: ${{ fromJson(needs.build_matrix.outputs.matrix).*.kubernetes-version }}
+        kubernetes-version: ${{ fromJson(needs.build_matrix.outputs.matrix)['kubernetes-version'] }}
     runs-on: ubuntu-latest
     env:
       # envtest doesn't support all versions, here K8S_VERSION is a full version like 1.28.13,

--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -17,7 +17,7 @@ jobs:
     needs: ["build_matrix"]
     strategy:
       matrix:
-        kubernetes-version: ${{ fromJson(needs.build_matrix.outputs.matrix).*.['kubernetes-version'] }}
+        kubernetes-version: ${{ fromJson(needs.build_matrix.outputs.matrix).*.'kubernetes-version' }}
     runs-on: ubuntu-latest
     env:
       # envtest doesn't support all versions, here K8S_VERSION is a full version like 1.28.13,

--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -6,14 +6,14 @@ on:
   pull_request:
     branches: ["main", "feature/*"]
   merge_group:
-    branches: ["main"]
+    types: ["checks_requested"]
 
 jobs:
   build_matrix:
     name: Build Matrix
     uses: ./.github/workflows/build_matrix.yaml
 
-  test:
+  controller_test:
     needs: ["build_matrix"]
     strategy:
       matrix:
@@ -32,12 +32,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
-
-      - name: Install tools
-        env:
-          ACTION: "install_tools"
-        run: |
-          tests/e2e-kubernetes/scripts/run.sh
 
       - name: Run Controller Tests
         run: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -76,10 +76,7 @@ jobs:
       ARCH: "${{ matrix.arch }}"
       AMI_FAMILY: "${{ matrix.family }}"
       TAG: "untested_${{ inputs.ref }}"
-      # envtest doesn't support all versions, here K8S_VERSION is a full version like 1.28.13,
-      # and in order to get latest supported version by envtest we convert it to 1.28.
       K8S_VERSION: "${{ matrix.kubernetes-version }}"
-      ENVTEST_K8S_VERSION: "${K8S_VERSION%.*}"
       SELINUX_MODE: "${{ matrix.selinux-mode }}"
     steps:
       - name: Checkout
@@ -105,9 +102,6 @@ jobs:
           ACTION: "install_tools"
         run: |
           tests/e2e-kubernetes/scripts/run.sh
-      - name: Run Controller Tests
-        run: |
-          make e2e-controller
       - name: Create cluster
         env:
           ACTION: "create_cluster"


### PR DESCRIPTION
With recent additions to both end-to-end and controller tests, the overall CI time greatly increased. Now we split them into two independent GitHub workflows to allow running in parallel without waiting each other.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
