### PR TITLE
Add support for reserving headroom for Mountpoint Pods

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
@@ -73,4 +73,6 @@ spec:
               value: {{ .Values.mountpointPod.preemptingPriorityClassName }}
             - name: MOUNTPOINT_HEADROOM_PRIORITY_CLASS_NAME
               value: {{ .Values.mountpointPod.headroomPriorityClassName }}
+            - name: MOUNTPOINT_HEADROOM_IMAGE
+              value: {{ .Values.experimental.headroomPodImage }}
             {{- end }}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
@@ -68,7 +68,9 @@ spec:
               value: {{ .Values.mountpointPod.namespace }}
             - name: MOUNTPOINT_PRIORITY_CLASS_NAME
               value: {{ .Values.mountpointPod.priorityClassName }}
+            {{- if .Values.experimental.reserveHeadroomForMountpointPods }}
             - name: MOUNTPOINT_PREEMPTING_PRIORITY_CLASS_NAME
               value: {{ .Values.mountpointPod.preemptingPriorityClassName }}
             - name: MOUNTPOINT_HEADROOM_PRIORITY_CLASS_NAME
               value: {{ .Values.mountpointPod.headroomPriorityClassName }}
+            {{- end }}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
@@ -68,3 +68,7 @@ spec:
               value: {{ .Values.mountpointPod.namespace }}
             - name: MOUNTPOINT_PRIORITY_CLASS_NAME
               value: {{ .Values.mountpointPod.priorityClassName }}
+            - name: MOUNTPOINT_PREEMPTING_PRIORITY_CLASS_NAME
+              value: {{ .Values.mountpointPod.preemptingPriorityClassName }}
+            - name: MOUNTPOINT_HEADROOM_PRIORITY_CLASS_NAME
+              value: {{ .Values.mountpointPod.headroomPriorityClassName }}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/mount-s3-priority.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/mount-s3-priority.yaml
@@ -23,7 +23,7 @@ globalDefault: false
 description: >-
     Preempting priority class for Mountpoint Pods.
     It has the highest possible value for non-builtin PriorityClasses to ensure Mountpoint Pods get scheduled quickly and not evicted first in case of a resource pressure.
-    Mountpoint Pods spawned with this priority class by default if "Reserving headroom for Mountpoint Pods" feature is enabled.
+    Mountpoint Pods are spawned with this priority class by default if "Reserving headroom for Mountpoint Pods" feature is enabled.
     See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/HEADROOM_FOR_MPPOD.md for more details.
 
 ---
@@ -39,4 +39,3 @@ description: >-
     See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/HEADROOM_FOR_MPPOD.md for more details.
 
 {{- end }}
-

--- a/charts/aws-mountpoint-s3-csi-driver/templates/mount-s3-priority.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/mount-s3-priority.yaml
@@ -10,7 +10,7 @@ description: >-
     It has the highest possible value for non-builtin PriorityClasses to ensure Mountpoint Pods get scheduled quickly and not evicted first in case of a resource pressure.
     It will not cause other Pods to be preempted.
 
-{{- if .Values.experimental.reserveHeadroomForMountpointPods -}}
+{{ if .Values.experimental.reserveHeadroomForMountpointPods -}}
 
 ---
 apiVersion: scheduling.k8s.io/v1
@@ -35,5 +35,5 @@ description: >-
     Default priority class for Headroom Pods.
     It has a negative priority to allow Mountpoint Pods to evict them.
 
-{{- end -}}
+{{- end }}
 

--- a/charts/aws-mountpoint-s3-csi-driver/templates/mount-s3-priority.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/mount-s3-priority.yaml
@@ -23,6 +23,8 @@ globalDefault: false
 description: >-
     Preempting priority class for Mountpoint Pods.
     It has the highest possible value for non-builtin PriorityClasses to ensure Mountpoint Pods get scheduled quickly and not evicted first in case of a resource pressure.
+    Mountpoint Pods spawned with this priority class by default if "Reserving headroom for Mountpoint Pods" feature is enabled.
+    See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/HEADROOM_FOR_MPPOD.md for more details.
 
 ---
 apiVersion: scheduling.k8s.io/v1
@@ -34,6 +36,7 @@ globalDefault: false
 description: >-
     Default priority class for Headroom Pods.
     It has a negative priority to allow Mountpoint Pods to evict them.
+    See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/HEADROOM_FOR_MPPOD.md for more details.
 
 {{- end }}
 

--- a/charts/aws-mountpoint-s3-csi-driver/templates/mount-s3-priority.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/mount-s3-priority.yaml
@@ -9,3 +9,31 @@ description: >-
     Default priority class for Mountpoint Pods.
     It has the highest possible value for non-builtin PriorityClasses to ensure Mountpoint Pods get scheduled quickly and not evicted first in case of a resource pressure.
     It will not cause other Pods to be preempted.
+
+{{- if .Values.experimental.reserveHeadroomForMountpointPods -}}
+
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: mount-s3-preempting-critical
+value: 1000000000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: >-
+    Preempting priority class for Mountpoint Pods.
+    It has the highest possible value for non-builtin PriorityClasses to ensure Mountpoint Pods get scheduled quickly and not evicted first in case of a resource pressure.
+
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: mount-s3-headroom
+value: -1000
+globalDefault: false
+description: >-
+    Default priority class for Headroom Pods.
+    It has a negative priority to allow Mountpoint Pods to evict them.
+
+{{- end -}}
+

--- a/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -52,6 +52,14 @@ rules:
   - apiGroups: ["s3.csi.aws.com"]
     resources: ["mountpoints3podattachments"]
     verbs: ["create", "delete", "update", "get", "watch", "list"]
+{{- if .Values.experimental.reserveHeadroomForMountpointPods }}
+  # If `reserveHeadroomForMountpointPods` is enabled, the CSI Driver needs to add labels and remove scheduling gates
+  # from the Workload Pods, therefore, it needs cluster-wide patch permission on pods.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["patch"]
+{{- end }}
+
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -55,6 +55,7 @@ rules:
 {{- if .Values.experimental.reserveHeadroomForMountpointPods }}
   # If `reserveHeadroomForMountpointPods` is enabled, the CSI Driver needs to add labels and remove scheduling gates
   # from the Workload Pods, therefore, it needs cluster-wide patch permission on pods.
+  # See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/HEADROOM_FOR_MPPOD.md for more details.
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["patch"]

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -117,7 +117,7 @@ eksPodIdentityAgent:
 supportLegacySystemDMounts: true
 
 experimental:
-  # Enables support for `experimental.s3.csi.aws.com/reserve-headroom-for-mppod` scheduling gate on the Workload Pods.
+  # Enables support for `s3.csi.aws.com/reserve-headroom-for-mppod` scheduling gate on the Workload Pods.
   # See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/HEADROOM_FOR_MPPOD.md for more details.
   reserveHeadroomForMountpointPods: false
   headroomPodImage: public.ecr.aws/eks-distro/kubernetes/pause:3.10

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -120,3 +120,4 @@ experimental:
   # Enables support for `experimental.s3.csi.aws.com/reserve-headroom-for-mppod` scheduling gate on the Workload Pods.
   # See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/HEADROOM_FOR_MPPOD.md for more details.
   reserveHeadroomForMountpointPods: false
+  headroomPodImage: public.ecr.aws/eks-distro/kubernetes/pause:3.10

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -118,5 +118,5 @@ supportLegacySystemDMounts: true
 
 experimental:
   # Enables support for `experimental.s3.csi.aws.com/reserve-headroom-for-mppod` scheduling gate on the Workload Pods.
-  # TODO: Add documentation.
+  # See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/HEADROOM_FOR_MPPOD.md for more details.
   reserveHeadroomForMountpointPods: false

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -89,6 +89,8 @@ controller:
 mountpointPod:
   namespace: mount-s3
   priorityClassName: mount-s3-critical
+  preemptingPriorityClassName: mount-s3-preempting-critical
+  headroomPriorityClassName: mount-s3-headroom
 
 nameOverride: ""
 fullnameOverride: ""
@@ -113,3 +115,8 @@ eksPodIdentityAgent:
 # or if you've migrated all workloads using S3 volumes after upgrading to v2.
 # TODO: Remove this in v3 as systemd mount support will be discontinued
 supportLegacySystemDMounts: true
+
+experimental:
+  # Enables support for `experimental.s3.csi.aws.com/reserve-headroom-for-mppod` scheduling gate on the Workload Pods.
+  # TODO: Add documentation.
+  reserveHeadroomForMountpointPods: false

--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -170,8 +170,8 @@ func (r *Reconciler) reconcileWorkloadPod(ctx context.Context, pod *corev1.Pod) 
 			if i == 0 {
 				err = r.labelWorkloadPodForHeadroomPod(ctx, pod, log)
 				if err != nil {
-					errs = append(errs, err)
-					continue
+					log.Error(err, "Failed to label Workload Pod for Headroom Pods")
+					return reconcile.Result{}, err
 				}
 			}
 

--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -907,7 +907,12 @@ func (r *Reconciler) createHeadroomPodForMountpointPod(ctx context.Context, work
 		return err
 	}
 
