### PR TITLE
Ensure to keep track of created resources in end-to-end tests to properly clean them

### DIFF
--- a/tests/e2e-kubernetes/testsuites/mountoptions.go
+++ b/tests/e2e-kubernetes/testsuites/mountoptions.go
@@ -87,6 +87,7 @@ func (t *s3CSIMountOptionsTestSuite) DefineTests(driver storageframework.TestDri
 		resource := createVolumeResource(ctx, l.config, pattern, v1.ReadWriteMany, []string{
 			"allow-other",
 		})
+		l.resources = append(l.resources, resource)
 		expectedMountOptions := []string{
 			"--allow-other",
 			"--debug",
@@ -99,6 +100,7 @@ func (t *s3CSIMountOptionsTestSuite) DefineTests(driver storageframework.TestDri
 			"--debug",
 			"--debug-crt",
 		})
+		l.resources = append(l.resources, resource)
 		expectedMountOptions = []string{
 			"--allow-other",
 			"--debug",
@@ -111,6 +113,7 @@ func (t *s3CSIMountOptionsTestSuite) DefineTests(driver storageframework.TestDri
 			"debug",
 			"debug-crt",
 		})
+		l.resources = append(l.resources, resource)
 		expectedMountOptions = []string{
 			"--allow-other",
 			"--debug",


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
