### PR TITLE
Use MountpointPodID in credential context

### DIFF
--- a/pkg/driver/node/credentialprovider/provider.go
+++ b/pkg/driver/node/credentialprovider/provider.go
@@ -58,8 +58,11 @@ type ProvideContext struct {
 	// EnvPath is basepath to use while creating environment variables to pass Mountpoint.
 	EnvPath string
 
-	PodID    string
-	VolumeID string
+	// WorkloadPodID is workload Pod UID
+	WorkloadPodID string
+	// MountpointPodID is Mountpoint Pod UID
+	MountpointPodID string
+	VolumeID        string
 
 	// The following values are provided from CSI volume context.
 	AuthenticationSource     AuthenticationSource
@@ -82,6 +85,21 @@ func (ctx *ProvideContext) SetWriteAndEnvPath(writePath, envPath string) {
 // SetServiceAccountEKSRoleARN sets `ServiceAccountEKSRoleARN` for `ctx`.
 func (ctx *ProvideContext) SetServiceAccountEKSRoleARN(roleArn string) {
 	ctx.ServiceAccountEKSRoleARN = roleArn
+}
+
+// SetMountpointPodID sets `MountpointPodID` for `ctx`.
+func (ctx *ProvideContext) SetMountpointPodID(mpPodUID string) {
+	ctx.MountpointPodID = mpPodUID
+}
+
+// GetCredentialPodID returns the appropriate Pod ID for credential operations.
+// When MountpointPodID is not empty string it returns MountpointPodID (for pod mounter mounts),
+// otherwise returns workload Pod ID (for systemd mounts).
+func (p *ProvideContext) GetCredentialPodID() string {
+	if p.MountpointPodID != "" {
+		return p.MountpointPodID
+	}
+	return p.WorkloadPodID
 }
 
 // A CleanupContext contains parameters needed to clean up credentials after volume unmount.

--- a/pkg/driver/node/credentialprovider/provider_driver.go
+++ b/pkg/driver/node/credentialprovider/provider_driver.go
@@ -122,7 +122,7 @@ func provideContainerCredentialsFromDriver(provideCtx ProvideContext, containerA
 // These variables injected to driver's Pod from a configured Kubernetes secret if configured, here it basically
 // created a AWS Profile from these credentials in [provideCtx.WritePath].
 func provideLongTermCredentialsFromDriver(provideCtx ProvideContext, accessKeyID, secretAccessKey, sessionToken string) (envprovider.Environment, error) {
-	prefix := driverLevelLongTermCredentialsProfilePrefix(provideCtx.PodID, provideCtx.VolumeID)
+	prefix := driverLevelLongTermCredentialsProfilePrefix(provideCtx.GetCredentialPodID(), provideCtx.VolumeID)
 	awsProfile, err := awsprofile.Create(awsprofile.Settings{
 		Basepath: provideCtx.WritePath,
 		Prefix:   prefix,

--- a/pkg/driver/node/credentialprovider/provider_pod.go
+++ b/pkg/driver/node/credentialprovider/provider_pod.go
@@ -67,7 +67,7 @@ func (c *Provider) provideFromPod(ctx context.Context, provideCtx ProvideContext
 		defaultRegion = region
 	}
 
-	podID := provideCtx.PodID
+	podID := provideCtx.GetCredentialPodID()
 	volumeID := provideCtx.VolumeID
 	if podID == "" {
 		return nil, status.Error(codes.InvalidArgument, "Missing Pod info. Please make sure to enable `podInfoOnMountCompat`, see "+podLevelCredentialsDocsPage)

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -205,7 +205,7 @@ func TestPodMounter(t *testing.T) {
 				err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
-					PodID:                testCtx.podUID,
+					WorkloadPodID:        testCtx.podUID,
 				}, args, testCtx.fsGroup, testCtx.pvMountOptions)
 				if err != nil {
 					log.Println("Mount failed", err)
@@ -250,8 +250,8 @@ func TestPodMounter(t *testing.T) {
 			}()
 
 			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
-				VolumeID: testCtx.volumeID,
-				PodID:    testCtx.podUID,
+				VolumeID:      testCtx.volumeID,
+				WorkloadPodID: testCtx.podUID,
 			}, mountpoint.ParseArgs(nil), testCtx.fsGroup, testCtx.pvMountOptions)
 			assert.NoError(t, err)
 		})
@@ -265,7 +265,7 @@ func TestPodMounter(t *testing.T) {
 				err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
 					AuthenticationSource: credentialprovider.AuthenticationSourceDriver,
 					VolumeID:             testCtx.volumeID,
-					PodID:                testCtx.podUID,
+					WorkloadPodID:        testCtx.podUID,
 				}, args, testCtx.fsGroup, testCtx.pvMountOptions)
 				if err != nil {
 					log.Println("Mount failed", err)
@@ -311,8 +311,8 @@ func TestPodMounter(t *testing.T) {
 			for range 5 {
 				err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath,
 					credentialprovider.ProvideContext{
-						VolumeID: testCtx.volumeID,
-						PodID:    testCtx.podUID,
+						VolumeID:      testCtx.volumeID,
+						WorkloadPodID: testCtx.podUID,
 					}, mountpoint.ParseArgs(nil), testCtx.fsGroup, testCtx.pvMountOptions)
 				assert.NoError(t, err)
 			}
@@ -349,8 +349,8 @@ func TestPodMounter(t *testing.T) {
 			}()
 
 			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
-				VolumeID: testCtx.volumeID,
-				PodID:    testCtx.podUID,
+				VolumeID:      testCtx.volumeID,
+				WorkloadPodID: testCtx.podUID,
 			}, mountpoint.ParseArgs(nil), testCtx.fsGroup, testCtx.pvMountOptions)
 			assert.NoError(t, err)
 
@@ -388,8 +388,8 @@ func TestPodMounter(t *testing.T) {
 			testCtx.s3paCache.TestItems = []crdv1beta.MountpointS3PodAttachment{testCrd2}
 
 			err = testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
-				VolumeID: testCtx.volumeID,
-				PodID:    testCtx.podUID,
+				VolumeID:      testCtx.volumeID,
+				WorkloadPodID: testCtx.podUID,
 			}, mountpoint.ParseArgs(nil), testCtx.fsGroup, testCtx.pvMountOptions)
 			assert.NoError(t, err)
 
