### PR TITLE
Improvements on Mountpoint Pod cleanup with Pod sharing

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -98,7 +98,7 @@ spec:
             - --v={{ .Values.node.logLevel }}
           env:
             - name: CSI_ENDPOINT
-              value: unix:/csi/csi.sock
+              value: unix:{{ trimSuffix "/" .Values.node.kubeletPath }}/plugins/s3.csi.aws.com/csi.sock
             - name: PTMX_PATH
               value: /host/dev/ptmx
             # mount-s3 runs in systemd context, so this is relative to the host
@@ -152,8 +152,6 @@ spec:
               # without needing to mount "/proc/mounts" from host.
               mountPropagation: HostToContainer
               {{- end }}
-            - name: plugin-dir
-              mountPath: /csi
             - name: systemd-bus
               mountPath: /run/systemd/private
             - name: host-dev

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -74,7 +74,7 @@ spec:
             - --v=4
           env:
             - name: CSI_ENDPOINT
-              value: unix:/csi/csi.sock
+              value: unix:/var/lib/kubelet/plugins/s3.csi.aws.com/csi.sock
             - name: PTMX_PATH
               value: /host/dev/ptmx
             # mount-s3 runs in systemd context, so this is relative to the host
@@ -112,8 +112,6 @@ spec:
               # Thanks to this, we can do "is mount point?" checks for volumes provided by the CSI Driver
               # without needing to mount "/proc/mounts" from host.
               mountPropagation: HostToContainer
-            - name: plugin-dir
-              mountPath: /csi
             - name: systemd-bus
               mountPath: /run/systemd/private
             - name: host-dev

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -129,8 +129,8 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 	// there is an existing mount point at `target`.
 	credEnv, authenticationSource, err := pm.provideCredentials(ctx, podPath, string(pod.UID), s3PodAttachment.Spec.WorkloadServiceAccountIAMRoleARN, credentialCtx)
 	if err != nil {
-		klog.Errorf("Failed to provide credentials for %s: %v\n%s", source, err, pm.helpMessageForGettingMountpointLogs(pod))
-		return fmt.Errorf("Failed to provide credentials for %q: %w\n%s", source, err, pm.helpMessageForGettingMountpointLogs(pod))
+		klog.Errorf("Failed to provide credentials for %s: %v. \n%s", source, err, pm.helpMessageForGettingMountpointLogs(pod))
+		return fmt.Errorf("Failed to provide credentials for %q: %w. \n%s", source, err, pm.helpMessageForGettingMountpointLogs(pod))
 	}
 
 	if !isSourceMountPoint {
@@ -238,14 +238,14 @@ func (pm *PodMounter) mountS3AtSource(ctx context.Context, source string, mpPod 
 		Env:        env.List(),
 	})
 	if err != nil {
-		klog.Errorf("Failed to send mount option to Mountpoint Pod %s for %s: %v\n%s", mpPod.Name, source, err, pm.helpMessageForGettingMountpointLogs(mpPod))
-		return fmt.Errorf("Failed to send mount options to Mountpoint Pod %s for %s: %w\n%s", mpPod.Name, source, err, pm.helpMessageForGettingMountpointLogs(mpPod))
+		klog.Errorf("Failed to send mount option to Mountpoint Pod %s for %s: %v. \n%s", mpPod.Name, source, err, pm.helpMessageForGettingMountpointLogs(mpPod))
+		return fmt.Errorf("Failed to send mount options to Mountpoint Pod %s for %s: %w. \n%s", mpPod.Name, source, err, pm.helpMessageForGettingMountpointLogs(mpPod))
 	}
 
 	err = pm.waitForMount(ctx, source, mpPod.Name, podMountErrorPath)
 	if err != nil {
-		klog.Errorf("Failed to wait for Mountpoint Pod %s to be ready for %s: %v\n%s", mpPod.Name, source, err, pm.helpMessageForGettingMountpointLogs(mpPod))
-		return fmt.Errorf("Failed to wait for Mountpoint Pod %s to be ready for %s: %w\n%s", mpPod.Name, source, err, pm.helpMessageForGettingMountpointLogs(mpPod))
+		klog.Errorf("Failed to wait for Mountpoint Pod %s to be ready for %s: %v. \n%s", mpPod.Name, source, err, pm.helpMessageForGettingMountpointLogs(mpPod))
+		return fmt.Errorf("Failed to wait for Mountpoint Pod %s to be ready for %s: %w. \n%s", mpPod.Name, source, err, pm.helpMessageForGettingMountpointLogs(mpPod))
 	}
 
 	// Mountpoint successfully started, so don't unmount the filesystem

