### PR TITLE
New driver configuration flag: EKS Pod Identity Agent Credentials URI

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -106,6 +106,8 @@ spec:
               value: {{ default "/opt/mountpoint-s3-csi/bin/" .Values.node.mountpointInstallPath }}mount-s3
             - name: KUBELET_PATH
               value: {{ .Values.node.kubeletPath }}
+            - name: EKS_POD_IDENTITY_AGENT_IPV4_TARGET_HOST
+              value: {{ .Values.eksPodIdentityAgent.ipv4TargetHost }}
             - name: CSI_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -106,8 +106,6 @@ spec:
               value: {{ default "/opt/mountpoint-s3-csi/bin/" .Values.node.mountpointInstallPath }}mount-s3
             - name: KUBELET_PATH
               value: {{ .Values.node.kubeletPath }}
-            - name: EKS_POD_IDENTITY_AGENT_IPV4_TARGET_HOST
-              value: {{ .Values.eksPodIdentityAgent.ipv4TargetHost }}
             - name: CSI_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -119,6 +117,8 @@ spec:
               value: pod
             - name: MOUNTPOINT_NAMESPACE
               value: {{ .Values.mountpointPod.namespace }}
+            - name: EKS_POD_IDENTITY_AGENT_CONTAINER_CREDENTIALS_FULL_URI
+              value: {{ .Values.eksPodIdentityAgent.containerCredentialsFullURI }}
             {{- end -}}
             {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -103,8 +103,11 @@ awsAccessSecret:
   accessKey: access_key
   sessionToken: session_token
 
+# The default IPv4 address in the credentials URI is in accordance to the references below:
+# Doc: https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html
+# Source code: https://github.com/aws/eks-pod-identity-agent/blob/8bd71a236522993f02427083e485c83f6ae4fe31/configuration/config.go
 eksPodIdentityAgent:
-  ipv4TargetHost: "169.254.170.23"
+  containerCredentialsFullURI: "http://169.254.170.23/v1/credentials"
 
 experimental:
   podMounter: false

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -103,5 +103,8 @@ awsAccessSecret:
   accessKey: access_key
   sessionToken: session_token
 
+eksPodIdentityAgent:
+  ipv4TargetHost: "169.254.170.23"
+
 experimental:
   podMounter: false

--- a/pkg/driver/node/credentialprovider/provider_test.go
+++ b/pkg/driver/node/credentialprovider/provider_test.go
@@ -362,6 +362,7 @@ func TestProvidingPodLevelCredentials(t *testing.T) {
 
 	t.Run("correct values for EKS Pod Identity", func(t *testing.T) {
 		t.Setenv("MOUNTER_KIND", "pod")
+		t.Setenv("EKS_POD_IDENTITY_AGENT_CONTAINER_CREDENTIALS_FULL_URI", "http://169.254.170.23/v1/credentials")
 
 		clientset := fake.NewSimpleClientset(serviceAccount(testPodServiceAccount, testPodNamespace, map[string]string{}))
 		provider := credentialprovider.New(clientset.CoreV1(), dummyRegionProvider)

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -106,9 +106,11 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 	//   Driver-level (in order):
 	// 	 	1) AWS credentials passed via Kubernetes secrets
 	// 	 	2) IAM Roles for Service Accounts (IRSA)
-	// 	 	3) IAM instance profile
+	// 		3) EKS Pod Identity
+	// 	 	4) IAM instance profile
 	//   Pod-level:
 	// 		1) IAM Roles for Service Accounts (IRSA)
+	// 		2) EKS Pod Identity
 	//
 	// In our test environment we add "AmazonS3FullAccess" policy to our EC2 instances
 	// (see "eksctl-patch.json" and "kops-patch.yaml") which allows Driver-level 3) to work.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* In the previous PR (https://github.com/awslabs/mountpoint-s3-csi-driver/pull/458), the default value of the URI was assumed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
