### PR TITLE
Support `ephemeral` volume type as local-cache instead of `persistentVolumeClaim` in Mountpoint Pod

### DIFF
--- a/pkg/driver/node/credentialprovider/provider_pod.go
+++ b/pkg/driver/node/credentialprovider/provider_pod.go
@@ -67,14 +67,16 @@ func (c *Provider) provideFromPod(ctx context.Context, provideCtx ProvideContext
 	// 2. Create environment to be returned with common variables (used in both cases: IRSA and EKS PI)
 	podNamespace := provideCtx.PodNamespace
 	podServiceAccount := provideCtx.ServiceAccountName
-	cacheKey := podNamespace + "/" + podServiceAccount
 
 	env := envprovider.Environment{
 		envprovider.EnvEC2MetadataDisabled: "true",
-		envprovider.EnvMountpointCacheKey:  cacheKey,
 	}
 
 	if provideCtx.IsSystemDMountpoint() {
+		cacheKey := podNamespace + "/" + podServiceAccount
+		// This is only needed for `SystemdMounter` to ensure cache folders are not shared accidentally,
+		// with `PodMounter`, cache folders are unique to the Mountpoint Pods.
+		env[envprovider.EnvMountpointCacheKey] = cacheKey
 		env[envprovider.EnvConfigFile] = filepath.Join(provideCtx.EnvPath, "disable-config")
 		env[envprovider.EnvSharedCredentialsFile] = filepath.Join(provideCtx.EnvPath, "disable-credentials")
 	}

--- a/pkg/driver/node/credentialprovider/provider_test.go
+++ b/pkg/driver/node/credentialprovider/provider_test.go
@@ -443,9 +443,6 @@ func TestProvidingPodLevelCredentials(t *testing.T) {
 			"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE": filepath.Join(testEnvPath, testPodLevelEksPodIdentityServiceAccountToken),
 			"AWS_CONTAINER_CREDENTIALS_FULL_URI":     testContainerCredentialsFullURI,
 
-			// Having a unique cache key for namespace/serviceaccount pair
-			"UNSTABLE_MOUNTPOINT_CACHE_KEY": testPodNamespace + "/" + testPodServiceAccount,
-
 			// Disable EC2 credentials
 			"AWS_EC2_METADATA_DISABLED": "true",
 		}, env)