--- a/pkg/driver/node/mounter/pod_unmounter.go
+++ b/pkg/driver/node/mounter/pod_unmounter.go
@@ -1,7 +1,9 @@
 package mounter
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -14,10 +16,19 @@ import (
 	"github.com/awslabs/aws-s3-csi-driver/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
 
-const cleanupInterval = 2 * time.Minute
+const (
+	danglingMountpointCleanupInterval = 2 * time.Minute
+
+	waitUntilMountpointIsUnmountedTimeout  = 30 * time.Second
+	waitUntilMountpointIsUnmountedInterval = 5 * time.Second
+
+	waitUntilMountpointIsUnusedTimeout  = 30 * time.Second
+	waitUntilMountpointIsUnusedInterval = 5 * time.Second
+)
 
 // PodUnmounter handles unmounting of Mountpoint Pods and cleanup of associated resources
 type PodUnmounter struct {
@@ -52,145 +63,14 @@ func (u *PodUnmounter) HandleMountpointPodUpdate(old, new any) {
 		return
 	}
 
-	if value, exists := mpPod.Annotations[mppod.AnnotationNeedsUnmount]; exists && value == "true" {
-		u.unmountSourceForPod(mpPod)
-	}
-}
-
-// unmountSourceForPod performs the unmounting process for a specific Mountpoint Pod
-// including cleanup of associated resources
-// mpPod: The Mountpoint Pod to unmount
-func (u *PodUnmounter) unmountSourceForPod(mpPod *corev1.Pod) {
-	mpPodUID := string(mpPod.UID)
-	unlockMountpointPod := lockMountpointPod(mpPod.Name)
-	defer unlockMountpointPod()
-
-	source := filepath.Join(SourceMountDir(u.kubeletPath), mpPod.Name)
-
-	// Check mountpoint status and handle special cases
-	isMountpoint, err := u.checkMountpointAndCleanup(source)
-	if err != nil {
-		klog.Errorf("Error during handling mountpoint check for %s: %v", source, err)
-		return
-	}
-	if !isMountpoint {
-		return
-	}
-
-	klog.Infof("Found Mountpoint Pod %s (UID: %s) with %s annotation, unmounting it", mpPod.Name, mpPodUID, mppod.AnnotationNeedsUnmount)
-	if err := u.unmountAndCleanupPod(mpPod, source); err != nil {
-		klog.Errorf("Failed to unmount and cleanup pod %s: %v", mpPod.Name, err)
-		return
-	}
-
-	klog.Infof("Successfully unmounted Mountpoint Pod - %s", mpPod.Name)
-}
-
-// checkMountpointAndCleanup validates if the source path is a healthy mountpoint
-// and performs cleanup for invalid or corrupted mountpoints.
-//
-// Returns:
-//   - bool: true if the source is a valid mountpoint that needs unmounting,
-//     false if it's not a mountpoint or was cleaned up
-//   - error: any errors encountered during validation or cleanup
-//
-// The function will attempt cleanup in the following cases:
-//   - When the mountpoint is corrupted (will attempt unmount and directory removal)
-//   - When the path exists but is not a mountpoint (will remove the directory)
-func (u *PodUnmounter) checkMountpointAndCleanup(source string) (bool, error) {
-	isMountpoint, err := u.mount.CheckMountpoint(source)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return false, nil
-		}
-		if u.mount.IsMountpointCorrupted(err) {
-			klog.Warningf("Corrupted mountpoint - unmounting %s", source)
-			if err := u.unmountAndRemoveDir(source); err != nil {
-				return false, err
-			}
-			return false, nil
-		}
-		klog.Errorf("Failed to check if source %s is Mountpoint mount: %v", source, err)
-		return false, err
-	}
-
-	if !isMountpoint {
-		if err := os.Remove(source); err != nil {
-			klog.Errorf("Failed to remove source directory %q: %v", source, err)
-		}
-		return false, nil
-	}
-
-	return true, nil
-}
-
-// unmountAndCleanupPod performs clean Mountpoint Pod unmount including exit file creation,
-// unmounting, and credential cleanup
-func (u *PodUnmounter) unmountAndCleanupPod(mpPod *corev1.Pod, source string) error {
-	mpPodUID := string(mpPod.UID)
-	podPath := filepath.Join(u.kubeletPath, "pods", mpPodUID)
-	volumeId := mpPod.Labels[mppod.LabelVolumeId]
-
-	if err := u.writeExitFile(podPath); err != nil {
-		klog.Errorf("Failed to write exit file for Mountpoint Pod (UID: %s): %v", mpPodUID, err)
-		return err
-	}
-
-	if err := u.unmountAndRemoveDir(source); err != nil {
-		return err
-	}
-
-	return u.cleanupCredentials(volumeId, mpPodUID, podPath, source)
-}
-
-// writeExitFile creates an exit file in the pod's directory to signal Mountpoint Pod termination
-// podPath: Path to the pod's directory
-// Returns error if file creation fails
-func (u *PodUnmounter) writeExitFile(podPath string) error {
-	podMountExitPath := mppod.PathOnHost(podPath, mppod.KnownPathMountExit)
-	_, err := os.OpenFile(podMountExitPath, os.O_RDONLY|os.O_CREATE, credentialprovider.CredentialFilePerm)
-	if err != nil {
-		klog.Errorf("Failed to send a exit message to Mountpoint Pod: %s", err)
-		return err
-	}
-	return nil
-}
-
-// unmountAndRemoveDir unmounts the source directory and removes it
-// source: Path to the source directory to unmount
-// Returns error if unmounting or cleanup fails
-func (u *PodUnmounter) unmountAndRemoveDir(source string) error {
-	if err := u.mount.Unmount(source); err != nil {
-		klog.Errorf("Failed to unmount source %q: %v", source, err)
-		return err
-	}
-
-	if err := os.Remove(source); err != nil {
-		klog.Errorf("Failed to remove source directory %q: %v", source, err)
-		return err
-	}
-	return nil
-}
-
-// cleanupCredentials removes credentials associated with the Mountpoint Pod
-func (u *PodUnmounter) cleanupCredentials(volumeId, mpPodUID, podPath, source string) error {
-	err := u.credProvider.Cleanup(credentialprovider.CleanupContext{
-		VolumeID:  volumeId,
-		PodID:     mpPodUID,
-		WritePath: mppod.PathOnHost(podPath, mppod.KnownPathCredentials),
-	})
-	if err != nil {
-		klog.Errorf("Failed to clean up credentials for %s: %v", source, err)
-		return err
-	}
-	return nil
+	u.unmountMountpointPodIfNeeded(mpPod)
 }
 
 // StartPeriodicCleanup begins periodic cleanup of dangling mounts
 // This is needed in case when `HandleMountpointPodUpdate()` missed an update event to trigger cleanup.
 // stopCh: Channel to signal stopping of the cleanup routine
 func (u *PodUnmounter) StartPeriodicCleanup(stopCh <-chan struct{}) {
-	ticker := time.NewTicker(cleanupInterval)
+	ticker := time.NewTicker(danglingMountpointCleanupInterval)
 	defer ticker.Stop()
 
 	for {
@@ -216,8 +96,7 @@ func (u *PodUnmounter) CleanupDanglingMounts() error {
 			return nil
 		}
 
-		klog.Errorf("Failed to read source mount directory %q: %v", sourceMountDir, err)
-		return err
+		return fmt.Errorf("failed to read source mount directory %q: %w", sourceMountDir, err)
 	}
 
 	for _, file := range entries {
@@ -230,30 +109,155 @@ func (u *PodUnmounter) CleanupDanglingMounts() error {
 		mpPod, err := u.podWatcher.Get(mpPodName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				klog.V(4).Infof("Mountpoint Pod %s not found, will unmount and delete source folder %s", mpPodName, source)
-
-				// Check mountpoint status and handle special cases
-				isMountPoint, err := u.checkMountpointAndCleanup(source)
-				if !isMountPoint || err != nil {
-					continue
-				}
-
-				// Can only do unmount and remove directory as MP Pod does not exist.
-				if err := u.unmountAndRemoveDir(source); err != nil {
-					klog.Errorf("Failed to cleanup dangling mount %s: %v", source, err)
+				if err := u.unmountAndRemoveMountpointSource(source); err != nil {
+					klog.Errorf("Failed to unmount and remove Mountpoint %q: %v", source, err)
 				}
 				continue
 			}
 
-			klog.Errorf("Failed to check Mountpoint Pod %s existence: %v", mpPodName, err)
-			return err
+			return fmt.Errorf("failed to check existence of Mountpoint Pod %q: %w", mpPodName, err)
 		}
 
-		// Unmount only if Mountpoint Pod is marked for unmounting
-		if value, exists := mpPod.Annotations[mppod.AnnotationNeedsUnmount]; exists && value == "true" {
-			u.unmountSourceForPod(mpPod)
-		}
+		u.unmountMountpointPodIfNeeded(mpPod)
 	}
 
 	return nil
+}
+
+// unmountMountpointPodIfNeeded unmounts `mpPod` if and only if annotated with "needs-unmount".
+func (u *PodUnmounter) unmountMountpointPodIfNeeded(mpPod *corev1.Pod) {
+	if value, _ := mpPod.Annotations[mppod.AnnotationNeedsUnmount]; value != "true" {
+		// Not marked for unmount, skip it
+		return
+	}
+
+	unlockMountpointPod := lockMountpointPod(mpPod.Name)
+	defer unlockMountpointPod()
+
+	u.cleanUnmount(mpPod)
+}
+
+// cleanUnmount performs a clean unmount for `mpPod`.
+func (u *PodUnmounter) cleanUnmount(mpPod *corev1.Pod) {
+	source := u.mountpointPodSourcePath(mpPod.Name)
+	podPath := u.podPath(string(mpPod.UID))
+
+	// First, write `mount.exit` file to signal a clean exit to Mountpoint Pod, so it exists with zero code.
+	if err := u.writeExitFile(podPath); err != nil {
+		klog.Errorf("Failed to write exit file for Mountpoint Pod %q: %v", mpPod.Name, err)
+		return
+	}
+
+	// Now unmount and remove `source`
+	if err := u.unmountAndRemoveMountpointSource(source); err != nil {
+		klog.Errorf("Failed to unmount and remove Mountpoint %q: %v", source, err)
+	}
+
+	if err := u.cleanupCredentials(mpPod); err != nil {
+		klog.Errorf("Failed to cleanup credentials of Mountpoint Pod %q: %v", mpPod.Name, err)
+		return
+	}
+}
+
+// unmountAndRemoveMountpointSource unmounts Mountpoint at `source`, and then removes the (empty) directory.
+func (u *PodUnmounter) unmountAndRemoveMountpointSource(source string) error {
+	isMountpoint, err := u.mount.CheckMountpoint(source)
+	isCorruptedMountpoint := err != nil && u.mount.IsMountpointCorrupted(err)
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		// Target does not exists, nothing to do
+		return nil
+	} else if err != nil && !isCorruptedMountpoint {
+		return fmt.Errorf("failed to check orphan Mountpoint %q: %w", source, err)
+	}
+
+	if isMountpoint {
+		// If `source` is still a Mountpoint mount, let's wait until all references (i.e., bind mounts) are gone
+		// to ensure to not interrupt any (potentially terminating) workloads.
+		if err := u.waitUntilMountpointIsUnused(source); err != nil {
+			return fmt.Errorf("failed to wait until orphan Mountpoint %q is unused: %w", source, err)
+		}
+	}
+
+	if isMountpoint || isCorruptedMountpoint {
+		if err := u.mount.Unmount(source); err != nil {
+			return fmt.Errorf("failed to unmount orphan Mountpoint %q: %w", source, err)
+		}
+	}
+
+	if err := u.waitUntilMountpointIsUnmounted(source); err != nil {
+		return fmt.Errorf("failed to wait until orphan Mountpoint %q is unmounted: %w", source, err)
+	}
+
+	// Now we know there is no Mountpoint at `source`, and it should be a regular directory.
+	// Let's remove it
+	if err := os.Remove(source); err != nil {
+		return fmt.Errorf("failed to remove source directory of orphan Mountpoint %q: %w", source, err)
+	}
+
+	return nil
+}
+
+// writeExitFile creates an exit file in the pod's directory to signal Mountpoint Pod termination
+// podPath: Path to the pod's directory
+// Returns error if file creation fails
+func (u *PodUnmounter) writeExitFile(podPath string) error {
+	podMountExitPath := mppod.PathOnHost(podPath, mppod.KnownPathMountExit)
+	_, err := os.OpenFile(podMountExitPath, os.O_RDONLY|os.O_CREATE, credentialprovider.CredentialFilePerm)
+	return err
+}
+
+// cleanupCredentials removes credentials associated with the Mountpoint Pod
+func (u *PodUnmounter) cleanupCredentials(mpPod *corev1.Pod) error {
+	return u.credProvider.Cleanup(credentialprovider.CleanupContext{
+		VolumeID:  mpPod.Labels[mppod.LabelVolumeId],
+		PodID:     string(mpPod.UID),
+		WritePath: mppod.PathOnHost(u.podPath(string(mpPod.UID)), mppod.KnownPathCredentials),
+	})
+}
+
+// waitUntilMountpointIsUnused waits until all references to Mountpoint at `source` is gone.
+// Returns an error if condition is not met within `waitUntilMountpointIsUnusedTimeout`.
+func (u *PodUnmounter) waitUntilMountpointIsUnused(source string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), waitUntilMountpointIsUnusedTimeout)
+	defer cancel()
+
+	return wait.PollUntilContextCancel(ctx, waitUntilMountpointIsUnusedInterval, true, func(ctx context.Context) (done bool, err error) {
+		references, err := u.mount.FindReferencesToMountpoint(source)
+		if err != nil {
+			return false, err
+		}
+
+		if len(references) > 0 {
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+// waitUntilMountpointIsUnmounted waits until Mountpoint at `source` is unmounted.
+// Returns an error if condition is not met within `waitUntilMountpointIsUnmountedTimeout`.
+func (u *PodUnmounter) waitUntilMountpointIsUnmounted(source string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), waitUntilMountpointIsUnmountedTimeout)
+	defer cancel()
+
+	return wait.PollUntilContextCancel(ctx, waitUntilMountpointIsUnmountedInterval, true, func(ctx context.Context) (done bool, err error) {
+		isMountpoint, err := u.mount.CheckMountpoint(source)
+		if err != nil {
+			return false, err
+		}
+
+		return !isMountpoint, nil
+	})
+}
+
+// mountpointPodSourcePath returns source path for `mpPodName`.
+// This is the path where `mpPodName` is mounted.
+func (u *PodUnmounter) mountpointPodSourcePath(mpPodName string) string {
+	return filepath.Join(SourceMountDir(u.kubeletPath), mpPodName)
+}
+
+// podPath returns `pod`'s basepath inside kubelet's path.
+func (u *PodUnmounter) podPath(podUID string) string {
+	return filepath.Join(u.kubeletPath, "pods", podUID)
 }

--- a/pkg/driver/node/mounter/systemd_mounter.go
+++ b/pkg/driver/node/mounter/systemd_mounter.go
@@ -171,7 +171,7 @@ func (m *SystemdMounter) Unmount(ctx context.Context, target string, credentialC
 
 func (m *SystemdMounter) credentialWriteAndEnvPath() (writePath string, envPath string) {
 	// This is the plugin directory for CSI driver mounted in the container.
-	writePath = "/csi"
+	writePath = hostPluginDirWithDefault()
 	// This is the plugin directory for CSI driver in the host.
 	envPath = hostPluginDirWithDefault()
 	return writePath, envPath

--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -114,6 +114,11 @@ func (m *Mounter) CheckMountpoint(target Target) (bool, error) {
 	return false, nil
 }
 
+// FindReferencesToMountpoint returns list of references to Mountpoint at `target`.
+func (m *Mounter) FindReferencesToMountpoint(target Target) ([]string, error) {
+	return m.mount.GetMountRefs(target)
+}
+
 // IsMountpointCorrupted returns whether an error returned from [Mounter.CheckMountpoint]
 // indicates the queried mount point is corrupted or not.
 //


### PR DESCRIPTION
- [Do not mount plugin-dir in CSI Driver container](https://github.com/awslabs/mountpoint-s3-csi-driver/commit/8af73383d96162b8ed6e64d4be1e7c5e71c8ec0b) 
The plugin directory (`/var/lib/kubelet/plugins/s3.csi.aws.com/` by default) was mounted in the CSI Driver container at `/csi`.
However, the kubelet directory (`/var/lib/kubelet` by default) is also mounted in the CSI Driver at `/var/lib/kubelet` which already includes the plugin dir.
This was okay so far, but with Pod sharing we started mounting Mountpoint instances in the plugin dir, and also bind mounts from the kubelet dir for the workloads.
This was causing Mountpoint mounts to have references to themselves in both the plugin dir and the kubelet dir, and due that when we try to unmount them,
we were getting "resource is busy" errors, as the kernel was thinking there are still references to the mount

- [Exit with success exit code from Mountpoint Pod if it fail to receive mount options and `mount.exit` file is present](https://github.com/awslabs/mountpoint-s3-csi-driver/commit/5b9d26417f034660c1448eebef22c560e9bccbcd) 

- [Make sure to wait until all references are gone before unmounting Mountpoint in PodUnmounter](https://github.com/awslabs/mountpoint-s3-csi-driver/commit/a1885211fdfe7a9ea9dd93422ddbc60f38f4f4ce) 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
