### PR TITLE
Add read only cluster access to ReadOnly IAM Role

### DIFF
--- a/tests/e2e-kubernetes/scripts/eksctl.sh
+++ b/tests/e2e-kubernetes/scripts/eksctl.sh
@@ -106,6 +106,12 @@ function eksctl_create_cluster() {
       --arn ${CI_ROLE_ARN} --username admin --group system:masters \
       --no-duplicate-arns
   fi
+
+  # Add read only cluster access to ReadOnly IAM Role
+  READ_ONLY_ARN="arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/ReadOnly"
+  ${BIN} create accessentry --cluster ${CLUSTER_NAME} --region ${REGION} --principal-arn ${READ_ONLY_ARN} --type STANDARD
+  aws eks associate-access-policy --region ${REGION} --cluster-name ${CLUSTER_NAME} --principal-arn ${READ_ONLY_ARN} \
+    --policy-arn arn:${AWS_PARTITION}:eks::aws:cluster-access-policy/AmazonEKSAdminViewPolicy --access-scope type=cluster
 }
 
 function eksctl_delete_cluster() {

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -5,6 +5,7 @@ set -euox pipefail
 ACTION=${ACTION:-}
 REGION=${AWS_REGION}
 
+AWS_PARTITION=$(aws sts get-caller-identity --query Arn --output text | cut -d: -f2)
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 REGISTRY=${REGISTRY:-${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com}
 IMAGE_NAME=${IMAGE_NAME:-}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add read only cluster access to ReadOnly IAM Role to be able to view K8s resources in E2E test clusters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
