### PR TITLE
Also check `mount-utils`'s `IsMountPoint` in `CheckMountpoint`

### DIFF
--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -88,6 +88,14 @@ func (m *Mounter) CheckMountpoint(target Target) (bool, error) {
 		return false, err
 	}
 
+	isMountPoint, err := m.mount.IsMountPoint(target)
+	if err != nil {
+		return false, err
+	}
+	if !isMountPoint {
+		return false, nil
+	}
+
 	mountPoints, err := m.mount.List()
 	if err != nil {
 		return false, fmt.Errorf("failed to list mounts for %q: %w", target, err)


### PR DESCRIPTION
Our current check to decide whether given path is a Mountpoint mount does not properly handle bind mounts - which is something we create for Pod sharing. The `IsMountPoint` method from `mount-utils` package properly handles bind mounts as well, and reports any issues correctly. Prior to this change, the CSI Driver was falsely thinking bind mounts are healthy even though they were not.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