@@ -533,9 +530,6 @@ func TestProvidingPodLevelCredentials(t *testing.T) {
 		assert.Equals(t, envprovider.Environment{
 			"AWS_ROLE_ARN":                testRoleARN,
 			"AWS_WEB_IDENTITY_TOKEN_FILE": filepath.Join(testEnvPath, testPodMounterPodLevelServiceAccountToken),
-
-			// Having a unique cache key for namespace/serviceaccount pair
-			"UNSTABLE_MOUNTPOINT_CACHE_KEY": testPodNamespace + "/" + testPodServiceAccount,
 
 			// Disable EC2 credentials
 			"AWS_EC2_METADATA_DISABLED": "true",

--- a/pkg/driver/node/volumecontext/volume_context.go
+++ b/pkg/driver/node/volumecontext/volume_context.go
@@ -6,10 +6,11 @@ const (
 	AuthenticationSource = "authenticationSource"
 	STSRegion            = "stsRegion"
 
-	Cache                          = "cache"
-	CacheEmptyDirSizeLimit         = "cacheEmptyDirSizeLimit"
-	CacheEmptyDirMedium            = "cacheEmptyDirMedium"
-	CachePersistentVolumeClaimName = "cachePersistentVolumeClaimName"
+	Cache                                = "cache"
+	CacheEmptyDirSizeLimit               = "cacheEmptyDirSizeLimit"
+	CacheEmptyDirMedium                  = "cacheEmptyDirMedium"
+	CacheEphemeralStorageClassName       = "cacheEphemeralStorageClassName"
+	CacheEphemeralStorageResourceRequest = "cacheEphemeralStorageResourceRequest"
 
 	MountpointPodServiceAccountName = "mountpointPodServiceAccountName"
 

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -197,7 +197,7 @@ func (c *Creator) configureLocalCache(mpPod *corev1.Pod, mpContainer *corev1.Con
 
 	if cacheEnabledViaOptions {
 		if cacheType != "" {
-			return errors.New("Cache configured with both `mountOptions` and `volumeAttributes`, please remove the deprecated cache configuragion in `mountOptions`")
+			return errors.New("Cache configured with both `mountOptions` and `volumeAttributes`, please remove the deprecated cache configuration in `mountOptions`")
 		}
 
 		// TODO: Create and link `CACHING.md`.
@@ -277,7 +277,7 @@ func (c *Creator) createCacheVolumeSourceForEphemeral(volumeAttributes map[strin
 			VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"type": "mountpoint-csi-driver-local-cache",
+						"s3.csi.aws.com/type": "local-ephemeral-cache",
 					},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -45,7 +45,7 @@ const (
 	// cacheTypeEmptyDir creates a cache unique to the Mountpoint Pod by using `emptyDir` volume type.
 	// See https://kubernetes.io/docs/concepts/storage/volumes/#emptydir.
 	cacheTypeEmptyDir = "emptyDir"
-	// cacheTypeEphemeral creates a generic ephemeral volume unique to the Mountpoint Pod (with `ReadWriteOncePod` access mode) by using `ephemeral` volume type.
+	// cacheTypeEphemeral creates a generic ephemeral volume unique to the Mountpoint Pod by using `ephemeral` volume type.
 	// See https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes.
 	cacheTypeEphemeral = "ephemeral"
 )
@@ -281,10 +281,7 @@ func (c *Creator) createCacheVolumeSourceForEphemeral(volumeAttributes map[strin
 					},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
-					AccessModes: []corev1.PersistentVolumeAccessMode{
-						// Make sure the Mountpoint Pods is the exclusive owner of this volume
-						corev1.ReadWriteOncePod,
-					},
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 					StorageClassName: &storageClassName,
 					VolumeMode:       ptr.To(corev1.PersistentVolumeFilesystem),
 					Resources: corev1.VolumeResourceRequirements{

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -296,7 +296,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 							},
 						},
 						Spec: corev1.PersistentVolumeClaimSpec{
-							AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod},
+							AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 							StorageClassName: &scName,
 							VolumeMode:       ptr.To(corev1.PersistentVolumeFilesystem),
 							Resources: corev1.VolumeResourceRequirements{

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -292,7 +292,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 					VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"type": "mountpoint-csi-driver-local-cache",
+								"s3.csi.aws.com/type": "local-ephemeral-cache",
 							},
 						},
 						Spec: corev1.PersistentVolumeClaimSpec{

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -1048,7 +1048,7 @@ var _ = Describe("Mountpoint Controller", func() {
 						VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"type": "mountpoint-csi-driver-local-cache",
+									"s3.csi.aws.com/type": "local-ephemeral-cache",
 								},
 							},
 							Spec: corev1.PersistentVolumeClaimSpec{

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -1027,28 +1027,14 @@ var _ = Describe("Mountpoint Controller", func() {
 				waitForObjectToDisappear(mountpointPod.Pod)
 			})
 
-			It("should configure PVC cache", func() {
-				// First create a PVC to use as cache
-				cachePVC := &corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cache-pvc",
-						Namespace: mountpointNamespace,
-					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-						Resources: corev1.VolumeResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceStorage: resource.MustParse("1Gi"),
-							},
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, cachePVC)).To(Succeed())
-				waitForObject(cachePVC)
+			It("should configure ephemeral cache", func() {
+				storageClassName := "test-storage-class"
+				storageRequest := "1Gi"
 
 				vol := createVolume(withVolumeAttributes(map[string]string{
-					"cache":                          "persistentVolumeClaim",
-					"cachePersistentVolumeClaimName": cachePVC.Name,
+					"cache":                                "ephemeral",
+					"cacheEphemeralStorageClassName":       storageClassName,
+					"cacheEphemeralStorageResourceRequest": storageRequest,
 				}))
 				vol.bind()
 
@@ -1058,8 +1044,24 @@ var _ = Describe("Mountpoint Controller", func() {
 				_, mountpointPod := waitAndVerifyS3PodAttachmentAndMountpointPod(testNode, vol, pod)
 
 				verifyLocalCacheVolume(mountpointPod.Pod, corev1.VolumeSource{
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: cachePVC.Name,
+					Ephemeral: &corev1.EphemeralVolumeSource{
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"type": "mountpoint-csi-driver-local-cache",
+								},
+							},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod},
+								StorageClassName: &storageClassName,
+								VolumeMode:       ptr.To(corev1.PersistentVolumeFilesystem),
+								Resources: corev1.VolumeResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse(storageRequest),
+									},
+								},
+							},
+						},
 					},
 				})
 
@@ -1082,10 +1084,39 @@ var _ = Describe("Mountpoint Controller", func() {
 				expectNoS3PodAttachmentWithFields(map[string]string{"NodeName": testNode})
 			})
 
-			It("should fail if PVC cache is configured without claim name", func() {
+			It("should fail if ephemeral cache is configured without a storage class name", func() {
 				vol := createVolume(withVolumeAttributes(map[string]string{
-					"cache": "persistentVolumeClaim",
-					// No cachePersistentVolumeClaimName provided
+					"cache":                                "ephemeral",
+					"cacheEphemeralStorageResourceRequest": "1Gi",
+					// No cacheEphemeralStorageClassName provided
+				}))
+				vol.bind()
+
+				pod := createPod(withPVC(vol.pvc))
+				pod.schedule(testNode)
+
+				expectNoS3PodAttachmentWithFields(map[string]string{"NodeName": testNode})
+			})
+
+			It("should fail if ephemeral cache is configured without a storage resource request", func() {
+				vol := createVolume(withVolumeAttributes(map[string]string{
+					"cache":                          "ephemeral",
+					"cacheEphemeralStorageClassName": "test-storage-class",
+					// No cacheEphemeralStorageResourceRequest provided
+				}))
+				vol.bind()
+
+				pod := createPod(withPVC(vol.pvc))
+				pod.schedule(testNode)
+
+				expectNoS3PodAttachmentWithFields(map[string]string{"NodeName": testNode})
+			})
+
+			It("should fail if ephemeral cache is configured with invalid resource request", func() {
+				vol := createVolume(withVolumeAttributes(map[string]string{
+					"cache":                                "ephemeral",
+					"cacheEphemeralStorageClassName":       "test-storage-class",
+					"cacheEphemeralStorageResourceRequest": "invalid-size",
 				}))
 				vol.bind()
 

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -1052,7 +1052,7 @@ var _ = Describe("Mountpoint Controller", func() {
 								},
 							},
 							Spec: corev1.PersistentVolumeClaimSpec{
-								AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod},
+								AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 								StorageClassName: &storageClassName,
 								VolumeMode:       ptr.To(corev1.PersistentVolumeFilesystem),
 								Resources: corev1.VolumeResourceRequirements{


### PR DESCRIPTION
This PR replaces `persistentVolumeClaim` cache type with `ephemeral`. If configured, the Mountpoint Pod will use a [generic ephemeral volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes) to ensure each Mountpoint Pod gets its own cache volume. 

Given the following configuration:
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: mp-cache-ebs-sc
provisioner: ebs.csi.aws.com
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
parameters:
  type: io2
  iopsPerGB: "256000"
  blockExpress: "true"
---
apiVersion: v1
kind: PersistentVolume
metadata:
  name: s3-pv
spec:
  # ...
  csi:
    driver: s3.csi.aws.com
    volumeHandle: s3-pv
    volumeAttributes:
      bucketName: amzn-s3-demo-bucket
      cache: ephemeral
      cacheEphemeralStorageClassName: mp-cache-ebs-sc # required
      cacheEphemeralStorageResourceRequest: 4Gi       # required
```

The spawned Mountpoint Pod will have the following PVC definition:
```yaml
Name:          mp-rpg92-local-cache
Namespace:     mount-s3
StorageClass:  mp-cache-ebs-sc
Status:        Bound
Volume:        pvc-2450cff6-d694-4e5d-a968-c1373068c9aa
Labels:        type=mountpoint-csi-driver-local-cache
Annotations:   pv.kubernetes.io/bind-completed: yes
               # ...
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      4Gi
Access Modes:  RWO 
VolumeMode:    Filesystem
Used By:       mp-rpg92
```

The PV will be dynamically provisioned by the EBS CSI Driver. The created PVC and PV will be automatically deleted (due to `reclaimPolicy: Delete` in SC) alongside Mountpoint Pod when its no longer in use.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
