### PR TITLE
Ensure to close FUSE file descriptor after Mountpoint is terminated

### DIFF
--- a/cmd/aws-s3-csi-mounter/csimounter/csimounter_test.go
+++ b/cmd/aws-s3-csi-mounter/csimounter/csimounter_test.go
@@ -118,8 +118,12 @@ func TestRunningMountpoint(t *testing.T) {
 	})
 
 	t.Run("Fails if file descriptor is invalid", func(t *testing.T) {
+		basepath := t.TempDir()
+		mountErrPath := filepath.Join(basepath, "mount.err")
+
 		_, err := csimounter.Run(csimounter.Options{
 			MountpointPath: mountpointPath,
+			MountErrPath:   mountErrPath,
 			MountOptions: mountoptions.Options{
 				Fd:         -1,
 				BucketName: "test-bucket",

--- a/pkg/mountpoint/runner/foreground.go
+++ b/pkg/mountpoint/runner/foreground.go
@@ -52,6 +52,7 @@ func RunInForeground(opts ForegroundOptions) (ExitCode, []byte, error) {
 	if fuseDev == nil {
 		return 0, nil, fmt.Errorf("runner: passed file descriptor %d is not a valid FUSE file descriptor", opts.Fd)
 	}
+	defer fuseDev.Close()
 
 	mountpointArgs := opts.Args
 


### PR DESCRIPTION
This should fix the flaky unit test https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/15275854246/job/42961924795?pr=483#step:8:122. 

Verified by running `go test ./cmd/aws-s3-csi-mounter/... -count 10000`. Previously, it was failing multiple times even with 1000 runs.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
