### PR TITLE
Slack notifications on PR's and Issues

### DIFF
--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -1,0 +1,35 @@
+name: Slack Notifications
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send issue notification to Slack
+        if: github.event_name == 'issues'
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "action": "${{ github.event.action }}",
+              "issue_url": "${{ github.event.issue.html_url }}"
+            }
+
+      - name: Send pull request notification to Slack
+        if: github.event_name == 'pull_request_target'
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "action": "${{ github.event.action }}",
+              "url": "${{ github.event.pull_request.html_url }}"
+            } 


### PR DESCRIPTION

## Adding Slack notifications on PR's and Issues

**Issue #, if available:**
None

**Description of changes:**
Added a new workflow file `.github/workflows/notify-slack.yaml` that sets up notifications for:

- Issues: When issues are opened, reopened, or edited
- Pull Requests: When PRs are opened, reopened, or updated with new commits


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



