### PR TITLE
Support using `emptyDir` and `persistentVolumeClaim` as local caches in Mountpoint Pod

### DIFF
--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -48,8 +48,8 @@ type Reconciler struct {
 }
 
 // NewReconciler returns a new reconciler created from `client` and `podConfig`.
-func NewReconciler(client client.Client, podConfig mppod.Config) *Reconciler {
-	creator := mppod.NewCreator(podConfig)
+func NewReconciler(client client.Client, podConfig mppod.Config, log logr.Logger) *Reconciler {
+	creator := mppod.NewCreator(podConfig, log)
 	return &Reconciler{Client: client, mountpointPodConfig: podConfig, mountpointPodCreator: creator, s3paExpectations: newExpectations()}
 }
 

--- a/cmd/aws-s3-csi-controller/main.go
+++ b/cmd/aws-s3-csi-controller/main.go
@@ -75,7 +75,7 @@ func main() {
 		},
 		CSIDriverVersion: version.GetVersion().DriverVersion,
 		ClusterVariant:   cluster.DetectVariant(conf, log),
-	})
+	}, log)
 
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		log.Error(err, "Failed to create controller")

--- a/pkg/driver/node/volumecontext/volume_context.go
+++ b/pkg/driver/node/volumecontext/volume_context.go
@@ -6,6 +6,11 @@ const (
 	AuthenticationSource = "authenticationSource"
 	STSRegion            = "stsRegion"
 
+	Cache                          = "cache"
+	CacheEmptyDirSizeLimit         = "cacheEmptyDirSizeLimit"
+	CacheEmptyDirMedium            = "cacheEmptyDirMedium"
+	CachePersistentVolumeClaimName = "cachePersistentVolumeClaimName"
+
 	MountpointPodServiceAccountName = "mountpointPodServiceAccountName"
 
 	MountpointContainerResourcesRequestsCpu    = "mountpointContainerResourcesRequestsCpu"

--- a/tests/controller/suite_test.go
+++ b/tests/controller/suite_test.go
@@ -101,7 +101,7 @@ var _ = BeforeSuite(func() {
 			ImagePullPolicy: mountpointImagePullPolicy,
 		},
 		CSIDriverVersion: version.GetVersion().DriverVersion,
-	}).SetupWithManager(k8sManager)
+	}, logf.Log).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/tests/e2e-kubernetes/testdriver.go
+++ b/tests/e2e-kubernetes/testdriver.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"maps"
 
 	"github.com/awslabs/mountpoint-s3-csi-driver/tests/e2e-kubernetes/s3client"
 	custom_testsuites "github.com/awslabs/mountpoint-s3-csi-driver/tests/e2e-kubernetes/testsuites"
@@ -29,9 +30,9 @@ type s3Driver struct {
 }
 
 type s3Volume struct {
-	bucketName           string
-	deleteBucket         s3client.DeleteBucketFunc
-	authenticationSource string
+	bucketName       string
+	deleteBucket     s3client.DeleteBucketFunc
+	volumeAttributes map[string]string
 }
 
 var _ framework.TestDriver = &s3Driver{}
@@ -92,9 +93,9 @@ func (d *s3Driver) CreateVolume(ctx context.Context, config *framework.PerTestCo
 	}
 
 	return &s3Volume{
-		bucketName:           bucketName,
-		deleteBucket:         deleteBucket,
-		authenticationSource: custom_testsuites.AuthenticationSourceFromContext(ctx),
+		bucketName:       bucketName,
+		deleteBucket:     deleteBucket,
+		volumeAttributes: custom_testsuites.VolumeAttributesFromContext(ctx),
 	}
 }
 
