### PR TITLE
Add IsMountpoint check in PodUnmounter

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -118,14 +118,14 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 
 		s3paCache := setupS3PodAttachmentCache(config, stopCh, nodeID, kubernetesVersion)
 
-		unmounter := mounter.NewPodUnmounter(nodeID, mpMounter, podWatcher, credProvider, mounter.SourceMountDir)
+		unmounter := mounter.NewPodUnmounter(nodeID, mpMounter, podWatcher, credProvider)
 
 		podWatcher.AddEventHandler(cache.ResourceEventHandlerFuncs{UpdateFunc: unmounter.HandleMountpointPodUpdate})
 
 		go unmounter.StartPeriodicCleanup(stopCh)
 
 		mounterImpl, err = mounter.NewPodMounter(podWatcher, s3paCache, credProvider, mpMounter, nil, nil,
-			kubernetesVersion, nodeID, mounter.SourceMountDir)
+			kubernetesVersion, nodeID)
 		if err != nil {
 			klog.Fatalln(err)
 		}

--- a/pkg/driver/node/mounter/mounter.go
+++ b/pkg/driver/node/mounter/mounter.go
@@ -4,6 +4,7 @@ package mounter
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/awslabs/aws-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/awslabs/aws-s3-csi-driver/pkg/mountpoint"
@@ -31,4 +32,9 @@ func MountS3Path() string {
 		mountS3Path = defaultMountS3Path
 	}
 	return mountS3Path
