### PR TITLE
Cleanup driver-level token files for PodMounter

### DIFF
--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -280,6 +280,7 @@ func (pm *PodMounter) Unmount(ctx context.Context, target string, credentialCtx 
 
 	if isSystemDMountpoint {
 		klog.Infof("Target %q was SystemD Mountpoint. Will cleanup credentials.", target)
+		credentialCtx.SetAsSystemDMountpoint()
 		credentialCtx.WritePath = hostPluginDirWithDefault()
 
 		err = pm.credProvider.Cleanup(credentialCtx)

--- a/pkg/driver/node/mounter/pod_unmounter.go
+++ b/pkg/driver/node/mounter/pod_unmounter.go
@@ -231,6 +231,7 @@ func (u *PodUnmounter) cleanupCredentials(mpPod *corev1.Pod) error {
 		VolumeID:  mpPod.Labels[mppod.LabelVolumeId],
 		PodID:     string(mpPod.UID),
 		WritePath: mppod.PathOnHost(u.podPath(string(mpPod.UID)), mppod.KnownPathCredentials),
+		MountKind: credentialprovider.MountKindPod,
 	})
 }
 

--- a/pkg/driver/node/mounter/systemd_mounter.go
+++ b/pkg/driver/node/mounter/systemd_mounter.go
@@ -148,6 +148,7 @@ func (m *SystemdMounter) Unmount(ctx context.Context, target string, credentialC
 	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	credentialCtx.SetAsSystemDMountpoint()
 	credentialCtx.WritePath, _ = m.credentialWriteAndEnvPath()
 
 	output, err := m.Runner.RunOneshot(timeoutCtx, &system.ExecConfig{

--- a/pkg/driver/node/mounter/systemd_mounter.go
+++ b/pkg/driver/node/mounter/systemd_mounter.go
@@ -96,6 +96,7 @@ func (m *SystemdMounter) Mount(ctx context.Context, bucketName string, target st
 				WritePath: credentialCtx.WritePath,
 				PodID:     credentialCtx.WorkloadPodID,
 				VolumeID:  credentialCtx.VolumeID,
+				MountKind: credentialprovider.MountKindSystemd,
 			}); mntErr != nil {
 				return fmt.Errorf("Unable to unmount the target %q : %v, %v", target, err, mntErr)
 			}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* During cleanup we currently do not remove IRSA and EKS Pod Identity token files for driver-level credentials.

- Add `MountKind` to `CleanupContext` struct
- If `MountKind` is PodMounter then cleanup IRSA and EKS Pod Identity token files

Manually validated cleanup in personal cluster.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