@@ -102,9 +103,9 @@ func (d *s3Driver) GetPersistentVolumeSource(readOnly bool, fsType string, testV
 	volume, _ := testVolume.(*s3Volume)
 
 	volumeAttributes := map[string]string{"bucketName": volume.bucketName}
-	if volume.authenticationSource != "" {
-		f.Logf("Using authentication source %s for volume", volume.authenticationSource)
-		volumeAttributes["authenticationSource"] = volume.authenticationSource
+	maps.Copy(volumeAttributes, volume.volumeAttributes)
+	if authenticationSource := volumeAttributes["authenticationSource"]; authenticationSource != "" {
+		f.Logf("Using authentication source %s for volume", authenticationSource)
 	}
 
 	return &v1.PersistentVolumeSource{

--- a/tests/e2e-kubernetes/testsuites/cache.go
+++ b/tests/e2e-kubernetes/testsuites/cache.go
@@ -98,7 +98,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		checkWriteToPath(f, pod, first, testWriteSize, seed)
 		checkListingPathWithEntries(f, pod, basePath, []string{"first"})
 		// Test reading multiple times to ensure cached-read works
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			checkReadFromPath(f, pod, first, testWriteSize, seed)
 		}
 
@@ -108,7 +108,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		// Ensure the data still read from the cache - without cache this would fail as its removed from underlying bucket
 		checkReadFromPath(f, pod, first, testWriteSize, seed)
 
-		e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("mkdir %s && cd %s && echo 'second!' > %s", dir, dir, second))
+		e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("mkdir %s && cd %s && echo 'second!' > %s; sync", dir, dir, second))
 		e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("cat %s | grep -q 'second!'", second))
 		checkListingPathWithEntries(f, pod, dir, []string{"second"})
 		checkListingPathWithEntries(f, pod, basePath, []string{"test-dir"})
@@ -134,28 +134,52 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		return pod, bucketName
 	}
 
