### PR TITLE
Pass AWS_ENDPOINT_URL_STS through to mount-s3.

### DIFF
--- a/pkg/driver/node/envprovider/provider.go
+++ b/pkg/driver/node/envprovider/provider.go
@@ -25,6 +25,7 @@ const (
 	EnvSecretAccessKey                 = "AWS_SECRET_ACCESS_KEY"
 	EnvSessionToken                    = "AWS_SESSION_TOKEN"
 	EnvMountpointCacheKey              = "UNSTABLE_MOUNTPOINT_CACHE_KEY"
+	EnvEndpointURLSTS                  = "AWS_ENDPOINT_URL_STS"
 )
 
 // Key represents an environment variable name.
@@ -42,6 +43,7 @@ var envAllowlist = []Key{
 	EnvRegion,
 	EnvDefaultRegion,
 	EnvSTSRegionalEndpoints,
+	EnvEndpointURLSTS,
 }
 
 // Region returns detected region from environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.


### PR DESCRIPTION
Hi! I've been testing `v2`, against which this PR is made.

One nice-to-have for testing/deploying outside of AWS is customising the `AWS_ENDPOINT_URL_STS` environment variable. This change gets that env var picked up and sent across from the `s3-plugin` container to the mountpoint pods.

(Not at all picky about the const name, feel free to change.)

I confirm this change is licensed under Apache v2 [per the repo](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/330cb964ff3c4e2ea293c1b4159faef677b36ea3/LICENSE).