### PR TITLE
Update outpost_bucket.yaml

### DIFF
--- a/examples/kubernetes/static_provisioning/outpost_bucket.yaml
+++ b/examples/kubernetes/static_provisioning/outpost_bucket.yaml
@@ -19,8 +19,7 @@ spec:
     driver: s3.csi.aws.com # Required
     volumeHandle: s3-csi-driver-volume # Must be unique
     volumeAttributes:
-      bucketName: "arn:aws:s3-outposts:region:account-id:outpost/outpost-id/bucket/bucket-name" # Replace with your Outpost bucket ARN
----
+      bucketName: "arn:aws:s3-outposts:region:accountid:outpost/outpost-id/accesspoint/accesspoint-name" # Replace with your Outpost Access point ARN and not the Bucket ARN
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
Earlier it was mentioned to use AWS Outpost S3 Bucket ARN but it only works with Outpost S3 access point ARN and not with bucket ARN

*Issue #, if available:* Adding the Outpost S3 Bucket ARN would not work and the container would get stuck in container creating state

*Description of changes:* Changed the Bucket ARN to use Outpost Access point ARN instead of Outpost S3 Bucket ARN


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