@@ -415,8 +415,8 @@ func TestPodMounter(t *testing.T) {
 			}()
 
 			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
-				VolumeID: testCtx.volumeID,
-				PodID:    testCtx.podUID,
+				VolumeID:      testCtx.volumeID,
+				WorkloadPodID: testCtx.podUID,
 			}, mountpoint.ParseArgs(nil), testCtx.fsGroup, testCtx.pvMountOptions)
 			if err == nil {
 				t.Errorf("mount shouldn't succeeded if Mountpoint does not receive the mount options")
@@ -454,8 +454,8 @@ func TestPodMounter(t *testing.T) {
 			}()
 
 			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
-				VolumeID: testCtx.volumeID,
-				PodID:    testCtx.podUID,
+				VolumeID:      testCtx.volumeID,
+				WorkloadPodID: testCtx.podUID,
 			}, mountpoint.ParseArgs(nil), testCtx.fsGroup, testCtx.pvMountOptions)
 			if err == nil {
 				t.Errorf("mount shouldn't succeeded if Mountpoint fails to start")
@@ -494,8 +494,8 @@ func TestPodMounter(t *testing.T) {
 			}()
 
 			err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
-				VolumeID: testCtx.volumeID,
-				PodID:    testCtx.podUID,
+				VolumeID:      testCtx.volumeID,
+				WorkloadPodID: testCtx.podUID,
 			}, mountpoint.ParseArgs(nil), testCtx.fsGroup, testCtx.pvMountOptions)
 			if err == nil {
 				t.Errorf("mount shouldn't succeeded if Mountpoint fails to start")
@@ -527,8 +527,8 @@ func TestPodMounter(t *testing.T) {
 		}()
 
 		err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
-			VolumeID: testCtx.volumeID,
-			PodID:    testCtx.podUID,
+			VolumeID:      testCtx.volumeID,
+			WorkloadPodID: testCtx.podUID,
 		}, mountpoint.ParseArgs(nil), testCtx.fsGroup, testCtx.pvMountOptions)
 		assert.NoError(t, err)
 
@@ -550,8 +550,8 @@ func TestPodMounter(t *testing.T) {
 		}()
 
 		err := testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
-			VolumeID: testCtx.volumeID,
-			PodID:    testCtx.podUID,
+			VolumeID:      testCtx.volumeID,
+			WorkloadPodID: testCtx.podUID,
 		}, mountpoint.ParseArgs(nil), testCtx.fsGroup, testCtx.pvMountOptions)
 		assert.NoError(t, err)
 

--- a/pkg/driver/node/mounter/systemd_mounter.go
+++ b/pkg/driver/node/mounter/systemd_mounter.go
@@ -93,7 +93,7 @@ func (m *SystemdMounter) Mount(ctx context.Context, bucketName string, target st
 			klog.V(4).Infof("Mount: Target path %q is a corrupted mount. Trying to unmount.", target)
 			if mntErr := m.Unmount(ctx, target, credentialprovider.CleanupContext{
 				WritePath: credentialCtx.WritePath,
-				PodID:     credentialCtx.PodID,
+				PodID:     credentialCtx.WorkloadPodID,
 				VolumeID:  credentialCtx.VolumeID,
 			}); mntErr != nil {
 				return fmt.Errorf("Unable to unmount the target %q : %v, %v", target, err, mntErr)

--- a/pkg/driver/node/mounter/systemd_mounter_test.go
+++ b/pkg/driver/node/mounter/systemd_mounter_test.go
@@ -54,9 +54,9 @@ func TestS3MounterMount(t *testing.T) {
 	testBucketName := "test-bucket"
 	testTargetPath := filepath.Join(t.TempDir(), "mount")
 	testProvideCtx := credentialprovider.ProvideContext{
-		PodID:     "test-pod",
-		VolumeID:  "test-volume",
-		WritePath: t.TempDir(),
+		WorkloadPodID: "test-pod",
+		VolumeID:      "test-volume",
+		WritePath:     t.TempDir(),
 	}
 
 	testCases := []struct {

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -272,7 +272,7 @@ func credentialProvideContextFromPublishRequest(req *csi.NodePublishVolumeReques
 	bucketRegion, _ := args.Value(mountpoint.ArgRegion)
 
 	return credentialprovider.ProvideContext{
-		PodID:                podID,
+		WorkloadPodID:        podID,
 		VolumeID:             req.GetVolumeId(),
 		AuthenticationSource: authSource,
 		PodNamespace:         volumeCtx[volumecontext.CSIPodNamespace],


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* We are not properly refreshing credentials in PodMounter after PodSharing PR.

- Added `MountpointPodID` to credential context
- Renamed `PodID` to  `WorkloadPodID` in credential context
- Use that as Pod ID if it's not empty string
- Validated manually that credentials are now refreshed correctly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