-	hrPod = r.mountpointPodCreator.HeadroomPod(workloadPod, pv)
+	hrPod, err = r.mountpointPodCreator.HeadroomPod(workloadPod, pv)
+	if err != nil {
+		log.Error(err, "Failed to create Headroom Pod Spec")
+		return err
+	}
+
 	err = r.Create(ctx, hrPod)
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {

--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -618,7 +618,7 @@ func (r *Reconciler) spawnMountpointPod(
 ) (*corev1.Pod, error) {
 	log.Info("Spawning Mountpoint Pod")
 
-	mpPod, err := r.mountpointPodCreator.Create(workloadPod.Spec.NodeName, pv)
+	mpPod, err := r.mountpointPodCreator.MountpointPod(workloadPod.Spec.NodeName, pv, mppod.DefaultPriorityClass)
 	if err != nil {
 		log.Error(err, "Failed to create Mountpoint Pod Spec")
 		return nil, err

--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -82,7 +82,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	if r.isMountpointPod(pod) {
+	if r.isInMountpointNamespace(pod) {
+		if mppod.IsHeadroomPod(pod) {
+			// Nothing to do here, `reconcileWorkloadPod` takes care of spawning and deleting Headroom Pods.
+			log.V(debugLevel).Info("Headroom Pod updated",
+				"headroomPod", pod.Name,
+				"status", pod.Status.Phase)
+			return reconcile.Result{}, nil
+		}
+
 		return r.reconcileMountpointPod(ctx, pod)
 	}
 
@@ -953,10 +961,8 @@ func (r *Reconciler) unlabelWorkloadPodForHeadroomPod(ctx context.Context, workl
 	return nil
 }
 
-// isMountpointPod returns whether given `pod` is a Mountpoint Pod.
-// It currently checks namespace of `pod`.
-func (r *Reconciler) isMountpointPod(pod *corev1.Pod) bool {
-	// TODO: Do we need to perform any additional check here?
+// isInMountpointNamespace returns whether given `pod` is in the Mountpoint namespace.
+func (r *Reconciler) isInMountpointNamespace(pod *corev1.Pod) bool {
 	return pod.Namespace == r.mountpointPodConfig.Namespace
 }
 

--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -133,8 +133,8 @@ func (r *Reconciler) reconcileWorkloadPod(ctx context.Context, pod *corev1.Pod) 
 	}
 
 	scheduled := isPodScheduled(pod)
-	needsHeadroomForMountpointPod := mppod.ShouldReserveHeadroomForMountpointPod(pod)
-	hasHeadroomPods := mppod.WorkloadHasLabelPodForHeadroomPod(pod)
+	needsHeadroomForMountpointPod := r.isHeadroomForMountpointPodsFeatureEnabled() && mppod.ShouldReserveHeadroomForMountpointPod(pod)
+	hasHeadroomPods := r.isHeadroomForMountpointPodsFeatureEnabled() && mppod.WorkloadHasLabelPodForHeadroomPod(pod)
 	if !scheduled && !needsHeadroomForMountpointPod && !hasHeadroomPods {
 		log.V(debugLevel).Info("Pod is not scheduled to a node yet - ignoring")
 		return reconcile.Result{}, nil
@@ -1006,6 +1006,12 @@ func (r *Reconciler) shouldDeleteHeadroomPodForTheWorkloadPod(workloadPod *corev
 // isInMountpointNamespace returns whether given `pod` is in the Mountpoint namespace.
 func (r *Reconciler) isInMountpointNamespace(pod *corev1.Pod) bool {
 	return pod.Namespace == r.mountpointPodConfig.Namespace
+}
+
+// isHeadroomForMountpointPodsFeatureEnabled returns whether the experimental feature-flag for reserving headroom for Mountpoint Pods enabled.
+func (r *Reconciler) isHeadroomForMountpointPodsFeatureEnabled() bool {
+	return r.mountpointPodConfig.HeadroomPriorityClassName != "" &&
+		r.mountpointPodConfig.PreemptingPriorityClassName != ""
 }
 
 // extractCSISpecFromPV tries to extract `CSIPersistentVolumeSource` from given `pv`.

--- a/cmd/aws-s3-csi-controller/main.go
+++ b/cmd/aws-s3-csi-controller/main.go
@@ -30,6 +30,8 @@ import (
 var mountpointNamespace = flag.String("mountpoint-namespace", os.Getenv("MOUNTPOINT_NAMESPACE"), "Namespace to spawn Mountpoint Pods in.")
 var mountpointVersion = flag.String("mountpoint-version", os.Getenv("MOUNTPOINT_VERSION"), "Version of Mountpoint within the given Mountpoint image.")
 var mountpointPriorityClassName = flag.String("mountpoint-priority-class-name", os.Getenv("MOUNTPOINT_PRIORITY_CLASS_NAME"), "Priority class name of the Mountpoint Pods.")
+var mountpointPreemptingPriorityClassName = flag.String("mountpoint-preempting-priority-class-name", os.Getenv("MOUNTPOINT_PREEMPTING_PRIORITY_CLASS_NAME"), "Preempting priority class name of the Mountpoint Pods.")
+var mountpointHeadroomPriorityClassName = flag.String("mountpoint-headroom-priority-class-name", os.Getenv("MOUNTPOINT_HEADROOM_PRIORITY_CLASS_NAME"), "Priority class name of the Headroom Pods.")
 var mountpointImage = flag.String("mountpoint-image", os.Getenv("MOUNTPOINT_IMAGE"), "Image of Mountpoint to use in spawned Mountpoint Pods.")
 var mountpointImagePullPolicy = flag.String("mountpoint-image-pull-policy", os.Getenv("MOUNTPOINT_IMAGE_PULL_POLICY"), "Pull policy of Mountpoint images.")
 var mountpointContainerCommand = flag.String("mountpoint-container-command", "/bin/aws-s3-csi-mounter", "Entrypoint command of the Mountpoint Pods.")
@@ -65,12 +67,16 @@ func main() {
 	}
 
 	reconciler := csicontroller.NewReconciler(mgr.GetClient(), mppod.Config{
-		Namespace:         *mountpointNamespace,
-		MountpointVersion: *mountpointVersion,
-		PriorityClassName: *mountpointPriorityClassName,
+		Namespace:                   *mountpointNamespace,
+		MountpointVersion:           *mountpointVersion,
+		PriorityClassName:           *mountpointPriorityClassName,
+		PreemptingPriorityClassName: *mountpointPreemptingPriorityClassName,
+		HeadroomPriorityClassName:   *mountpointHeadroomPriorityClassName,
 		Container: mppod.ContainerConfig{
-			Command:         *mountpointContainerCommand,
-			Image:           *mountpointImage,
+			Command: *mountpointContainerCommand,
+			Image:   *mountpointImage,
+			// TODO: Make it configurable?
+			HeadroomImage:   "public.ecr.aws/eks-distro/kubernetes/pause:3.10",
 			ImagePullPolicy: corev1.PullPolicy(*mountpointImagePullPolicy),
 		},
 		CSIDriverVersion: version.GetVersion().DriverVersion,

--- a/cmd/aws-s3-csi-controller/main.go
+++ b/cmd/aws-s3-csi-controller/main.go
@@ -33,6 +33,7 @@ var mountpointPriorityClassName = flag.String("mountpoint-priority-class-name", 
 var mountpointPreemptingPriorityClassName = flag.String("mountpoint-preempting-priority-class-name", os.Getenv("MOUNTPOINT_PREEMPTING_PRIORITY_CLASS_NAME"), "Preempting priority class name of the Mountpoint Pods.")
 var mountpointHeadroomPriorityClassName = flag.String("mountpoint-headroom-priority-class-name", os.Getenv("MOUNTPOINT_HEADROOM_PRIORITY_CLASS_NAME"), "Priority class name of the Headroom Pods.")
 var mountpointImage = flag.String("mountpoint-image", os.Getenv("MOUNTPOINT_IMAGE"), "Image of Mountpoint to use in spawned Mountpoint Pods.")
+var headroomImage = flag.String("headroom-image", os.Getenv("MOUNTPOINT_HEADROOM_IMAGE"), "Image of a pause container to use in spawned Headroom Pods.")
 var mountpointImagePullPolicy = flag.String("mountpoint-image-pull-policy", os.Getenv("MOUNTPOINT_IMAGE_PULL_POLICY"), "Pull policy of Mountpoint images.")
 var mountpointContainerCommand = flag.String("mountpoint-container-command", "/bin/aws-s3-csi-mounter", "Entrypoint command of the Mountpoint Pods.")
 
@@ -73,10 +74,9 @@ func main() {
 		PreemptingPriorityClassName: *mountpointPreemptingPriorityClassName,
 		HeadroomPriorityClassName:   *mountpointHeadroomPriorityClassName,
 		Container: mppod.ContainerConfig{
-			Command: *mountpointContainerCommand,
-			Image:   *mountpointImage,
-			// TODO: Make it configurable?
-			HeadroomImage:   "public.ecr.aws/eks-distro/kubernetes/pause:3.10",
+			Command:         *mountpointContainerCommand,
+			Image:           *mountpointImage,
+			HeadroomImage:   *headroomImage,
 			ImagePullPolicy: corev1.PullPolicy(*mountpointImagePullPolicy),
 		},
 		CSIDriverVersion: version.GetVersion().DriverVersion,

--- a/docs/HEADROOM_FOR_MPPOD.md
+++ b/docs/HEADROOM_FOR_MPPOD.md
@@ -67,7 +67,7 @@ metadata:
   name: workload
 spec:
   schedulingGates:
-    - name: experimental.s3.csi.aws.com/reserve-headroom-for-mppod # <-- HERE
+    - name: s3.csi.aws.com/reserve-headroom-for-mppod # <-- HERE
   containers:
     # ...
   volumes:

--- a/docs/HEADROOM_FOR_MPPOD.md
+++ b/docs/HEADROOM_FOR_MPPOD.md
@@ -1,0 +1,75 @@
+# [Experimental] Reserving headroom for Mountpoint Pods
+
+_This is an experimental feature and the API or behavior may change in subsequent MINOR [releases](https://github.com/awslabs/mountpoint-s3-csi-driver?tab=readme-ov-file#releases)_.
+
+This feature causes overprovisioning in [node autoscalers](https://kubernetes.io/docs/concepts/cluster-administration/node-autoscaling/) like [Karpenter](https://karpenter.sh/) with the goal of reserving some headroom for _dynamically_ spawned Mountpoint Pods _after_ node creation.
+
+## Why is it needed?
+
+The CSI Driver v2 spawns Mountpoint Pods into the same nodes as the workloads to provide volumes. The CSI Driver spawns these Mountpoint Pods _after_ the workloads are assigned to nodes. This approach is taken because we might be able to [share an existing Mountpoint Pod](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/v2/docs/MOUNTPOINT_POD_SHARING.md) on a specific node, eliminating the need to spawn a new one. Therefore, the CSI Driver needs to wait until a workload is scheduled to a specific node before deciding whether to share an existing Mountpoint Pod or spawn a new one.
+
+This dynamic spawning of Mountpoint Pods on specific nodes creates a problem with node autoscalers like Karpenter. Since autoscalers are not aware of Mountpoint Pod requirements when making scaling decisions, they may make suboptimal choices. As a result, there may not be enough space for a Mountpoint Pod on the specific node where the workload is deployed.
+
+This feature aims to mitigate this issue by reserving headroom for upcoming Mountpoint Pods, ensuring autoscalers create instances large enough to host Mountpoint Pods alongside workloads.
+
+## How does it work?
+
+When the CSI Driver detects a Workload Pod using the scheduling gate to enable this feature, it performs the following steps:
+
+  1. Labels the Workload Pod to use inter-pod affinity rules in the Headroom Pods
+  2. Creates Headroom Pods using a pause container with inter-pod affinity rule to the Workload Pod - since node autoscalers like [Karpenter supports inter-pod affinity rules](https://karpenter.sh/docs/concepts/scheduling/#pod-affinityanti-affinity), this should help them to choose a right instance type
+  3. Ungates the scheduling gate from the Workload Pod to let it scheduled - alongside the Headroom Pods if possible
+  4. Schedules Mountpoint Pod if necessary (i.e., the CSI Driver cannot share an existing Mountpoint Pod) into the same node as the Workload and Headroom Pods
+  5. Mountpoint Pod preempts the Headroom Pods if there is no space in the node - as the Headroom Pods uses a negative priority, or just gets scheduled if there is enough space for all pods
+  6. Deletes the Headroom Pods as soon as the Workload Pod is running or terminated - as Mountpoint Pods are already scheduled or no longer needed
+
+## What are the limitations of this feature?
+
+### Overprovisioning
+
+This feature may cause overprovisioning (i.e., autoscalers may create larger instance types than needed to host pending workloads), which could result in allocating more resources than the cluster requires. This occurs because the CSI Driver allocates one Headroom Pod per volume, but in some cases that capacity may not be needed due to the Mountpoint Pod sharing feature.
+
+Features like [Karpenter's consolidation](https://karpenter.sh/docs/concepts/disruption/#consolidation) mechanisms may help the cluster settle on more appropriately sized instance types after all pods are scheduled, but this would still consume additional resources and time since autoscalers were not aware of the exact number of workloads in advance.
+
+### Downsides of inter-pod affinity
+
+As noted in [Kubernetes's documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity), inter-pod affinity rules require substantial amounts of processing which can slow down scheduling in large clusters significantly, and it's not recommended in clusters larger than several hundred nodes.
+
+Additionally, inter-pod affinity rules are insufficient to capture the intent of "all-or-nothing" scheduling (also known as [co-scheduling](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/coscheduling/README.md), [gang scheduling](https://yunikorn.apache.org/docs/user_guide/gang_scheduling/), or group scheduling) requirements. Therefore, the Kubernetes Scheduler may still schedule a Workload Pod without considering its associated Headroom Pod.
+
+## How is it used?
+
+Opting into this feature requires two steps.
+
+### 1. Enable this feature during Helm chart installation (one-time setup)
+
+```bash
+$ helm upgrade --install aws-mountpoint-s3-csi-driver \
+    --set experimental.reserveHeadroomForMountpointPods=true \
+    ...
+    aws-mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
+```
+
+This is behind a feature flag because it adds cluster-wide `patch` permissions on pods to the CSI Driver Controller's Service Account. This permission is needed for:
+  1. Adding labels to Workload Pods for use in inter-pod affinity rules in Headroom Pods
+  2. Removing scheduling gates from Workload Pods after creating Headroom Pods to make the Workload Pod ready for scheduling
+
+### 2. Add a scheduling gate for each Workload Pod where reserving headroom for Mountpoint Pods is desired
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: workload
+spec:
+  schedulingGates:
+    - name: experimental.s3.csi.aws.com/reserve-headroom-for-mppod # <-- HERE
+  containers:
+    # ...
+  volumes:
+    - name: vol
+      persistentVolumeClaim:
+        claimName: s3-pvc
+```
+
+This is currently done manually, and we may move this logic into a mutating admission webhook in the future to make configuration easier.

--- a/docs/HEADROOM_FOR_MPPOD.md
+++ b/docs/HEADROOM_FOR_MPPOD.md
@@ -27,7 +27,7 @@ When the CSI Driver detects a Workload Pod using the scheduling gate to enable t
 
 ### Overprovisioning
 
-This feature may cause overprovisioning (i.e., autoscalers may create larger instance types than needed to host pending workloads), which could result in allocating more resources than the cluster requires. This occurs because the CSI Driver allocates one Headroom Pod per volume, but in some cases that capacity may not be needed due to the Mountpoint Pod sharing feature.
+This feature may cause overprovisioning (i.e., autoscalers may create larger instance types than needed to host pending workloads), which could result in allocating more resources than the cluster requires. This occurs because the CSI Driver allocates one Headroom Pod per volume, but in some cases that capacity may not be needed due to the Mountpoint Pod sharing feature. This might also cause Workload Pods might deploy more sparsely - reducing the utilization of Mountpoint Pod sharing feature overall.
 
 Features like [Karpenter's consolidation](https://karpenter.sh/docs/concepts/disruption/#consolidation) mechanisms may help the cluster settle on more appropriately sized instance types after all pods are scheduled, but this would still consume additional resources and time since autoscalers were not aware of the exact number of workloads in advance.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -104,4 +104,4 @@ $ kubectl logs -n kube-system -l app=s3-csi-controller
 
 See [logging guide](./LOGGING.md#the-controller-component-aws-s3-csi-controller) for more details.
 
-Another thing to ensure is that you're using correct scheduling gate, the CSI Driver expects the scheduling gate to be `experimental.s3.csi.aws.com/reserve-headroom-for-mppod`, and would ignore any other scheduling gates. See [configuration guide of Reserving headroom for Mountpoint Pods](./HEADROOM_FOR_MPPOD.md#how-is-it-used) feature for more details.
+Another thing to ensure is that you're using correct scheduling gate, the CSI Driver expects the scheduling gate to be `s3.csi.aws.com/reserve-headroom-for-mppod`, and would ignore any other scheduling gates. See [configuration guide of Reserving headroom for Mountpoint Pods](./HEADROOM_FOR_MPPOD.md#how-is-it-used) feature for more details.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -91,3 +91,17 @@ There is also [a feature request on Mountpoint](https://github.com/awslabs/mount
 
 When using S3 Outposts, it is required to include the full ARN for your Outpost bucket in the `bucketName` field.
 See [the S3 Outposts example](../examples/kubernetes/static_provisioning/outpost_bucket.yaml).
+
+## I'm using experimental "Reserving headroom for Mountpoint Pods" feature and my pods are stuck in `SchedulingGated`
+
+The [Reserving headroom for Mountpoint Pods](./HEADROOM_FOR_MPPOD.md) requires you to add [Pod Scheduling Gates](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/) to your Workload Pods to opt-in. The CSI Driver then creates necessary Headroom Pods and removes the scheduling gate - making it ready to be scheduled.
+
+If your Workload Pods are stuck in `SchedulingGated`, that means the CSI Driver fails to create Headroom Pods or remove the scheduling gate. In this case you can check the CSI Driver's controller logs to see if it experiences any errors:
+
+```bash
+$ kubectl logs -n kube-system -l app=s3-csi-controller
+```
+
+See [logging guide](./LOGGING.md#the-controller-component-aws-s3-csi-controller) for more details.
+
+Another thing to ensure is that you're using correct scheduling gate, the CSI Driver expects the scheduling gate to be `experimental.s3.csi.aws.com/reserve-headroom-for-mppod`, and would ignore any other scheduling gates. See [configuration guide of Reserving headroom for Mountpoint Pods](./HEADROOM_FOR_MPPOD.md#how-is-it-used) feature for more details.

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -36,8 +36,7 @@ const (
 	mountpointPodReadinessWaitDuration = 15 * time.Second
 )
 
-// TODO: Replace this with a tracking ticket.
-const unschedulableMountpointPodReference = "https://github.com/awslabs/mountpoint-s3-csi-driver/issues/534"
+const unschedulableMountpointPodReference = "https://github.com/awslabs/mountpoint-s3-csi-driver/issues/543"
 
 // targetDirPerm is the permission to use while creating target directory if its not exists.
 const targetDirPerm = fs.FileMode(0755)

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -506,21 +506,21 @@ func (pm *PodMounter) volumeNameFromTargetPath(target string) (string, error) {
 	return tp.VolumeID, nil
 }
 
-// helpMessageForGettingMountpointLogs returns a help message to throubleshoot Mountpoint failures.
+// helpMessageForGettingMountpointLogs returns a help message to troubleshoot Mountpoint failures.
 func (pm *PodMounter) helpMessageForGettingMountpointLogs(pod *corev1.Pod) string {
 	return fmt.Sprintf("You can see Mountpoint logs by running: `kubectl logs -n %s %s`. If the Mountpoint Pod already restarted, you can also pass `--previous` to get logs from the previous run.", pod.Namespace, pod.Name)
 }
 
-// helpMessageForGettingMountpointPodStatus returns a help message to throubleshoot if Mountpoint Pod is not running.
+// helpMessageForGettingMountpointPodStatus returns a help message to troubleshoot if Mountpoint Pod is not running.
 func (pm *PodMounter) helpMessageForGettingMountpointPodStatus(err error, mpPodName string) string {
 	if errors.Is(err, watcher.ErrPodUnschedulable) {
-		return fmt.Sprintf("Seems like Mountpoint Pod is in 'Pending' status because it is unschedulable. This usually happens if there is no space for Mountpoint Pod in the node, see %s fore more details and some possible workarounds. You can see Mountpoint Pod's status and any potential failures by running: `kubectl describe pods -n %s %s`", unschedulableMountpointPodReference, mountpointPodNamespace, mpPodName)
+		return fmt.Sprintf("Seems like Mountpoint Pod is in 'Pending' status because it is unschedulable. This usually happens if there is no space for Mountpoint Pod in the node, see %s for more details and some possible workarounds. You can see Mountpoint Pod's status and any potential failures by running: `kubectl describe pods -n %s %s`", unschedulableMountpointPodReference, mountpointPodNamespace, mpPodName)
 	}
 
 	return fmt.Sprintf("Seems like Mountpoint Pod is not in 'Running' status. You can see it's status and any potential failures by running: `kubectl describe pods -n %s %s`", mountpointPodNamespace, mpPodName)
 }
 
-// helpMessageForGettingControllerLogs returns a help message to throubleshoot if the `MountpointS3PodAttachment` is not created/updated.
+// helpMessageForGettingControllerLogs returns a help message to troubleshoot if the `MountpointS3PodAttachment` is not created/updated.
 func (pm *PodMounter) helpMessageForGettingControllerLogs() string {
 	return "You can see the controller logs by running `kubectl logs -n kube-system -lapp=s3-csi-controller`."
 }

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -52,7 +52,17 @@ const (
 
 const CommunicationDirSizeLimit = 10 * 1024 * 1024 // 10MB
 
-// A ContainerConfig represents configuration for containers in the spawned Mountpoint Pods.
+// A PriorityClassKind represents type of priority class to use while spawning a Mountpoint Pod.
+type PriorityClassKind uint8
+
+const (
+	// DefaultPriorityClass means using the default (ideally non-preempting) priority class while spawning a Mountpoint Pod.
+	DefaultPriorityClass PriorityClassKind = iota
+	// PreemptingPriorityClass means using the preempting priority class (in order to evict Headroom Pods) while spawning a Mountpoint Pod.
+	PreemptingPriorityClass
+)
+
+// A ContainerConfig represents configuration for containers in the spawned Mountpoint/Headroom Pods.
 type ContainerConfig struct {
 	Command         string
 	Image           string
@@ -61,12 +71,13 @@ type ContainerConfig struct {
 
 // A Config represents configuration for spawned Mountpoint Pods.
 type Config struct {
-	Namespace         string
-	MountpointVersion string
-	PriorityClassName string
-	Container         ContainerConfig
-	CSIDriverVersion  string
-	ClusterVariant    cluster.Variant
+	ClusterVariant              cluster.Variant
+	Namespace                   string
+	MountpointVersion           string
+	PriorityClassName           string
+	PreemptingPriorityClassName string
+	Container                   ContainerConfig
+	CSIDriverVersion            string
 }
 
 // A Creator allows creating specification for Mountpoint Pods to schedule.
@@ -80,9 +91,15 @@ func NewCreator(config Config, log logr.Logger) *Creator {
 	return &Creator{config: config, log: log}
 }
 
-// Create returns a new Mountpoint Pod spec to schedule for given `node` and `pv`.
-func (c *Creator) Create(node string, pv *corev1.PersistentVolume) (*corev1.Pod, error) {
+// MountpointPod returns a new Mountpoint Pod spec to schedule for given `node`, `pv` and `priorityClassKind`.
+func (c *Creator) MountpointPod(node string, pv *corev1.PersistentVolume, priorityClassKind PriorityClassKind) (*corev1.Pod, error) {
 	uid := c.config.ClusterVariant.MountpointPodUserID()
+
+	priorityClassName := c.config.PriorityClassName
+	if priorityClassKind == PreemptingPriorityClass {
+		priorityClassName = c.config.PreemptingPriorityClassName
+	}
+
 	mpPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "mp-",
@@ -126,7 +143,7 @@ func (c *Creator) Create(node string, pv *corev1.PersistentVolume) (*corev1.Pod,
 					},
 				},
 			}},
-			PriorityClassName: c.config.PriorityClassName,
+			PriorityClassName: priorityClassName,
 			Affinity: &corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{
 					// This is to making sure Mountpoint Pod gets scheduled into same node as the Workload Pod

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -66,16 +66,18 @@ const (
 type ContainerConfig struct {
 	Command         string
 	Image           string
+	HeadroomImage   string
 	ImagePullPolicy corev1.PullPolicy
 }
 
-// A Config represents configuration for spawned Mountpoint Pods.
+// A Config represents configuration for spawned Mountpoint/Headroom Pods.
 type Config struct {
 	ClusterVariant              cluster.Variant
 	Namespace                   string
 	MountpointVersion           string
 	PriorityClassName           string
 	PreemptingPriorityClassName string
+	HeadroomPriorityClassName   string
 	Container                   ContainerConfig
 	CSIDriverVersion            string
 }

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -18,24 +18,26 @@ import (
 )
 
 const (
-	namespace         = "mount-s3"
-	mountpointVersion = "1.10.0"
-	image             = "mp-image:latest"
-	imagePullPolicy   = corev1.PullAlways
-	command           = "/bin/aws-s3-csi-mounter"
-	priorityClassName = "mount-s3-critical"
-	testNode          = "test-node"
-	testPodUID        = "test-pod-uid"
-	testVolName       = "test-vol"
-	testVolID         = "test-vol-id"
-	csiDriverVersion  = "1.12.0"
+	namespace                   = "mount-s3"
+	mountpointVersion           = "1.10.0"
+	image                       = "mp-image:latest"
+	imagePullPolicy             = corev1.PullAlways
+	command                     = "/bin/aws-s3-csi-mounter"
+	priorityClassName           = "mount-s3-critical"
+	preemptingPriorityClassName = "mount-s3-preempting-critical"
+	testNode                    = "test-node"
+	testPodUID                  = "test-pod-uid"
+	testVolName                 = "test-vol"
+	testVolID                   = "test-vol-id"
+	csiDriverVersion            = "1.12.0"
 )
 
 func createTestConfig(clusterVariant cluster.Variant) mppod.Config {
 	return mppod.Config{
-		Namespace:         namespace,
-		MountpointVersion: mountpointVersion,
-		PriorityClassName: priorityClassName,
+		Namespace:                   namespace,
+		MountpointVersion:           mountpointVersion,
+		PriorityClassName:           priorityClassName,
+		PreemptingPriorityClassName: preemptingPriorityClassName,
 		Container: mppod.ContainerConfig{
 			Image:           image,
 			ImagePullPolicy: imagePullPolicy,
@@ -49,7 +51,7 @@ func createTestConfig(clusterVariant cluster.Variant) mppod.Config {
 func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRunAsUser *int64) {
 	creator := mppod.NewCreator(createTestConfig(clusterVariant), testr.New(t))
 
-	verifyDefaultValues := func(mpPod *corev1.Pod) {
+	verifyDefaultValues := func(mpPod *corev1.Pod, expectedPriorityClassName string) {
 		assert.Equals(t, "mp-", mpPod.GenerateName)
 		assert.Equals(t, "", mpPod.Name)
 		assert.Equals(t, namespace, mpPod.Namespace)
@@ -60,7 +62,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 			mppod.LabelVolumeId:          testVolID,
 		}, mpPod.Labels)
 
-		assert.Equals(t, priorityClassName, mpPod.Spec.PriorityClassName)
+		assert.Equals(t, expectedPriorityClassName, mpPod.Spec.PriorityClassName)
 		assert.Equals(t, corev1.RestartPolicyOnFailure, mpPod.Spec.RestartPolicy)
 		assert.Equals(t, expectedRunAsUser, mpPod.Spec.SecurityContext.FSGroup)
 		assert.Equals(t, &corev1.Volume{
@@ -111,7 +113,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 	}
 
 	t.Run("Empty PV", func(t *testing.T) {
-		mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+		mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testVolName,
 			},
@@ -122,15 +124,15 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 					},
 				},
 			},
-		})
+		}, mppod.DefaultPriorityClass)
 
 		assert.NoError(t, err)
-		verifyDefaultValues(mpPod)
+		verifyDefaultValues(mpPod, priorityClassName)
 	})
 
 	t.Run("Mount Options", func(t *testing.T) {
 		t.Run("With cache", func(t *testing.T) {
-			mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+			mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -144,10 +146,10 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						"cache /mnt/mp-cache",
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 
 			assert.NoError(t, err)
-			verifyDefaultValues(mpPod)
+			verifyDefaultValues(mpPod, priorityClassName)
 			verifyLocalCacheVolume(t, mpPod, corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			})
@@ -156,7 +158,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 
 	t.Run("Cache Configuration", func(t *testing.T) {
 		t.Run("With emptyDir cache", func(t *testing.T) {
-			mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+			mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -170,10 +172,10 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 
 			assert.NoError(t, err)
-			verifyDefaultValues(mpPod)
+			verifyDefaultValues(mpPod, priorityClassName)
 			verifyLocalCacheVolume(t, mpPod, corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			})
@@ -181,7 +183,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 
 		t.Run("With emptyDir cache and size limit", func(t *testing.T) {
 			sizeLimit := "1Gi"
-			mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+			mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -196,10 +198,10 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 
 			assert.NoError(t, err)
-			verifyDefaultValues(mpPod)
+			verifyDefaultValues(mpPod, priorityClassName)
 			verifyLocalCacheVolume(t, mpPod, corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{
 					SizeLimit: ptr.To(resource.MustParse(sizeLimit)),
@@ -208,7 +210,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 		})
 
 		t.Run("With emptyDir cache and memory medium", func(t *testing.T) {
-			mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+			mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -223,10 +225,10 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 
 			assert.NoError(t, err)
-			verifyDefaultValues(mpPod)
+			verifyDefaultValues(mpPod, priorityClassName)
 			verifyLocalCacheVolume(t, mpPod, corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{
 					Medium: corev1.StorageMediumMemory,
@@ -236,7 +238,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 
 		t.Run("With emptyDir cache, size limit and memory medium", func(t *testing.T) {
 			sizeLimit := "1Gi"
-			mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+			mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -252,10 +254,10 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 
 			assert.NoError(t, err)
-			verifyDefaultValues(mpPod)
+			verifyDefaultValues(mpPod, priorityClassName)
 			verifyLocalCacheVolume(t, mpPod, corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{
 					SizeLimit: ptr.To(resource.MustParse(sizeLimit)),
@@ -267,7 +269,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 		t.Run("With ephemeral cache", func(t *testing.T) {
 			scName := "test-cache-sc"
 			storageRequest := "1Gi"
-			mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+			mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -283,10 +285,10 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 
 			assert.NoError(t, err)
-			verifyDefaultValues(mpPod)
+			verifyDefaultValues(mpPod, priorityClassName)
 			verifyLocalCacheVolume(t, mpPod, corev1.VolumeSource{
 				Ephemeral: &corev1.EphemeralVolumeSource{
 					VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
@@ -311,7 +313,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 		})
 
 		t.Run("With ephemeral cache but missing storage class name", func(t *testing.T) {
-			_, err := creator.Create(testNode, &corev1.PersistentVolume{
+			_, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -326,12 +328,12 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 			assert.Equals(t, cmpopts.AnyError, err)
 		})
 
 		t.Run("With ephemeral cache but missing resource request", func(t *testing.T) {
-			_, err := creator.Create(testNode, &corev1.PersistentVolume{
+			_, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -346,12 +348,12 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 			assert.Equals(t, cmpopts.AnyError, err)
 		})
 
 		t.Run("With ephemeral cache but invalid resource request", func(t *testing.T) {
-			_, err := creator.Create(testNode, &corev1.PersistentVolume{
+			_, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -367,12 +369,12 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 			assert.Equals(t, cmpopts.AnyError, err)
 		})
 
 		t.Run("With invalid cache type", func(t *testing.T) {
-			_, err := creator.Create(testNode, &corev1.PersistentVolume{
+			_, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -386,12 +388,12 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 			assert.Equals(t, cmpopts.AnyError, err)
 		})
 
 		t.Run("With invalid emptyDir size limit", func(t *testing.T) {
-			_, err := creator.Create(testNode, &corev1.PersistentVolume{
+			_, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -406,12 +408,12 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 			assert.Equals(t, cmpopts.AnyError, err)
 		})
 
 		t.Run("With invalid emptyDir medium", func(t *testing.T) {
-			_, err := creator.Create(testNode, &corev1.PersistentVolume{
+			_, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -426,12 +428,12 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 			assert.Equals(t, cmpopts.AnyError, err)
 		})
 
 		t.Run("With both mount options cache and volume attributes cache", func(t *testing.T) {
-			_, err := creator.Create(testNode, &corev1.PersistentVolume{
+			_, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -448,13 +450,13 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						"cache /mnt/mp-cache",
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 			assert.Equals(t, cmpopts.AnyError, err)
 		})
 	})
 
 	t.Run("With ServiceAccountName specified in PV", func(t *testing.T) {
-		mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+		mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testVolName,
 			},
@@ -468,16 +470,16 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 					},
 				},
 			},
-		})
+		}, mppod.DefaultPriorityClass)
 
 		assert.NoError(t, err)
-		verifyDefaultValues(mpPod)
+		verifyDefaultValues(mpPod, priorityClassName)
 		assert.Equals(t, "mount-s3-sa", mpPod.Spec.ServiceAccountName)
 	})
 
 	t.Run("With Container Resources specified in PV", func(t *testing.T) {
 		t.Run("With valid requests and limits", func(t *testing.T) {
-			mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+			mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -494,10 +496,10 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 
 			assert.NoError(t, err)
-			verifyDefaultValues(mpPod)
+			verifyDefaultValues(mpPod, priorityClassName)
 			mpContainer := mpPod.Spec.Containers[0]
 			assert.Equals(t, corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
@@ -510,7 +512,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 		})
 
 		t.Run("With valid requests only", func(t *testing.T) {
-			mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+			mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -525,10 +527,10 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 
 			assert.NoError(t, err)
-			verifyDefaultValues(mpPod)
+			verifyDefaultValues(mpPod, priorityClassName)
 			mpContainer := mpPod.Spec.Containers[0]
 			assert.Equals(t, corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
@@ -539,7 +541,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 		})
 
 		t.Run("With valid limits only", func(t *testing.T) {
-			mpPod, err := creator.Create(testNode, &corev1.PersistentVolume{
+			mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testVolName,
 				},
@@ -554,10 +556,10 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 						},
 					},
 				},
-			})
+			}, mppod.DefaultPriorityClass)
 
 			assert.NoError(t, err)
-			verifyDefaultValues(mpPod)
+			verifyDefaultValues(mpPod, priorityClassName)
 			mpContainer := mpPod.Spec.Containers[0]
 			assert.Equals(t, true, mpContainer.Resources.Requests.Cpu().IsZero())
 			assert.Equals(t, true, mpContainer.Resources.Requests.Memory().IsZero())
@@ -595,7 +597,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 				},
 			} {
 				t.Run(name, func(t *testing.T) {
-					_, err := creator.Create(testNode, &corev1.PersistentVolume{
+					_, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: testVolName,
 						},
@@ -606,7 +608,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 								},
 							},
 						},
-					})
+					}, mppod.DefaultPriorityClass)
 
 					assert.Equals(t, cmpopts.AnyError, err)
 				})
@@ -614,6 +616,25 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 
 		})
 	})
+
+	t.Run("With Preempting Priority Class", func(t *testing.T) {
+		mpPod, err := creator.MountpointPod(testNode, &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testVolName,
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						VolumeHandle: testVolID,
+					},
+				},
+			},
+		}, mppod.PreemptingPriorityClass)
+
+		assert.NoError(t, err)
+		verifyDefaultValues(mpPod, preemptingPriorityClassName)
+	})
+
 }
 
 func TestCreatingMountpointPods(t *testing.T) {

--- a/pkg/podmounter/mppod/headroom.go
+++ b/pkg/podmounter/mppod/headroom.go
@@ -26,14 +26,12 @@ const (
 // to reserve headroom for the Mountpoint Pod to serve volumes to workload.
 //
 // If this scheduling gate is used on a Workload Pod, the CSI Driver:
-//  1. Will label the Workload Pod with [LabelHeadroomForWorkload] equals to Workload Pod's UID
-//  2. Will create a Headroom Pod using a pause container with inter-pod affinity to the Workload Pod
-//  3. Will ungate this scheduling gate from the Workload Pod to let it scheduled (alongside the Headroom Pod)
-//  4. Will schedule Mountpoint Pod if necessary (i.e., the CSI Driver cannot share an existing Mountpoint Pod)
-//     into the same node as the Workload and Headroom Pods
-//  5. Mountpoint Pod will replace the Headroom Pod if there is no space in the node
-//  6. Once the Workload Pod is no longer in `Pending` state (i.e., either scheduled or terminated),
-//     the Headroom Pod will be deleted by the CSI Driver
+//  1. Labels the Workload Pod to use inter-pod affinity rules in the Headroom Pods
+//  2. Creates Headroom Pods using a pause container with inter-pod affinity rule to the Workload Pod
+//  3. Ungates the scheduling gate from the Workload Pod to let it scheduled - alongside the Headroom Pods if possible
+//  4. Schedules Mountpoint Pod if necessary (i.e., the CSI Driver cannot share an existing Mountpoint Pod) into the same node as the Workload and Headroom Pods using a preempting priority class
+//  5. Mountpoint Pod most likely preempts the Headroom Pods if there is no space in the node - as the Headroom Pods uses a negative priority -, or just gets scheduled if there is enough space for all pods
+//  6. Deletes the Headroom Pods as soon as the Workload Pod is running or terminated - as Mountpoint Pods are already scheduled or no longer needed
 const SchedulingGateReserveHeadroomForMountpointPod = "experimental.s3.csi.aws.com/reserve-headroom-for-mppod"
 
 const headroomPodNamePrefix = "hr-"

--- a/pkg/podmounter/mppod/headroom.go
+++ b/pkg/podmounter/mppod/headroom.go
@@ -1,0 +1,87 @@
+package mppod
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+// Labels populated on spawned Headroom Pods.
+const (
+	LabelHeadroomForPod    = "experimental.s3.csi.aws.com/headroom-for-pod"
+	LabelHeadroomForVolume = "experimental.s3.csi.aws.com/headroom-for-volume"
+)
+
+// Labels populated on Workload Pods requesting Headroom Pods.
+const (
+	LabelHeadroomForWorkload = "experimental.s3.csi.aws.com/headroom-for-workload"
+)
+
+// HeadroomPod returns a new Headroom Pod spec for the given `workloadPod` and `pv`.
+// This Headroom Pod serves as a capacity headroom to allow scheduling of the Mountpoint Pod alongside `workloadPod` to provide volume for `pv`.
+func (c *Creator) HeadroomPod(workloadPod *corev1.Pod, pv *corev1.PersistentVolume) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      HeadroomPodNameFor(workloadPod, pv),
+			Namespace: c.config.Namespace,
+			Labels: map[string]string{
+				LabelHeadroomForPod:    string(workloadPod.UID),
+				LabelHeadroomForVolume: pv.Name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			PriorityClassName: c.config.HeadroomPriorityClassName,
+			Affinity: &corev1.Affinity{
+				// Specify inter-pod affinity rule to Workload Pod to
+				// ensure they're co-scheduled into the same node.
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      LabelHeadroomForWorkload,
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{string(workloadPod.UID)},
+									},
+								},
+							},
+							Namespaces:  []string{workloadPod.Namespace},
+							TopologyKey: "kubernetes.io/hostname",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "pause",
+					Image: c.config.Container.HeadroomImage,
+					// TODO: Populate resources if PV specifies Mountpoint Pod resources.
+					// Resources: corev1.ResourceRequirements{},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						RunAsNonRoot:             ptr.To(true),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+				},
+			},
+			Tolerations: []corev1.Toleration{
+				// Tolerate all taints, so this Headroom Pod would be scheduled to any node alongside the Workload Pod.
+				{Operator: corev1.TolerationOpExists},
+			},
+		},
+	}
+}
+
+// HeadroomPodNameFor returns a consistent name for the Headroom Pod for given `workloadPod` and `pv`.
+func HeadroomPodNameFor(workloadPod *corev1.Pod, pv *corev1.PersistentVolume) string {
+	return fmt.Sprintf("hr-%x", sha256.Sum224(fmt.Appendf(nil, "%s%s", workloadPod.UID, pv.Name)))
+}

--- a/pkg/podmounter/mppod/headroom.go
+++ b/pkg/podmounter/mppod/headroom.go
@@ -13,13 +13,13 @@ import (
 
 // Labels populated on spawned Headroom Pods.
 const (
-	LabelHeadroomForPod    = "experimental.s3.csi.aws.com/headroom-for-pod"
-	LabelHeadroomForVolume = "experimental.s3.csi.aws.com/headroom-for-volume"
+	LabelHeadroomForPod    = "s3.csi.aws.com/headroom-for-pod"
+	LabelHeadroomForVolume = "s3.csi.aws.com/headroom-for-volume"
 )
 
 // Labels populated on Workload Pods requesting Headroom Pods.
 const (
-	LabelHeadroomForWorkload = "experimental.s3.csi.aws.com/headroom-for-workload"
+	LabelHeadroomForWorkload = "s3.csi.aws.com/headroom-for-workload"
 )
 
 // A scheduling gate can be used on Workload Pods using a volume backed by the CSI Driver to signal the CSI Driver
@@ -32,7 +32,7 @@ const (
 //  4. Schedules Mountpoint Pod if necessary (i.e., the CSI Driver cannot share an existing Mountpoint Pod) into the same node as the Workload and Headroom Pods using a preempting priority class
 //  5. Mountpoint Pod most likely preempts the Headroom Pods if there is no space in the node - as the Headroom Pods uses a negative priority -, or just gets scheduled if there is enough space for all pods
 //  6. Deletes the Headroom Pods as soon as the Workload Pod is running or terminated - as Mountpoint Pods are already scheduled or no longer needed
-const SchedulingGateReserveHeadroomForMountpointPod = "experimental.s3.csi.aws.com/reserve-headroom-for-mppod"
+const SchedulingGateReserveHeadroomForMountpointPod = "s3.csi.aws.com/reserve-headroom-for-mppod"
 
 const headroomPodNamePrefix = "hr-"
 

--- a/pkg/podmounter/mppod/headroom.go
+++ b/pkg/podmounter/mppod/headroom.go
@@ -156,15 +156,15 @@ func UnlabelWorkloadPodForHeadroomPod(workloadPod *corev1.Pod) bool {
 
 // ShouldReserveHeadroomForMountpointPod returns whether the `workloadPod` wants to reserve headroom for a Mountpoint Pod.
 func ShouldReserveHeadroomForMountpointPod(workloadPod *corev1.Pod) bool {
-	return slices.ContainsFunc(workloadPod.Spec.SchedulingGates, isHeadroomScheduligGate)
+	return slices.ContainsFunc(workloadPod.Spec.SchedulingGates, isHeadroomSchedulingGate)
 }
 
 // UngateHeadroomSchedulingGateForWorkloadPod removes the [SchedulingGateReserveHeadroomForMountpointPod] scheduling gate from the `workloadPod`.
 func UngateHeadroomSchedulingGateForWorkloadPod(workloadPod *corev1.Pod) {
-	workloadPod.Spec.SchedulingGates = slices.DeleteFunc(workloadPod.Spec.SchedulingGates, isHeadroomScheduligGate)
+	workloadPod.Spec.SchedulingGates = slices.DeleteFunc(workloadPod.Spec.SchedulingGates, isHeadroomSchedulingGate)
 }
 
-// isHeadroomScheduligGate returns whether the `sg` equals to [SchedulingGateReserveHeadroomForMountpointPod].
-func isHeadroomScheduligGate(sg corev1.PodSchedulingGate) bool {
+// isHeadroomSchedulingGate returns whether the `sg` equals to [SchedulingGateReserveHeadroomForMountpointPod].
+func isHeadroomSchedulingGate(sg corev1.PodSchedulingGate) bool {
 	return sg.Name == SchedulingGateReserveHeadroomForMountpointPod
 }

--- a/pkg/podmounter/mppod/headroom_test.go
+++ b/pkg/podmounter/mppod/headroom_test.go
@@ -1,0 +1,156 @@
+package mppod_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestShouldReserveHeadroomForMountpointPod(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "pod with headroom scheduling gate",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{
+						{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod with multiple scheduling gates including headroom gate",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{
+						{Name: "other-gate"},
+						{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+						{Name: "another-gate"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod without headroom scheduling gate",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{
+						{Name: "other-gate"},
+						{Name: "another-gate"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod with no scheduling gates",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod with nil scheduling gates",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: nil,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mppod.ShouldReserveHeadroomForMountpointPod(tt.pod)
+			assert.Equals(t, tt.expected, result)
+		})
+	}
+}
+
+func TestUngateHeadroomSchedulingGateForWorkloadPod(t *testing.T) {
+	tests := []struct {
+		name               string
+		pod                *corev1.Pod
+		expectedGatesAfter []corev1.PodSchedulingGate
+	}{
+		{
+			name: "remove headroom gate from single gate",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{
+						{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+					},
+				},
+			},
+			expectedGatesAfter: []corev1.PodSchedulingGate{},
+		},
+		{
+			name: "remove headroom gate from multiple gates",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{
+						{Name: "first-gate"},
+						{Name: mppod.SchedulingGateReserveHeadroomForMountpointPod},
+						{Name: "last-gate"},
+					},
+				},
+			},
+			expectedGatesAfter: []corev1.PodSchedulingGate{
+				{Name: "first-gate"},
+				{Name: "last-gate"},
+			},
+		},
+		{
+			name: "no headroom gate to remove",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{
+						{Name: "first-gate"},
+						{Name: "second-gate"},
+					},
+				},
+			},
+			expectedGatesAfter: []corev1.PodSchedulingGate{
+				{Name: "first-gate"},
+				{Name: "second-gate"},
+			},
+		},
+		{
+			name: "empty scheduling gates",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{},
+				},
+			},
+			expectedGatesAfter: []corev1.PodSchedulingGate{},
+		},
+		{
+			name: "nil scheduling gates",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					SchedulingGates: nil,
+				},
+			},
+			expectedGatesAfter: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mppod.UngateHeadroomSchedulingGateForWorkloadPod(tt.pod)
+			assert.Equals(t, tt.expectedGatesAfter, tt.pod.Spec.SchedulingGates)
+		})
+	}
+}

--- a/pkg/podmounter/mppod/headroom_test.go
+++ b/pkg/podmounter/mppod/headroom_test.go
@@ -361,3 +361,64 @@ func TestHeadroomLabelingFunctions(t *testing.T) {
 	assert.Equals(t, false, unlabeledAgain)
 	assert.Equals(t, false, mppod.WorkloadHasLabelPodForHeadroomPod(pod))
 }
+
+func TestIsHeadroomPod(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "headroom pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hr-abc123",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "regular pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "regular-pod-name",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "mountpoint pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mp-abc123",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod with headroom pod prefix in middle",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-hr-name",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod with empty name",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mppod.IsHeadroomPod(tt.pod)
+			assert.Equals(t, tt.expected, result)
+		})
+	}
+}

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -395,7 +395,7 @@ var _ = Describe("Mountpoint Controller", func() {
 
 						expectedFields := defaultExpectedFields(testNode, vol.pv)
 						expectedFields["WorkloadFSGroup"] = "1111"
-						s3pa, _ := waitAndVerifyS3PodAttachmentAndMountpointPodWithExpectedFields(testNode, vol, pod1, expectedFields)
+						s3pa, _ := waitAndVerifyS3PodAttachmentAndMountpointPodWithExpectedFields(testNode, vol, pod1, expectedFields, mountpointPriorityClassName)
 						expectNoPodUIDInS3PodAttachment(s3pa, string(pod2.UID))
 
 						pod2.schedule(testNode)
@@ -428,9 +428,9 @@ var _ = Describe("Mountpoint Controller", func() {
 						Expect(len(s3pa1.Spec.MountpointS3PodAttachments)).To(Equal(1))
 						Expect(len(s3pa2.Spec.MountpointS3PodAttachments)).To(Equal(1))
 						Expect(len(s3pa3.Spec.MountpointS3PodAttachments)).To(Equal(1))
-						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa1, pod1, vol)
-						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa2, pod2, vol)
-						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa3, pod3, vol)
+						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa1, pod1, vol, mountpointPriorityClassName)
+						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa2, pod2, vol, mountpointPriorityClassName)
+						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa3, pod3, vol, mountpointPriorityClassName)
 
 						Expect(s3pa1.Name).NotTo(Equal(s3pa2.Name), "S3PodAttachment should not have the same name")
 						Expect(s3pa1.Name).NotTo(Equal(s3pa3.Name), "S3PodAttachment should not have the same name")
@@ -465,7 +465,7 @@ var _ = Describe("Mountpoint Controller", func() {
 						expectedFields["AuthenticationSource"] = "pod"
 						expectedFields["WorkloadServiceAccountName"] = sa.Name
 						expectedFields["WorkloadNamespace"] = defaultNamespace
-						s3pa, _ := waitAndVerifyS3PodAttachmentAndMountpointPodWithExpectedFields(testNode, vol, pod1, expectedFields)
+						s3pa, _ := waitAndVerifyS3PodAttachmentAndMountpointPodWithExpectedFields(testNode, vol, pod1, expectedFields, mountpointPriorityClassName)
 						expectNoPodUIDInS3PodAttachment(s3pa, string(pod2.UID))
 
 						pod2.schedule(testNode)
@@ -501,7 +501,7 @@ var _ = Describe("Mountpoint Controller", func() {
 						expectedFields["WorkloadServiceAccountName"] = sa.Name
 						expectedFields["WorkloadNamespace"] = defaultNamespace
 						expectedFields["WorkloadServiceAccountIAMRoleARN"] = "test-role"
-						s3pa, _ := waitAndVerifyS3PodAttachmentAndMountpointPodWithExpectedFields(testNode, vol, pod1, expectedFields)
+						s3pa, _ := waitAndVerifyS3PodAttachmentAndMountpointPodWithExpectedFields(testNode, vol, pod1, expectedFields, mountpointPriorityClassName)
 						expectNoPodUIDInS3PodAttachment(s3pa, string(pod2.UID))
 
 						pod2.schedule(testNode)
@@ -559,9 +559,9 @@ var _ = Describe("Mountpoint Controller", func() {
 						Expect(len(s3pa1.Spec.MountpointS3PodAttachments)).To(Equal(1))
 						Expect(len(s3pa2.Spec.MountpointS3PodAttachments)).To(Equal(1))
 						Expect(len(s3pa3.Spec.MountpointS3PodAttachments)).To(Equal(1))
-						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa1, pod1, vol)
-						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa2, pod2, vol)
-						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa3, pod3, vol)
+						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa1, pod1, vol, mountpointPriorityClassName)
+						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa2, pod2, vol, mountpointPriorityClassName)
+						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa3, pod3, vol, mountpointPriorityClassName)
 
 						Expect(s3pa1.Name).NotTo(Equal(s3pa2.Name), "S3PodAttachment should not have the same name")
 						Expect(s3pa1.Name).NotTo(Equal(s3pa3.Name), "S3PodAttachment should not have the same name")
@@ -613,9 +613,9 @@ var _ = Describe("Mountpoint Controller", func() {
 						Expect(len(s3pa1.Spec.MountpointS3PodAttachments)).To(Equal(1))
 						Expect(len(s3pa2.Spec.MountpointS3PodAttachments)).To(Equal(1))
 						Expect(len(s3pa3.Spec.MountpointS3PodAttachments)).To(Equal(1))
-						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa1, pod1, vol)
-						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa2, pod2, vol)
-						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa3, pod3, vol)
+						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa1, pod1, vol, mountpointPriorityClassName)
+						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa2, pod2, vol, mountpointPriorityClassName)
+						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa3, pod3, vol, mountpointPriorityClassName)
 
 						Expect(s3pa1.Name).NotTo(Equal(s3pa2.Name), "S3PodAttachment should not have the same name")
 						Expect(s3pa1.Name).NotTo(Equal(s3pa3.Name), "S3PodAttachment should not have the same name")
@@ -677,7 +677,7 @@ var _ = Describe("Mountpoint Controller", func() {
 						expectedFields["WorkloadServiceAccountName"] = sa1.Name
 						s3pa1 := waitForS3PodAttachmentWithFields(expectedFields, "")
 						Expect(len(s3pa1.Spec.MountpointS3PodAttachments)).To(Equal(1))
-						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa1, pod1, vol)
+						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa1, pod1, vol, mountpointPriorityClassName)
 
 						pod2 := createPod(withPVC(pvc2), withServiceAccount(sa1.Name), withNamespace(ns.Name))
 						vol2.bind()
@@ -686,7 +686,7 @@ var _ = Describe("Mountpoint Controller", func() {
 						expectedFields["WorkloadNamespace"] = ns.Name
 						s3pa2 := waitForS3PodAttachmentWithFields(expectedFields, "")
 						Expect(len(s3pa2.Spec.MountpointS3PodAttachments)).To(Equal(1))
-						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa2, pod2, vol)
+						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa2, pod2, vol, mountpointPriorityClassName)
 
 						Expect(s3pa1.Name).NotTo(Equal(s3pa2.Name), "S3PodAttachment should not have the same name")
 						Expect(mpPod1.Name).NotTo(Equal(mpPod2.Name), "Mountpoint Pods should not have the same name")
@@ -708,8 +708,8 @@ var _ = Describe("Mountpoint Controller", func() {
 						s3pa := waitForS3PodAttachmentWithFields(expectedFields, "")
 
 						Expect(len(s3pa.Spec.MountpointS3PodAttachments)).To(Equal(1))
-						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod1, vol)
-						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod2, vol)
+						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod1, vol, mountpointPriorityClassName)
+						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod2, vol, mountpointPriorityClassName)
 						Expect(mpPod1.Name).To(Equal(mpPod2.Name))
 
 						// Now terminate the workloads for `mpPod1` (which is the same as `mpPod2`)
@@ -730,7 +730,7 @@ var _ = Describe("Mountpoint Controller", func() {
 						})
 
 						// Verify `pod3` has been assigned to a new Mountpoint Pod
-						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol)
+						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol, mountpointPriorityClassName)
 						Expect(mpPod1.Name).NotTo(Equal(mpPod3.Name))
 					})
 
@@ -748,8 +748,8 @@ var _ = Describe("Mountpoint Controller", func() {
 						s3pa := waitForS3PodAttachmentWithFields(expectedFields, "")
 
 						Expect(len(s3pa.Spec.MountpointS3PodAttachments)).To(Equal(1))
-						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod1, vol)
-						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod2, vol)
+						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod1, vol, mountpointPriorityClassName)
+						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod2, vol, mountpointPriorityClassName)
 						Expect(mpPod1.Name).To(Equal(mpPod2.Name))
 
 						// Now patch `mpPod1` as it was created with a different CSI Driver version
@@ -769,7 +769,7 @@ var _ = Describe("Mountpoint Controller", func() {
 						Expect(findMountpointPodNameForWorkload(s3pa, string(pod3.UID))).NotTo(BeEmpty())
 
 						// Verify `pod3` has been assigned to a new Mountpoint Pod
-						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol)
+						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol, mountpointPriorityClassName)
 						Expect(mpPod1.Name).NotTo(Equal(mpPod3.Name))
 					})
 
@@ -787,8 +787,8 @@ var _ = Describe("Mountpoint Controller", func() {
 						s3pa := waitForS3PodAttachmentWithFields(expectedFields, "")
 
 						Expect(len(s3pa.Spec.MountpointS3PodAttachments)).To(Equal(1))
-						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod1, vol)
-						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod2, vol)
+						mpPod1 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod1, vol, mountpointPriorityClassName)
+						mpPod2 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod2, vol, mountpointPriorityClassName)
 						Expect(mpPod1.Name).To(Equal(mpPod2.Name))
 
 						// Now annotate `mpPod1` with "no-new-workload"
@@ -807,7 +807,7 @@ var _ = Describe("Mountpoint Controller", func() {
 						Expect(findMountpointPodNameForWorkload(s3pa, string(pod3.UID))).NotTo(BeEmpty())
 
 						// Verify `pod3` has been assigned to a new Mountpoint Pod
-						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol)
+						mpPod3 := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod3, vol, mountpointPriorityClassName)
 						Expect(mpPod1.Name).NotTo(Equal(mpPod3.Name))
 					})
 				})
@@ -1181,7 +1181,7 @@ var _ = Describe("Mountpoint Controller", func() {
 
 			pod.runOn(testNode)
 
-			waitAndVerifyS3PodAttachmentAndMountpointPod(testNode, vol, pod)
+			waitAndVerifyS3PodAttachmentAndMountpointPodWithPreemptingPriorityClass(testNode, vol, pod)
 			waitForObjectToDisappear(hrPod.Pod)
 		})
 
@@ -1202,8 +1202,8 @@ var _ = Describe("Mountpoint Controller", func() {
 
 			pod.runOn(testNode)
 
-			waitAndVerifyS3PodAttachmentAndMountpointPod(testNode, vol1, pod)
-			waitAndVerifyS3PodAttachmentAndMountpointPod(testNode, vol2, pod)
+			waitAndVerifyS3PodAttachmentAndMountpointPodWithPreemptingPriorityClass(testNode, vol1, pod)
+			waitAndVerifyS3PodAttachmentAndMountpointPodWithPreemptingPriorityClass(testNode, vol2, pod)
 			waitForObjectToDisappear(hrPod1.Pod)
 			waitForObjectToDisappear(hrPod2.Pod)
 		})
@@ -1304,7 +1304,7 @@ var _ = Describe("Mountpoint Controller", func() {
 
 			pod.runOn(testNode)
 
-			waitAndVerifyS3PodAttachmentAndMountpointPod(testNode, vol1, pod)
+			waitAndVerifyS3PodAttachmentAndMountpointPodWithPreemptingPriorityClass(testNode, vol1, pod)
 			expectNoS3PodAttachmentWithFields(defaultExpectedFields(testNode, vol2.pv))
 			waitForObjectToDisappear(hrPod.Pod)
 		})
@@ -1653,10 +1653,11 @@ func waitAndVerifyS3PodAttachmentAndMountpointPodWithExpectedFields(
 	vol *testVolume,
 	pod *testPod,
 	expectedFields map[string]string,
+	expectedPriorityClass string,
 ) (*crdv2beta.MountpointS3PodAttachment, *testPod) {
 	s3pa := waitForS3PodAttachmentWithFields(expectedFields, "")
 	Expect(len(s3pa.Spec.MountpointS3PodAttachments)).To(Equal(1))
-	mpPod := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod, vol)
+	mpPod := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod, vol, expectedPriorityClass)
 	return s3pa, mpPod
 }
 
@@ -1667,7 +1668,17 @@ func waitAndVerifyS3PodAttachmentAndMountpointPod(
 	vol *testVolume,
 	pod *testPod,
 ) (*crdv2beta.MountpointS3PodAttachment, *testPod) {
-	return waitAndVerifyS3PodAttachmentAndMountpointPodWithExpectedFields(node, vol, pod, defaultExpectedFields(node, vol.pv))
+	return waitAndVerifyS3PodAttachmentAndMountpointPodWithExpectedFields(node, vol, pod, defaultExpectedFields(node, vol.pv), mountpointPriorityClassName)
+}
+
+// waitAndVerifyS3PodAttachmentAndMountpointPodWithPreemptingPriorityClass waits and verifies that MountpointS3PodAttachment and Mountpoint Pod
+// are created for given `node`, `vol` and `pod`, with the preempting priority class.
+func waitAndVerifyS3PodAttachmentAndMountpointPodWithPreemptingPriorityClass(
+	node string,
+	vol *testVolume,
+	pod *testPod,
+) (*crdv2beta.MountpointS3PodAttachment, *testPod) {
+	return waitAndVerifyS3PodAttachmentAndMountpointPodWithExpectedFields(node, vol, pod, defaultExpectedFields(node, vol.pv), preemptingPodPriorityClassName)
 }
 
 // waitAndVerifyS3PodAttachmentAndMountpointPodWithMinVersionAndExpectedField waits and verifies that MountpointS3PodAttachment with `minVersion` and Mountpoint Pod
@@ -1681,7 +1692,7 @@ func waitAndVerifyS3PodAttachmentAndMountpointPodWithMinVersionAndExpectedField(
 ) (*crdv2beta.MountpointS3PodAttachment, *testPod) {
 	s3pa := waitForS3PodAttachmentWithFields(expectedFields, minVersion)
 	Expect(len(s3pa.Spec.MountpointS3PodAttachments)).To(Equal(1))
-	mpPod := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod, vol)
+	mpPod := waitAndVerifyMountpointPodFromPodAttachment(s3pa, pod, vol, mountpointPriorityClassName)
 	return s3pa, mpPod
 }
 
@@ -1697,7 +1708,7 @@ func waitAndVerifyS3PodAttachmentAndMountpointPodWithMinVersion(
 }
 
 // waitAndVerifyMountpointPodFromPodAttachment waits and verifies Mountpoint Pod scheduled for given `s3pa`, `pod` and `vol.`
-func waitAndVerifyMountpointPodFromPodAttachment(s3pa *crdv2beta.MountpointS3PodAttachment, pod *testPod, vol *testVolume) *testPod {
+func waitAndVerifyMountpointPodFromPodAttachment(s3pa *crdv2beta.MountpointS3PodAttachment, pod *testPod, vol *testVolume, expectedPriorityClass string) *testPod {
 	GinkgoHelper()
 
 	podUID := string(pod.UID)
@@ -1716,7 +1727,7 @@ func waitAndVerifyMountpointPodFromPodAttachment(s3pa *crdv2beta.MountpointS3Pod
 	))
 
 	mountpointPod := waitForMountpointPodWithName(mpPodName)
-	verifyMountpointPodFor(pod, vol, mountpointPod)
+	verifyMountpointPodFor(pod, vol, mountpointPod, expectedPriorityClass)
 
 	return mountpointPod
 }
@@ -1735,7 +1746,7 @@ func findMountpointPodNameForWorkload(s3pa *crdv2beta.MountpointS3PodAttachment,
 }
 
 // verifyMountpointPodFor verifies given `mountpointPod` for given `pod` and `vol`.
-func verifyMountpointPodFor(pod *testPod, vol *testVolume, mountpointPod *testPod) {
+func verifyMountpointPodFor(pod *testPod, vol *testVolume, mountpointPod *testPod, expectedPriorityClass string) {
 	GinkgoHelper()
 
 	Expect(mountpointPod.ObjectMeta.Labels).To(HaveKeyWithValue(mppod.LabelMountpointVersion, mountpointVersion))
@@ -1758,7 +1769,7 @@ func verifyMountpointPodFor(pod *testPod, vol *testVolume, mountpointPod *testPo
 			Operator: corev1.TolerationOpExists,
 		},
 	}))
-	Expect(mountpointPod.Spec.PriorityClassName).To(Equal(mountpointPriorityClassName))
+	Expect(mountpointPod.Spec.PriorityClassName).To(Equal(expectedPriorityClass))
 
 	Expect(mountpointPod.Spec.Containers[0].Image).To(Equal(mountpointImage))
 	Expect(mountpointPod.Spec.Containers[0].ImagePullPolicy).To(Equal(mountpointImagePullPolicy))

--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -65,6 +65,7 @@ var CSITestSuites = []func() framework.TestSuite{
 	custom_testsuites.InitS3CSICredentialsTestSuite,
 	custom_testsuites.InitS3CSICacheTestSuite,
 	custom_testsuites.InitS3CSIPodSharingTestSuite,
+	custom_testsuites.InitS3HeadroomTestSuite,
 }
 
 // This executes testSuites for csi volumes.

--- a/tests/e2e-kubernetes/scripts/helm.sh
+++ b/tests/e2e-kubernetes/scripts/helm.sh
@@ -49,6 +49,7 @@ function helm_install_driver() {
     --set image.tag=${TAG} \
     --set image.pullPolicy=Always \
     --set node.serviceAccount.create=true \
+    --set experimental.reserveHeadroomForMountpointPods=true \
     --kubeconfig ${KUBECONFIG}
   $KUBECTL_BIN rollout status daemonset s3-csi-node -n kube-system --timeout=60s --kubeconfig $KUBECONFIG
   $KUBECTL_BIN get pods -A --kubeconfig $KUBECONFIG

--- a/tests/e2e-kubernetes/testsuites/headroom.go
+++ b/tests/e2e-kubernetes/testsuites/headroom.go
@@ -20,9 +20,9 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-const labelHeadroomForPod = "experimental.s3.csi.aws.com/headroom-for-pod"
-const labelHeadroomForVolume = "experimental.s3.csi.aws.com/headroom-for-volume"
-const headroomSchedulingGate = "experimental.s3.csi.aws.com/reserve-headroom-for-mppod"
+const labelHeadroomForPod = "s3.csi.aws.com/headroom-for-pod"
+const labelHeadroomForVolume = "s3.csi.aws.com/headroom-for-volume"
+const headroomSchedulingGate = "s3.csi.aws.com/reserve-headroom-for-mppod"
 const headroomPriorityClass = "mount-s3-headroom"
 
 type s3CSIHeadroomTestSuite struct {

--- a/tests/e2e-kubernetes/testsuites/headroom.go
+++ b/tests/e2e-kubernetes/testsuites/headroom.go
@@ -1,0 +1,138 @@
+package custom_testsuites
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+const headroomSchedulingGate = "experimental.s3.csi.aws.com/reserve-headroom-for-mppod"
+const headroomPriorityClass = "mount-s3-headroom"
+
+type s3CSIHeadroomTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+func InitS3HeadroomTestSuite() storageframework.TestSuite {
+	return &s3CSIHeadroomTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "headroom",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+func (t *s3CSIHeadroomTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *s3CSIHeadroomTestSuite) SkipUnsupportedTests(_ storageframework.TestDriver, pattern storageframework.TestPattern) {
+	if pattern.VolType != storageframework.PreprovisionedPV {
+		e2eskipper.Skipf("Suite %q does not support %v", t.tsInfo.Name, pattern.VolType)
+	}
+}
+
+func (t *s3CSIHeadroomTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	f := framework.NewFrameworkWithCustomTimeouts(NamespacePrefix+"cache", storageframework.GetDriverTimeouts(driver))
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	type local struct {
+		config *storageframework.PerTestConfig
+
+		// A list of cleanup functions to be called after each test to clean resources created during the test.
+		cleanup []func(context.Context) error
+	}
+
+	var l local
+
+	deferCleanup := func(f func(context.Context) error) {
+		l.cleanup = append(l.cleanup, f)
+	}
+
+	cleanup := func(ctx context.Context) {
+		var errs []error
+		slices.Reverse(l.cleanup) // clean items in reverse order similar to how `defer` works
+		for _, f := range l.cleanup {
+			errs = append(errs, f(ctx))
+		}
+		framework.ExpectNoError(errors.NewAggregate(errs), "while cleanup resource")
+	}
+	BeforeEach(func(ctx context.Context) {
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		DeferCleanup(cleanup)
+	})
+
+	checkBasicFileOperations := func(pod *v1.Pod, volPath string) {
+		seed := time.Now().UTC().UnixNano()
+		filename := fmt.Sprintf("test-%d.txt", seed)
+		path := filepath.Join(volPath, filename)
+		testWriteSize := 1024 // 1KB
+
+		checkWriteToPath(f, pod, path, testWriteSize, seed)
+		checkReadFromPath(f, pod, path, testWriteSize, seed)
+		checkListingPathWithEntries(f, pod, volPath, []string{filename})
+		checkDeletingPath(f, pod, path)
+		checkListingPathWithEntries(f, pod, volPath, []string{})
+	}
+
+	Describe("Headroom", Ordered, func() {
+		BeforeAll(func(ctx context.Context) {
+			_, err := f.ClientSet.SchedulingV1().PriorityClasses().Get(ctx, headroomPriorityClass, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					Skip("`experimental.reserveHeadroomForMountpointPods` feature is not enabled, skipping headroom tests")
+					return
+				}
+
+				framework.Failf("Failed to query priority class for Headroom Pods: %s", err)
+			}
+		})
+
+		It("should get scheduled automatically after reserving headroom", func(ctx context.Context) {
+			vol := createVolumeResourceWithMountOptions(ctx, l.config, pattern, []string{"allow-delete"})
+			deferCleanup(vol.CleanupResource)
+
+			pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{vol.Pvc}, admissionapi.LevelBaseline, "")
+			pod.Spec.SchedulingGates = []v1.PodSchedulingGate{{Name: headroomSchedulingGate}}
+
+			pod, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+			framework.ExpectNoError(err)
+			deferCleanup(func(ctx context.Context) error { return e2epod.DeletePodWithWait(ctx, f.ClientSet, pod) })
+
+			checkBasicFileOperations(pod, e2epod.VolumeMountPath1)
+		})
+
+		It("should get scheduled automatically after reserving headroom for multiple volumes", func(ctx context.Context) {
+			vol1 := createVolumeResourceWithMountOptions(ctx, l.config, pattern, []string{"allow-delete"})
+			deferCleanup(vol1.CleanupResource)
+			vol2 := createVolumeResourceWithMountOptions(ctx, l.config, pattern, []string{"allow-delete"})
+			deferCleanup(vol2.CleanupResource)
+
+			pod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{vol1.Pvc, vol2.Pvc}, admissionapi.LevelBaseline, "")
+			pod.Spec.SchedulingGates = []v1.PodSchedulingGate{{Name: headroomSchedulingGate}}
+
+			pod, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+			framework.ExpectNoError(err)
+			deferCleanup(func(ctx context.Context) error { return e2epod.DeletePodWithWait(ctx, f.ClientSet, pod) })
+
+			checkBasicFileOperations(pod, fmt.Sprintf(e2epod.VolumeMountPathTemplate, 1))
+			checkBasicFileOperations(pod, fmt.Sprintf(e2epod.VolumeMountPathTemplate, 2))
+		})
+	})
+}


### PR DESCRIPTION
This PR adds an experimental feature for reserving headroom for Mountpoint Pods to help with issues like https://github.com/awslabs/mountpoint-s3-csi-driver/issues/534.

## Why?

The CSI Driver v2 spawns Mountpoint Pods into the same nodes as the workloads to provide volumes. The CSI Driver spawns these Mountpoint Pods _after_ the workloads are assigned to nodes. This approach is taken because we might be able to [share an existing Mountpoint Pod](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/v2/docs/MOUNTPOINT_POD_SHARING.md) on a specific node, eliminating the need to spawn a new one. Therefore, the CSI Driver needs to wait until a workload is scheduled to a specific node before deciding whether to share an existing Mountpoint Pod or spawn a new one.

This dynamic spawning of Mountpoint Pods on specific nodes creates a problem with node autoscalers like Karpenter. Since autoscalers are not aware of Mountpoint Pod requirements when making scaling decisions, they may make suboptimal choices. As a result, there may not be enough space for a Mountpoint Pod on the specific node where the workload is deployed.

This feature aims to mitigate this issue by reserving headroom for upcoming Mountpoint Pods, ensuring autoscalers create instances large enough to host Mountpoint Pods alongside workloads.

## How it's used?

Opting into this feature requires two steps.

### 1. Enable this feature during Helm chart installation (one-time setup)

```bash
$ helm upgrade --install aws-mountpoint-s3-csi-driver \
    --set experimental.reserveHeadroomForMountpointPods=true \
    ...
    aws-mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
```

This is behind a feature flag because it adds cluster-wide `patch` permissions on pods to the CSI Driver Controller's Service Account. This permission is needed for:
  1. Adding labels to Workload Pods for use in inter-pod affinity rules in Headroom Pods
  2. Removing scheduling gates from Workload Pods after creating Headroom Pods to make the Workload Pod ready for scheduling

### 2. Add a scheduling gate for each Workload Pod where reserving headroom for Mountpoint Pods is desired

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: workload
spec:
  schedulingGates:
    - name: s3.csi.aws.com/reserve-headroom-for-mppod # <-- HERE
  containers:
    # ...
  volumes:
    - name: vol
      persistentVolumeClaim:
        claimName: s3-pvc
```

This is currently done manually, and we may move this logic into a mutating admission webhook in the future to make configuration easier.

## How it works?

When the CSI Driver detects a Workload Pod using the scheduling gate to enable this feature, it performs the following steps:

  1. Labels the Workload Pod to use inter-pod affinity rules in the Headroom Pods
  2. Creates Headroom Pods using a pause container with inter-pod affinity rule to the Workload Pod - since node autoscalers like [Karpenter supports inter-pod affinity rules](https://karpenter.sh/docs/concepts/scheduling/#pod-affinityanti-affinity), this should help them to choose a right instance type
  3. Ungates the scheduling gate from the Workload Pod to let it scheduled - alongside the Headroom Pods if possible
  4. Schedules Mountpoint Pod if necessary (i.e., the CSI Driver cannot share an existing Mountpoint Pod) into the same node as the Workload and Headroom Pods using a preempting priority class
  5. Mountpoint Pod most likely preempts the Headroom Pods if there is no space in the node - as the Headroom Pods uses a negative priority -, or just gets scheduled if there is enough space for all pods
  6. Deletes the Headroom Pods as soon as the Workload Pod is running or terminated - as Mountpoint Pods are already scheduled or no longer needed

## Limitations

This approach has some downsides:
- Overprovisioning: It may cause node autoscalers to create bigger instances than the cluster needs.
- Inter-pod affinity: Inter-pod affinity rules are compute-intensive and may cause significant slowdowns on scheduling in clusters with more than several hundred nodes
- Preemption: Mountpoint Pods would be spawned with preempting priority class if this feature is on, and they might preempt some other pods rather than Headroom Pods. Even though the CSI Driver sets a negative priority on Headroom Pods to make them the first target in case of preemption there are no guarantees that the Headroom Pods won't be evicted by other high priority pods and causing Mountpoint Pods to preempting other pods.

See [the documentation](https://github.com/unexge/mountpoint-s3-csi-driver/blob/2d2b6dd68f1b78bf8a458e170ba9cbb894f5f5a5/docs/HEADROOM_FOR_MPPOD.md) for more details. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
