### PR TITLE
Change source mountpoint name to be MP Pod Name instead of UID

### DIFF
--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -112,9 +112,8 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 		klog.Errorf("Failed to wait for Mountpoint Pod to be ready for %q: %v", target, err)
 		return fmt.Errorf("Failed to wait for Mountpoint Pod to be ready for %q: %w", target, err)
 	}
-	mpPodUID := string(pod.UID)
-	source := filepath.Join(pm.sourceMountDir, mpPodUID)
-	unlockMountpointPod := lockMountpointPod(mpPodUID)
+	source := filepath.Join(pm.sourceMountDir, mpPodName)
+	unlockMountpointPod := lockMountpointPod(mpPodName)
 	defer unlockMountpointPod()
 
 	isTargetMountPoint, err := pm.IsMountPoint(target)

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -123,7 +123,7 @@ func setup(t *testing.T) *testCtx {
 		pvMountOptions: pvMountOptions,
 		mpPodName:      mpPodName,
 		mpPodUID:       mpPodUID,
-		sourcePath:     filepath.Join(sourceMountDir, mpPodUID),
+		sourcePath:     filepath.Join(sourceMountDir, mpPodName),
 	}
 
 	testCrd := crdv1beta.MountpointS3PodAttachment{

--- a/pkg/driver/node/mounter/pod_unmounter_test.go
+++ b/pkg/driver/node/mounter/pod_unmounter_test.go
@@ -135,7 +135,7 @@ func TestHandleS3PodAttachmentUpdate(t *testing.T) {
 				err := os.MkdirAll(commDir, 0750)
 				assert.NoError(t, err)
 
-				err = os.MkdirAll(filepath.Join(sourceMountDir, string(tt.pod.UID)), 0750)
+				err = os.MkdirAll(filepath.Join(sourceMountDir, string(tt.pod.Name)), 0750)
 				assert.NoError(t, err)
 			}
 
@@ -246,7 +246,7 @@ func TestCleanupDanglingMounts(t *testing.T) {
 				err := os.MkdirAll(commDir, 0750)
 				assert.NoError(t, err)
 
-				err = os.MkdirAll(filepath.Join(sourceMountDir, string(pod.UID)), 0750)
+				err = os.MkdirAll(filepath.Join(sourceMountDir, string(pod.Name)), 0750)
 				assert.NoError(t, err)
 			}
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Change source mountpoint name to be MP Pod Name instead of UID. UID was previously used because we didn't make get MP Pod call during credential refresh. This is no longer needed as we now always get MP Pod Spec. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