+	type localCacheKind string
+	const (
+		localCacheUnspecified  localCacheKind = ""
+		localCacheMountOptions                = "localCacheMountOptions"
+		localCacheEmptyDir                    = "localCacheEmptyDir"
+	)
+
 	type cacheTestConfig struct {
-		useLocalCache   bool
+		localCacheKind  localCacheKind
 		useExpressCache bool
 	}
 
 	testCache := func(config cacheTestConfig) {
 		var baseMountOptions []string
 		var basePodModifiers []func(*v1.Pod)
+		var enhanceContext func(context.Context) context.Context
 		var expressCacheBucketName string
 
 		BeforeEach(func(ctx context.Context) {
 			// Reset shared configuration on each run
 			baseMountOptions = nil
 			basePodModifiers = nil
+			enhanceContext = func(ctx context.Context) context.Context { return ctx }
 			expressCacheBucketName = ""
 
-			if config.useLocalCache {
+			switch config.localCacheKind {
+			case localCacheMountOptions:
 				cacheDir := randomCacheDir()
-				basePodModifiers = append(basePodModifiers, func(pod *v1.Pod) {
-					ensureCacheDirExistsInNode(pod, cacheDir)
-				})
+
+				if !IsPodMounter {
+					// This hacky workaround is only needed for `SystemdMounter`,
+					// `PodMounter` will automatically create cache folder within the Mountpoint Pod.
+					basePodModifiers = append(basePodModifiers, func(pod *v1.Pod) {
+						ensureCacheDirExistsInNode(pod, cacheDir)
+					})
+				}
+
 				baseMountOptions = append(baseMountOptions, fmt.Sprintf("cache %s", cacheDir))
+			case localCacheEmptyDir:
+				enhanceContext = func(ctx context.Context) context.Context {
+					return contextWithVolumeAttributes(ctx, map[string]string{
+						"cache":                  "emptyDir",
+						"cacheEmptyDirSizeLimit": "32Mi",
+						"cacheEmptyDirMedium":    "Memory",
+					})
+				}
 			}
 
 			if config.useExpressCache {
@@ -168,6 +192,8 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		})
 
 		It("basic file operations as root", func(ctx context.Context) {
+			ctx = enhanceContext(ctx)
+
 			mountOptions := append(baseMountOptions, "allow-delete")
 			podModifiers := append(basePodModifiers, func(pod *v1.Pod) {
 				pod.Spec.Containers[0].SecurityContext.RunAsUser = ptr.To(root)
@@ -179,6 +205,8 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		})
 
 		It("basic file operations as non-root", func(ctx context.Context) {
+			ctx = enhanceContext(ctx)
+
 			mountOptions := append(baseMountOptions,
 				"allow-delete",
 				"allow-other",
@@ -191,6 +219,8 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		})
 
 		It("two containers in the same pod using the same cache", func(ctx context.Context) {
+			ctx = enhanceContext(ctx)
+
 			testFile := filepath.Join(e2epod.VolumeMountPath1, "helloworld.txt")
 
 			mountOptions := append(baseMountOptions, "allow-delete")
@@ -217,8 +247,10 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		// If we're testing multi-level cache, add two more test cases:
 		// 	1) Ensure it still works if local-cache is wiped out
 		// 	1) Ensure it still works if Express-cache is wiped out
-		if config.useLocalCache && config.useExpressCache {
+		if config.localCacheKind != localCacheUnspecified && config.useExpressCache {
 			It("should use Express cache if local cache is empty", func(ctx context.Context) {
+				ctx = enhanceContext(ctx)
+
 				mountOptions := append(baseMountOptions, "allow-delete")
 				podModifiers := append(basePodModifiers, func(pod *v1.Pod) {
 					pod.Spec.Containers[0].SecurityContext.RunAsUser = ptr.To(root)
@@ -234,7 +266,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 
 				checkWriteToPath(f, pod, first, testWriteSize, seed)
 				// Initial read should work and populate both local and Express cache
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					checkReadFromPath(f, pod, first, testWriteSize, seed)
 				}
 
@@ -243,12 +275,14 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 				e2evolume.VerifyExecInPodSucceed(f, pod, "rm -rf /cache/*")
 
 				// Reading should still work
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					checkReadFromPath(f, pod, first, testWriteSize, seed)
 				}
 			})
 
 			It("should use local cache if Express cache is empty", func(ctx context.Context) {
+				ctx = enhanceContext(ctx)
+
 				mountOptions := append(baseMountOptions, "allow-delete")
 				podModifiers := append(basePodModifiers, func(pod *v1.Pod) {
 					pod.Spec.Containers[0].SecurityContext.RunAsUser = ptr.To(root)
@@ -264,7 +298,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 
 				checkWriteToPath(f, pod, first, testWriteSize, seed)
 				// Initial read should work and populate both local and Express cache
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					checkReadFromPath(f, pod, first, testWriteSize, seed)
 				}
 
@@ -273,7 +307,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 				s3client.New().WipeoutBucket(ctx, expressCacheBucketName)
 
 				// Reading should still work
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					checkReadFromPath(f, pod, first, testWriteSize, seed)
 				}
 			})
@@ -281,9 +315,21 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 	}
 
 	Describe("Cache", func() {
-		Describe("Local", func() {
+		Describe("Local (MountOptions)", func() {
 			testCache(cacheTestConfig{
-				useLocalCache: true,
+				localCacheKind: localCacheMountOptions,
+			})
+		})
+
+		Describe("Local (EmptyDir)", func() {
+			BeforeEach(func() {
+				if !IsPodMounter {
+					Skip("Skipping `emptyDir` cache tests for `SystemdMounter`")
+				}
+			})
+
+			testCache(cacheTestConfig{
+				localCacheKind: localCacheEmptyDir,
 			})
 		})
 
@@ -293,9 +339,22 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 			})
 		})
 
-		Describe("Multi-Level", Serial, func() {
+		Describe("Multi-Level (MountOptions)", Serial, func() {
 			testCache(cacheTestConfig{
-				useLocalCache:   true,
+				localCacheKind:  localCacheMountOptions,
+				useExpressCache: true,
+			})
+		})
+
+		Describe("Multi-Level (EmptyDir)", Serial, func() {
+			BeforeEach(func() {
+				if !IsPodMounter {
+					Skip("Skipping `emptyDir` cache tests for `SystemdMounter`")
+				}
+			})
+
+			testCache(cacheTestConfig{
+				localCacheKind:  localCacheEmptyDir,
 				useExpressCache: true,
 			})
 		})

--- a/tests/e2e-kubernetes/testsuites/pod_sharing.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing.go
@@ -195,7 +195,9 @@ func (t *s3CSIPodSharingTestSuite) DefineTests(driver storageframework.TestDrive
 			framework.ExpectNoError(err)
 			ginkgo.DeferCleanup(idConfig.Cleanup)
 
-			resource := createVolumeResourceWithMountOptions(contextWithAuthenticationSource(ctx, "pod"), l.config, pattern, nil)
+			resource := createVolumeResourceWithMountOptions(contextWithVolumeAttributes(ctx, map[string]string{
+				"authenticationSource": "pod",
+			}), l.config, pattern, nil)
 			l.resources = append(l.resources, resource)
 
 			targetNode, pods := createPodsInTheSameNode(ctx, f, 2, resource, func(index int, pod *v1.Pod) {
@@ -226,7 +228,9 @@ func (t *s3CSIPodSharingTestSuite) DefineTests(driver storageframework.TestDrive
 			ginkgo.DeferCleanup(idConfig2.Cleanup)
 
 			saNames := []string{idConfig1.ServiceAccount.Name, idConfig2.ServiceAccount.Name}
-			resource := createVolumeResourceWithMountOptions(contextWithAuthenticationSource(ctx, "pod"), l.config, pattern, nil)
+			resource := createVolumeResourceWithMountOptions(contextWithVolumeAttributes(ctx, map[string]string{
+				"authenticationSource": "pod",
+			}), l.config, pattern, nil)
 			l.resources = append(l.resources, resource)
 
 			_, pods := createPodsInTheSameNode(ctx, f, 2, resource, func(index int, pod *v1.Pod) {

--- a/tests/e2e-kubernetes/testsuites/util.go
+++ b/tests/e2e-kubernetes/testsuites/util.go
@@ -59,21 +59,18 @@ func genBinDataFromSeed(len int, seed int64) []byte {
 func checkWriteToPath(f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
 	data := genBinDataFromSeed(toWrite, seed)
 	encoded := base64.StdEncoding.EncodeToString(data)
-	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("echo %s | base64 -d | sha256sum", encoded))
-	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("echo %s | base64 -d | dd of=%s bs=%d count=1", encoded, path, toWrite))
+	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("echo %s | base64 -d | dd conv=fsync of=%s bs=%d count=1", encoded, path, toWrite))
 	framework.Logf("written data with sha: %x", sha256.Sum256(data))
 }
 
 func checkWriteToPathFails(f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
 	data := genBinDataFromSeed(toWrite, seed)
 	encoded := base64.StdEncoding.EncodeToString(data)
-	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("echo %s | base64 -d | sha256sum", encoded))
 	e2evolume.VerifyExecInPodFail(f, pod, fmt.Sprintf("echo %s | base64 -d | dd of=%s bs=%d count=1", encoded, path, toWrite), 1)
 }
 
 func checkReadFromPath(f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
 	sum := sha256.Sum256(genBinDataFromSeed(toWrite, seed))
-	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum", path, toWrite))
 	e2evolume.VerifyExecInPodSucceed(f, pod, fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum | grep -Fq %x", path, toWrite, sum))
 }
 
@@ -181,7 +178,7 @@ func createPod(ctx context.Context, client clientset.Interface, namespace string
 	if serviceAccount == "" {
 		serviceAccount = "default"
 	}
-	framework.Logf("Creating Pod %s in %s (SA: %s)", pod.Name, namespace, serviceAccount)
+	framework.Logf("Creating Pod in %s (SA: %s)", namespace, serviceAccount)
 	pod, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("pod Create API error: %w", err)


### PR DESCRIPTION
This PR adds support for using `emptyDir` and `persistentVolumeClaim` volumes as local caches in Mountpoint Pods. 
These new cache configurations can be enabled using `volumeAttributes` of S3 PVs:
```yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  name: s3-pv
spec:
  # ...
  csi:
    driver: s3.csi.aws.com
    volumeAttributes:
      # Cache type
      cache: emptyDir|persistentVolumeClaim

      # Configurations for `emptyDir`
      cacheEmptyDirSizeLimit: 500Mi # optional
      cacheEmptyDirMedium: Memory # optional

      # Configurations for `pvc`
      cachePersistentVolumeClaimName: local-nvme-pvc # required
```

The old way to configure cache using `mountOptions` is still supported, and we'll fall back to creating an `emptyDir` without any limit using the default storage medium automatically if that's the case. But using both is not supported, and the CSI Driver will return an error saying you should remove old configuration from `mountOptions`.

## TODOs in follow-up PRs

- [ ] Add end-to-end tests using EBS CSI Driver to provision EBS volumes to use as cache
- [ ] Improve error messages to include Mountpoint Pod's status, as now Mountpoint Pod could fail to get scheduled if PVC is not bound for example. We should improve error messages in those cases

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