+}
+
+// Internal S3 CSI Driver directory for source mount points
+func SourceMountDir(kubeletPath string) string {
+	return filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
 }

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -67,13 +67,16 @@ func setup(t *testing.T) *testCtx {
 	t.Cleanup(cancel)
 
 	kubeletPath := t.TempDir()
+	// Eval symlinks on `kubeletPath` as `mount.NewFakeMounter` also does that and we rely on
+	// `mount.List()` to compare mount points and they need to be the same.
+	parentDir, err := filepath.EvalSymlinks(filepath.Dir(kubeletPath))
+	assert.NoError(t, err)
+	kubeletPath = filepath.Join(parentDir, filepath.Base(kubeletPath))
 	t.Setenv("KUBELET_PATH", kubeletPath)
 
 	// Chdir to `kubeletPath` so `mountoptions.{Recv, Send}` can use relative paths to Unix sockets
 	// to overcome `bind: invalid argument`.
 	t.Chdir(kubeletPath)
-
-	sourceMountDir := t.TempDir()
 
 	bucketName := "test-bucket"
 	podUID := uuid.New().String()
@@ -89,19 +92,12 @@ func setup(t *testing.T) *testCtx {
 		kubeletPath,
 		fmt.Sprintf("pods/%s/volumes/kubernetes.io~csi/%s/mount", podUID, pvName),
 	)
+	sourceMountDir := mounter.SourceMountDir(kubeletPath)
+	sourcePath := filepath.Join(sourceMountDir, mpPodName)
 
 	// Same behaviour as Kubernetes, see https://github.com/kubernetes/kubernetes/blob/8f8c94a04d00e59d286fe4387197bc62c6a4f374/pkg/volume/csi/csi_mounter.go#L211-L215
-	err := os.MkdirAll(filepath.Dir(targetPath), 0750)
+	err = os.MkdirAll(filepath.Dir(targetPath), 0750)
 	assert.NoError(t, err)
-
-	// Eval symlinks on `targetPath` as `mount.NewFakeMounter` also does that and we rely on
-	// `mount.List()` to compare mount points and they need to be the same.
-	parentDir, err := filepath.EvalSymlinks(filepath.Dir(targetPath))
-	assert.NoError(t, err)
-	targetPath = filepath.Join(parentDir, filepath.Base(targetPath))
-	parentDir, err = filepath.EvalSymlinks(filepath.Dir(sourceMountDir))
-	assert.NoError(t, err)
-	sourceMountDir = filepath.Join(parentDir, filepath.Base(sourceMountDir))
 
 	client := fake.NewClientset()
 	fakeMounter := mount.NewFakeMounter(nil)
@@ -123,7 +119,7 @@ func setup(t *testing.T) *testCtx {
 		pvMountOptions: pvMountOptions,
 		mpPodName:      mpPodName,
 		mpPodUID:       mpPodUID,
-		sourcePath:     filepath.Join(sourceMountDir, mpPodName),
+		sourcePath:     sourcePath,
 	}
 
 	testCrd := crdv1beta.MountpointS3PodAttachment{
@@ -171,7 +167,7 @@ func setup(t *testing.T) *testCtx {
 	assert.NoError(t, err)
 
 	podMounter, err := mounter.NewPodMounter(podWatcher, s3paCache, credProvider, mpmounter.NewWithMount(fakeMounter), mountSyscall,
-		mountBindSyscall, testK8sVersion, nodeName, sourceMountDir)
+		mountBindSyscall, testK8sVersion, nodeName)
 	assert.NoError(t, err)
 
 	testCtx.podMounter = podMounter

--- a/pkg/driver/node/mounter/pod_unmounter.go
+++ b/pkg/driver/node/mounter/pod_unmounter.go
@@ -21,12 +21,11 @@ const cleanupInterval = 2 * time.Minute
 
 // PodUnmounter handles unmounting of Mountpoint Pods and cleanup of associated resources
 type PodUnmounter struct {
-	nodeID         string
-	mount          *mpmounter.Mounter
-	kubeletPath    string
-	sourceMountDir string
-	podWatcher     *watcher.Watcher
-	credProvider   *credentialprovider.Provider
+	nodeID       string
+	mount        *mpmounter.Mounter
+	kubeletPath  string
+	podWatcher   *watcher.Watcher
+	credProvider *credentialprovider.Provider
 }
 
 // NewPodUnmounter creates a new PodUnmounter instance with the given parameters
@@ -35,15 +34,13 @@ func NewPodUnmounter(
 	mount *mpmounter.Mounter,
 	podWatcher *watcher.Watcher,
 	credProvider *credentialprovider.Provider,
-	sourceMountDir string,
 ) *PodUnmounter {
 	return &PodUnmounter{
-		nodeID:         nodeID,
-		mount:          mount,
-		kubeletPath:    util.KubeletPath(),
-		sourceMountDir: sourceMountDir,
-		podWatcher:     podWatcher,
-		credProvider:   credProvider,
+		nodeID:       nodeID,
+		mount:        mount,
+		kubeletPath:  util.KubeletPath(),
+		podWatcher:   podWatcher,
+		credProvider: credProvider,
 	}
 }
 
@@ -68,25 +65,82 @@ func (u *PodUnmounter) unmountSourceForPod(mpPod *corev1.Pod) {
 	unlockMountpointPod := lockMountpointPod(mpPod.Name)
 	defer unlockMountpointPod()
 
-	klog.Infof("Found Mountpoint Pod %s (UID: %s) with %s annotation, unmounting it", mpPod.Name, mpPodUID, mppod.AnnotationNeedsUnmount)
+	source := filepath.Join(SourceMountDir(u.kubeletPath), mpPod.Name)
 
+	// Check mountpoint status and handle special cases
+	isMountpoint, err := u.checkMountpointAndCleanup(source)
+	if err != nil {
+		klog.Errorf("Error during handling mountpoint check for %s: %v", source, err)
+		return
+	}
+	if !isMountpoint {
+		return
+	}
+
+	klog.Infof("Found Mountpoint Pod %s (UID: %s) with %s annotation, unmounting it", mpPod.Name, mpPodUID, mppod.AnnotationNeedsUnmount)
+	if err := u.unmountAndCleanupPod(mpPod, source); err != nil {
+		klog.Errorf("Failed to unmount and cleanup pod %s: %v", mpPod.Name, err)
+		return
+	}
+
+	klog.Infof("Successfully unmounted Mountpoint Pod - %s", mpPod.Name)
+}
+
+// checkMountpointAndCleanup validates if the source path is a healthy mountpoint
+// and performs cleanup for invalid or corrupted mountpoints.
+//
+// Returns:
+//   - bool: true if the source is a valid mountpoint that needs unmounting,
+//     false if it's not a mountpoint or was cleaned up
+//   - error: any errors encountered during validation or cleanup
+//
+// The function will attempt cleanup in the following cases:
+//   - When the mountpoint is corrupted (will attempt unmount and directory removal)
+//   - When the path exists but is not a mountpoint (will remove the directory)
+func (u *PodUnmounter) checkMountpointAndCleanup(source string) (bool, error) {
+	isMountpoint, err := u.mount.CheckMountpoint(source)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		if u.mount.IsMountpointCorrupted(err) {
+			klog.Warningf("Corrupted mountpoint - unmounting %s", source)
+			if err := u.unmountAndRemoveDir(source); err != nil {
+				return false, err
+			}
+			return false, nil
+		}
+		klog.Errorf("Failed to check if source %s is Mountpoint mount: %v", source, err)
+		return false, err
+	}
+
+	if !isMountpoint {
+		if err := os.Remove(source); err != nil {
+			klog.Errorf("Failed to remove source directory %q: %v", source, err)
+		}
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// unmountAndCleanupPod performs clean Mountpoint Pod unmount including exit file creation,
+// unmounting, and credential cleanup
+func (u *PodUnmounter) unmountAndCleanupPod(mpPod *corev1.Pod, source string) error {
+	mpPodUID := string(mpPod.UID)
 	podPath := filepath.Join(u.kubeletPath, "pods", mpPodUID)
-	source := filepath.Join(u.sourceMountDir, mpPod.Name)
 	volumeId := mpPod.Labels[mppod.LabelVolumeId]
 
 	if err := u.writeExitFile(podPath); err != nil {
 		klog.Errorf("Failed to write exit file for Mountpoint Pod (UID: %s): %v", mpPodUID, err)
-		return
+		return err
 	}
 
-	if err := u.unmountAndCleanup(source); err != nil {
-		return
+	if err := u.unmountAndRemoveDir(source); err != nil {
+		return err
 	}
-	klog.Infof("Successfully unmounted Mountpoint Pod - %s", mpPod.Name)
 
-	if err := u.cleanupCredentials(volumeId, mpPodUID, podPath, source); err != nil {
-		return
-	}
+	return u.cleanupCredentials(volumeId, mpPodUID, podPath, source)
 }
 
 // writeExitFile creates an exit file in the pod's directory to signal Mountpoint Pod termination
@@ -102,10 +156,10 @@ func (u *PodUnmounter) writeExitFile(podPath string) error {
 	return nil
 }
 
-// unmountAndCleanup unmounts the source directory and removes it
+// unmountAndRemoveDir unmounts the source directory and removes it
 // source: Path to the source directory to unmount
 // Returns error if unmounting or cleanup fails
-func (u *PodUnmounter) unmountAndCleanup(source string) error {
+func (u *PodUnmounter) unmountAndRemoveDir(source string) error {
 	if err := u.mount.Unmount(source); err != nil {
 		klog.Errorf("Failed to unmount source %q: %v", source, err)
 		return err
@@ -154,14 +208,15 @@ func (u *PodUnmounter) StartPeriodicCleanup(stopCh <-chan struct{}) {
 // CleanupDanglingMounts scans the source mount directory for potential dangling mounts
 // and cleans them up. It also unmounts any Mountpoint Pods marked for unmounting.
 func (u *PodUnmounter) CleanupDanglingMounts() error {
-	entries, err := os.ReadDir(u.sourceMountDir)
+	sourceMountDir := SourceMountDir(u.kubeletPath)
+	entries, err := os.ReadDir(sourceMountDir)
 	if err != nil {
 		// Source mount dir does not exists, meaning there aren't any mounts
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 
-		klog.Errorf("Failed to read source mount directory %q: %v", u.sourceMountDir, err)
+		klog.Errorf("Failed to read source mount directory %q: %v", sourceMountDir, err)
 		return err
 	}
 
@@ -171,12 +226,20 @@ func (u *PodUnmounter) CleanupDanglingMounts() error {
 		}
 
 		mpPodName := file.Name()
-		source := filepath.Join(u.sourceMountDir, mpPodName)
+		source := filepath.Join(sourceMountDir, mpPodName)
 		mpPod, err := u.podWatcher.Get(mpPodName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.V(4).Infof("Mountpoint Pod %s not found, will unmount and delete source folder %s", mpPodName, source)
-				if err := u.unmountAndCleanup(source); err != nil {
+
+				// Check mountpoint status and handle special cases
+				isMountPoint, err := u.checkMountpointAndCleanup(source)
+				if !isMountPoint || err != nil {
+					continue
+				}
+
+				// Can only do unmount and remove directory as MP Pod does not exist.
+				if err := u.unmountAndRemoveDir(source); err != nil {
 					klog.Errorf("Failed to cleanup dangling mount %s: %v", source, err)
 				}
 				continue

--- a/pkg/driver/node/mounter/pod_unmounter_test.go
+++ b/pkg/driver/node/mounter/pod_unmounter_test.go
@@ -55,13 +55,26 @@ func countUnmountCalls(mounter *mount.FakeMounter) int {
 	return unmountCalls
 }
 
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return info.IsDir()
+}
+
 func TestHandleS3PodAttachmentUpdate(t *testing.T) {
 	tests := []struct {
-		name          string
-		nodeID        string
-		pod           *corev1.Pod
-		unmountError  error
-		expectUnmount bool
+		name                  string
+		nodeID                string
+		pod                   *corev1.Pod
+		unmountError          error
+		createSourcePath      bool
+		isMountPoint          bool
+		expectUnmount         bool
+		expectSourcePathExist bool
 	}{
 		{
 			name:   "different node",
@@ -79,7 +92,10 @@ func TestHandleS3PodAttachmentUpdate(t *testing.T) {
 					NodeName: "different-node",
 				},
 			},
-			expectUnmount: false,
+			createSourcePath:      true,
+			isMountPoint:          true,
+			expectUnmount:         false,
+			expectSourcePathExist: true,
 		},
 		{
 			name:   "same node with unmount annotation",
@@ -100,7 +116,10 @@ func TestHandleS3PodAttachmentUpdate(t *testing.T) {
 					NodeName: nodeName,
 				},
 			},
-			expectUnmount: true,
+			createSourcePath:      true,
+			isMountPoint:          true,
+			expectUnmount:         true,
+			expectSourcePathExist: false,
 		},
 		{
 			name:   "same node without unmount annotation",
@@ -115,29 +134,73 @@ func TestHandleS3PodAttachmentUpdate(t *testing.T) {
 					NodeName: nodeName,
 				},
 			},
-			expectUnmount: false,
+			createSourcePath:      true,
+			isMountPoint:          true,
+			expectUnmount:         false,
+			expectSourcePathExist: true,
+		},
+		{
+			name:   "same node with unmount annotation, not mountpoint",
+			nodeID: nodeName,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: mountpointPodNamespace,
+					UID:       "uid1",
+					Annotations: map[string]string{
+						mppod.AnnotationNeedsUnmount: "true",
+					},
+					Labels: map[string]string{
+						mppod.LabelVolumeId: "vol1",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: nodeName,
+				},
+			},
+			createSourcePath:      true,
+			isMountPoint:          false,
+			expectUnmount:         false,
+			expectSourcePathExist: false,
+		},
+		{
+			name:   "same node with unmount annotation, no source directory",
+			nodeID: nodeName,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: mountpointPodNamespace,
+					UID:       "uid1",
+					Annotations: map[string]string{
+						mppod.AnnotationNeedsUnmount: "true",
+					},
+					Labels: map[string]string{
+						mppod.LabelVolumeId: "vol1",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: nodeName,
+				},
+			},
+			createSourcePath:      false,
+			isMountPoint:          false,
+			expectUnmount:         false,
+			expectSourcePathExist: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			kubeletPath := t.TempDir()
+			parentDir, err := filepath.EvalSymlinks(filepath.Dir(kubeletPath))
+			assert.NoError(t, err)
+			kubeletPath = filepath.Join(parentDir, filepath.Base(kubeletPath))
 			t.Setenv("KUBELET_PATH", kubeletPath)
 			t.Chdir(kubeletPath)
 
-			sourceMountDir := t.TempDir()
+			sourceMountDir := mounter.SourceMountDir(kubeletPath)
 
 			podWatcher, client := setupPodWatcher(t, tt.pod)
-
-			if tt.pod != nil {
-				podPath := filepath.Join(kubeletPath, "pods", string(tt.pod.UID))
-				commDir := mppod.PathOnHost(podPath)
-				err := os.MkdirAll(commDir, 0750)
-				assert.NoError(t, err)
-
-				err = os.MkdirAll(filepath.Join(sourceMountDir, string(tt.pod.Name)), 0750)
-				assert.NoError(t, err)
-			}
 
 			fakeMounter := mount.NewFakeMounter(nil)
 			if tt.unmountError != nil {
@@ -146,11 +209,28 @@ func TestHandleS3PodAttachmentUpdate(t *testing.T) {
 				}
 			}
 
+			if tt.pod != nil {
+				podPath := filepath.Join(kubeletPath, "pods", string(tt.pod.UID))
+				commDir := mppod.PathOnHost(podPath)
+				err := os.MkdirAll(commDir, 0750)
+				assert.NoError(t, err)
+
+				if tt.createSourcePath {
+					sourcePath := filepath.Join(sourceMountDir, string(tt.pod.Name))
+					err = os.MkdirAll(sourcePath, 0750)
+					assert.NoError(t, err)
+
+					if tt.isMountPoint {
+						fakeMounter.Mount("mountpoint-s3", sourcePath, "fuse", []string{})
+					}
+				}
+			}
+
 			credProvider := credentialprovider.New(client.CoreV1(), func() (string, error) {
 				return dummyIMDSRegion, nil
 			})
 
-			unmounter := mounter.NewPodUnmounter(tt.nodeID, mpmounter.NewWithMount(fakeMounter), podWatcher, credProvider, sourceMountDir)
+			unmounter := mounter.NewPodUnmounter(tt.nodeID, mpmounter.NewWithMount(fakeMounter), podWatcher, credProvider)
 			unmounter.HandleMountpointPodUpdate(nil, tt.pod)
 
 			unmountCalls := countUnmountCalls(fakeMounter)
@@ -159,6 +239,7 @@ func TestHandleS3PodAttachmentUpdate(t *testing.T) {
 				expectedUnmounts = 1
 			}
 			assert.Equals(t, expectedUnmounts, unmountCalls)
+			assert.Equals(t, tt.expectSourcePathExist, dirExists(filepath.Join(sourceMountDir, string(tt.pod.Name))))
 		})
 	}
 }
@@ -229,26 +310,20 @@ func TestCleanupDanglingMounts(t *testing.T) {
 				},
 			},
 			unmountError:  errors.New("unmount error"),
-			expectedCalls: 1,
+			expectedCalls: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			kubeletPath := t.TempDir()
+			parentDir, err := filepath.EvalSymlinks(filepath.Dir(kubeletPath))
+			assert.NoError(t, err)
+			kubeletPath = filepath.Join(parentDir, filepath.Base(kubeletPath))
 			t.Setenv("KUBELET_PATH", kubeletPath)
 			t.Chdir(kubeletPath)
-			sourceMountDir := t.TempDir()
 
-			for _, pod := range tt.pods {
-				podPath := filepath.Join(kubeletPath, "pods", string(pod.UID))
-				commDir := mppod.PathOnHost(podPath)
-				err := os.MkdirAll(commDir, 0750)
-				assert.NoError(t, err)
-
-				err = os.MkdirAll(filepath.Join(sourceMountDir, string(pod.Name)), 0750)
-				assert.NoError(t, err)
-			}
+			sourceMountDir := mounter.SourceMountDir(kubeletPath)
 
 			fakeMounter := mount.NewFakeMounter(nil)
 			if tt.unmountError != nil {
@@ -257,13 +332,26 @@ func TestCleanupDanglingMounts(t *testing.T) {
 				}
 			}
 
+			for _, pod := range tt.pods {
+				podPath := filepath.Join(kubeletPath, "pods", string(pod.UID))
+				commDir := mppod.PathOnHost(podPath)
+				err := os.MkdirAll(commDir, 0750)
+				assert.NoError(t, err)
+
+				sourcePath := filepath.Join(sourceMountDir, string(pod.Name))
+				err = os.MkdirAll(sourcePath, 0750)
+				assert.NoError(t, err)
+
+				fakeMounter.Mount("mountpoint-s3", sourcePath, "fuse", []string{})
+			}
+
 			podWatcher, client := setupPodWatcher(t, tt.pods...)
 			credProvider := credentialprovider.New(client.CoreV1(), func() (string, error) {
 				return dummyIMDSRegion, nil
 			})
 
-			unmounter := mounter.NewPodUnmounter(nodeName, mpmounter.NewWithMount(fakeMounter), podWatcher, credProvider, sourceMountDir)
-			err := unmounter.CleanupDanglingMounts()
+			unmounter := mounter.NewPodUnmounter(nodeName, mpmounter.NewWithMount(fakeMounter), podWatcher, credProvider)
+			err = unmounter.CleanupDanglingMounts()
 			assert.NoError(t, err)
 
 			unmountCalls := countUnmountCalls(fakeMounter)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Currently, there is error message during unmount when there are multiple `HandleMountpointPodUpdate` method invocations. Fix this by first checking if `sourcePath` is mountpoint or not and handle special cases accordingly.

Also, refactor `SourceMountDir` to be dependent on `kubeletpath`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
