### PR TITLE
Add dynamic provisioning support and examples for S3 CSI Driver

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3,9 +3,43 @@
 See [the Mountpoint documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md) for
 Mountpoint specific configuration.
 
+## Dynamic Provisioning
+
+The driver supports dynamic provisioning using StorageClass, which allows you to specify the S3 bucket to use for all PVs created with that StorageClass.
+
+To use dynamic provisioning, create a StorageClass that specifies the S3 bucket name:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: s3-bucket-storage
+provisioner: s3.csi.aws.com
+parameters:
+  bucketName: my-custom-bucket
+```
+
+Then create a PVC that references this StorageClass:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: s3-bucket-storage
+```
+
+The CSI driver will automatically create a PV using the bucket specified in the StorageClass.
+
 ## Static Provisioning
 
-The driver only supports Static Provisioning as of today, and you need an existing S3 Bucket to use.
+The driver also supports static provisioning, and you need an existing S3 Bucket to use.
 
 To use Static Provisioning, you should set `storageClassName` field of your PersistentVolume (PV) and PersistentVolumeClaim (PVC) to `""` (empty string).
 Also, in order to make sure no other PVCs can claim your PV, you should define a one-to-one mapping using `claimRef`:

--- a/examples/kubernetes/dynamic_provisioning/README.md
+++ b/examples/kubernetes/dynamic_provisioning/README.md
@@ -1,0 +1,43 @@
+# Dynamic Provisioning Example
+This example shows how to use dynamic provisioning with the Mountpoint for Amazon S3 CSI Driver to create a persistent volume that mounts an S3 bucket.
+
+## Prerequisites
+
+- An existing S3 bucket (the bucket must already exist as the driver doesn't create buckets)
+- Kubernetes cluster with the Mountpoint for Amazon S3 CSI Driver installed
+- Proper IAM permissions to access the S3 bucket
+
+## Configure
+
+Edit [dynamic_provisioning.yaml](dynamic_provisioning.yaml):
+
+- `parameters.bucketName`: Change to the name of your existing S3 bucket
+- If you need to specify the region or other mount options, you can add them later to the PV that gets created
+
+## Deploy
+
+```
+kubectl apply -f examples/kubernetes/dynamic_provisioning/dynamic_provisioning.yaml
+```
+
+## Check the pod is running
+
+```
+kubectl get pod s3-app
+```
+
+## Verify the volume is mounted
+
+```
+kubectl exec -it s3-app -- ls -la /data
+```
+
+You should see the contents of your S3 bucket mounted at `/data`.
+
+## Cleanup
+
+```
+kubectl delete -f examples/kubernetes/dynamic_provisioning/dynamic_provisioning.yaml
+```
+
+Note: Deleting the resources will not delete the S3 bucket, as the CSI driver does not manage bucket lifecycle.

--- a/examples/kubernetes/dynamic_provisioning/dynamic_provisioning.yaml
+++ b/examples/kubernetes/dynamic_provisioning/dynamic_provisioning.yaml
@@ -1,0 +1,37 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: s3-bucket-storage
+provisioner: s3.csi.aws.com
+parameters:
+  bucketName: my-custom-bucket
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: s3-bucket-storage
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: s3-app
+spec:
+  containers:
+  - name: app
+    image: busybox
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: s3-volume
+      mountPath: /data
+  volumes:
+  - name: s3-volume
+    persistentVolumeClaim:
+      claimName: s3-claim

--- a/examples/kubernetes/dynamic_provisioning/rwx_provisioning.yaml
+++ b/examples/kubernetes/dynamic_provisioning/rwx_provisioning.yaml
@@ -1,0 +1,37 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: s3-rwx-storage
+provisioner: s3.csi.aws.com
+parameters:
+  bucketName: my-rwx-bucket
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-rwx-claim
+spec:
+  accessModes:
+    - ReadWriteMany  # Explicitly requesting ReadWriteMany access mode
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: s3-rwx-storage
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: s3-rwx-app
+spec:
+  containers:
+  - name: app
+    image: busybox
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: s3-volume
+      mountPath: /data
+  volumes:
+  - name: s3-volume
+    persistentVolumeClaim:
+      claimName: s3-rwx-claim

--- a/examples/kubernetes/dynamic_provisioning/statefulset_example.yaml
+++ b/examples/kubernetes/dynamic_provisioning/statefulset_example.yaml
@@ -1,0 +1,55 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: s3-bucket-storage
+provisioner: s3.csi.aws.com
+parameters:
+  bucketName: my-statefulset-bucket
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+  - port: 80
+    name: web
+  clusterIP: None
+  selector:
+    app: nginx
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: "nginx"
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: registry.k8s.io/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: s3-storage
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: s3-storage
+    spec:
+      accessModes: [ "ReadWriteMany" ]
+      storageClassName: "s3-bucket-storage"
+      resources:
+        requests:
+          storage: 1Gi

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -124,6 +124,13 @@ func (ns *S3NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 
 	args := mountpoint.ParseArgs(mountpointArgs)
 
+	// Check if subDir is provided in volume context (for StatefulSet support)
+	if subDir, hasSubDir := volumeCtx[volumecontext.SubDir]; hasSubDir && subDir != "" {
+		// Add the --subdirectory flag with the namespace_pvcName value
+		args.Set(mountpoint.ArgSubDir, subDir)
+		klog.V(4).Infof("NodePublishVolume: using subdirectory %s for bucket %s", subDir, bucket)
+	}
+
 	fsGroup := ""
 	pvMountOptions := ""
 	if capMount := volCap.GetMount(); capMount != nil && util.UsePodMounter() {

--- a/pkg/driver/node/volumecontext/volume_context.go
+++ b/pkg/driver/node/volumecontext/volume_context.go
@@ -3,6 +3,7 @@ package volumecontext
 
 const (
 	BucketName           = "bucketName"
+	SubDir               = "subDir"
 	AuthenticationSource = "authenticationSource"
 	STSRegion            = "stsRegion"
 

--- a/pkg/mountpoint/args.go
+++ b/pkg/mountpoint/args.go
@@ -22,6 +22,7 @@ const (
 	ArgFileMode        = "--file-mode"
 	ArgDebug           = "--debug"
 	ArgDebugCRT        = "--debug-crt"
+	ArgSubDir          = "--subdirectory"
 )
 
 // An ArgKey represents the key of an argument.


### PR DESCRIPTION
This pull request introduces dynamic provisioning support for the Mountpoint for Amazon S3 CSI Driver, along with several related updates to the documentation, examples, and driver implementation. The key changes include adding functionality for dynamic provisioning, updating the driver to validate and handle new parameters, and providing examples for various use cases like StatefulSets and ReadWriteMany (RWX) volumes.

### Dynamic Provisioning Support

* **Driver Implementation Updates**:
  - Added support for dynamic provisioning by introducing the `bucketName` parameter in the StorageClass. The driver now validates this parameter and generates a unique subdirectory for volumes to support StatefulSets. (`pkg/driver/controller.go`, [[1]](diffhunk://#diff-4e4f8ad2f057d794bd5842ed50e358451e6e1b3b20e5f2836289665bdfbf5625R21-R117) [[2]](diffhunk://#diff-4e4f8ad2f057d794bd5842ed50e358451e6e1b3b20e5f2836289665bdfbf5625L49-R131) [[3]](diffhunk://#diff-4e4f8ad2f057d794bd5842ed50e358451e6e1b3b20e5f2836289665bdfbf5625L77-R196)
  - Added a `subDir` parameter to the volume context and updated the `NodePublishVolume` method to handle subdirectories for bucket mounting. (`pkg/driver/node/node.go`, [[1]](diffhunk://#diff-dcdc523a320665b7c13a60310742f9284ba4a60c9bfc0e04b1940afae8fa68e0R127-R133); `pkg/driver/node/volumecontext/volume_context.go`, [[2]](diffhunk://#diff-980c02403287a8f6530e27ed874948493a086e40c97c4af276a50d5ecebada1cR6); `pkg/mountpoint/args.go`, [[3]](diffhunk://#diff-1fce912a3e77a68c6ca48d00ff4c675a5b3e09397fcb7af2fdae6210c977c5a6R25)

* **Documentation Updates**:
  - Updated `docs/CONFIGURATION.md` to include a new section on dynamic provisioning, explaining how to configure a StorageClass and PVC for dynamic provisioning.

### Examples for Dynamic Provisioning

* **New Examples**:
  - Added a dynamic provisioning example with a StorageClass, PVC, and a pod writing to an S3 bucket. (`examples/kubernetes/dynamic_provisioning/dynamic_provisioning.yaml`, [examples/kubernetes/dynamic_provisioning/dynamic_provisioning.yamlR1-R37](diffhunk://#diff-6e31c92853801998047be512be815156af215b2fccf44e78eda253cab119a83cR1-R37))
  - Added an RWX-specific example showcasing the use of ReadWriteMany access mode. (`examples/kubernetes/dynamic_provisioning/rwx_provisioning.yaml`, [examples/kubernetes/dynamic_provisioning/rwx_provisioning.yamlR1-R37](diffhunk://#diff-bbd788a9533846041cdc8e8b2fc34a74608d282a77b54eff91555d2fda1590d7R1-R37))
  - Added a StatefulSet example demonstrating dynamic provisioning with multiple replicas sharing a bucket. (`examples/kubernetes/dynamic_provisioning/statefulset_example.yaml`, [examples/kubernetes/dynamic_provisioning/statefulset_example.yamlR1-R55](diffhunk://#diff-e5d4b4fdfcaefe86142127355d2b9d8091fdeb502ddffe066c33f5cc776eb97dR1-R55))

* **Example Documentation**:
  - Created a README for the dynamic provisioning example, detailing prerequisites, configuration, deployment, and cleanup steps. (`examples/kubernetes/dynamic_provisioning/README.md`, [examples/kubernetes/dynamic_provisioning/README.mdR1-R43](diffhunk://#diff-4b8b7671b698e12c2c3c2f0e926a1fc7fb67c99a0d1d0b53d9a0aba526a69700R1-R43))