### PR TITLE
Add end-to-end tests using EBS volumes as local-cache in Mountpoint Pod

### DIFF
--- a/tests/e2e-kubernetes/scripts/eksctl-patch.json
+++ b/tests/e2e-kubernetes/scripts/eksctl-patch.json
@@ -45,6 +45,13 @@
     }
   },
   {
+    "op": "add",
+    "path": "/addons/-",
+    "value": {
+      "name": "aws-ebs-csi-driver"
+    }
+  },
+  {
     "op": "replace",
     "path": "/cloudWatch/clusterLogging",
     "value": {

--- a/tests/e2e-kubernetes/testsuites/cache.go
+++ b/tests/e2e-kubernetes/testsuites/cache.go
@@ -140,10 +140,10 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 
 	type localCacheKind string
 	const (
-		localCacheUnspecified           localCacheKind = ""
-		localCacheMountOptions                         = "localCacheMountOptions"
-		localCacheEmptyDir                             = "localCacheEmptyDir"
-		localCachePersistentVolumeClaim                = "localCachePersistentVolumeClaim"
+		localCacheUnspecified  localCacheKind = ""
+		localCacheMountOptions                = "localCacheMountOptions"
+		localCacheEmptyDir                    = "localCacheEmptyDir"
+		localCacheEBSPVC                      = "localCacheEBSPVC"
 	)
 
 	type cacheTestConfig struct {
@@ -185,7 +185,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 						"cacheEmptyDirMedium":    "Memory",
 					})
 				}
-			case localCachePersistentVolumeClaim:
+			case localCacheEBSPVC:
 				cachePVC := createEBSCacheSCAndPVC(ctx, f)
 				enhanceContext = func(ctx context.Context) context.Context {
 					return contextWithVolumeAttributes(ctx, map[string]string{
@@ -364,7 +364,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 			})
 		})
 
-		Describe("PersistentVolumeClaim (EBS)", Ordered, Serial, func() {
+		Describe("EBS PersistentVolumeClaim", Ordered, Serial, func() {
 			BeforeAll(func(ctx context.Context) {
 				if ebsCSIDriverDaemonSet(ctx, f) == nil {
 					Skip("EBS CSI Driver is not installed, skipping EBS PVC cache tests")
@@ -379,13 +379,13 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 
 			Describe("Local", func() {
 				testCache(cacheTestConfig{
-					localCacheKind: localCachePersistentVolumeClaim,
+					localCacheKind: localCacheEBSPVC,
 				})
 			})
 
 			Describe("Multi-Level", func() {
 				testCache(cacheTestConfig{
-					localCacheKind:  localCachePersistentVolumeClaim,
+					localCacheKind:  localCacheEBSPVC,
 					useExpressCache: true,
 				})
 			})

--- a/tests/e2e-kubernetes/testsuites/cache.go
+++ b/tests/e2e-kubernetes/testsuites/cache.go
@@ -426,6 +426,9 @@ func createEBSCacheSCAndPVC(ctx context.Context, f *framework.Framework) *v1.Per
 		Provisioner:       "ebs.csi.aws.com",
 		VolumeBindingMode: ptr.To(storagev1.VolumeBindingWaitForFirstConsumer),
 		ReclaimPolicy:     ptr.To(v1.PersistentVolumeReclaimDelete),
+		Parameters: map[string]string{
+			"encrypted": "true",
+		},
 	}
 
 	framework.Logf("Creating StorageClass %s with EBS CSI Driver provisioner", scName)


### PR DESCRIPTION
This is done using the EBS CSI Driver with dynamic provisioning.

Follow-up for https://github.com/awslabs/mountpoint-s3-csi-driver/pull/487.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
