### PR TITLE
Fixes on upgrade test GitHub workflow

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -13,6 +13,14 @@ on:
         required: false
         type: boolean
         description: "If true, only upgrade tests will run."
+      upgrade_tests_old_version:
+        required: false
+        type: string
+        description: "Only used if `run_upgrade_tests` is true, specifies the old version to test upgrade from."
+      upgrade_tests_new_version:
+        required: false
+        type: string
+        description: "Only used if `run_upgrade_tests` is true, specifies the new version to test upgrade to."
 
 concurrency:
   group: e2e-cluster-${{ inputs.environment }}
@@ -81,6 +89,8 @@ jobs:
       TAG: "untested_${{ inputs.ref }}"
       K8S_VERSION: "${{ matrix.kubernetes-version }}"
       SELINUX_MODE: "${{ matrix.selinux-mode }}"
+      MOUNTPOINT_CSI_DRIVER_PREVIOUS_VERSION: "${{ inputs.upgrade_tests_old_version }}"
+      MOUNTPOINT_CSI_DRIVER_NEW_VERSION: "${{ inputs.upgrade_tests_new_version }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -109,7 +109,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
-          role-duration-seconds: ${{ inputs.run_upgrade_tests && 7200 || 14400 }}
+          role-duration-seconds: ${{ inputs.run_upgrade_tests && 14400 || 7200 }}
       - name: Install tools
         env:
           ACTION: "install_tools"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -109,6 +109,9 @@ jobs:
         with:
           role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
+          # Upgrade tests takes around 3 hours to run to ensure they hit multiple credential refresh cycles.
+          # That's why we're increasing the AWS credential duration here compared to regular end-to-end tests.
+          # See comments on top of `UPGRADE_TEST_DURATION_IN_MINUTES` constant in `tests/e2e-kubernetes/testsuites/upgrade.go`.
           role-duration-seconds: ${{ inputs.run_upgrade_tests && 14400 || 7200 }}
       - name: Install tools
         env:
@@ -133,6 +136,7 @@ jobs:
       - name: Run E2E Tests
         # The CSI Driver v1 doesn't support running on SELinux enabled hosts,
         # so we're skipping upgrade tests from v1 if SELinux is enabled.
+        # TODO: Delete this after 2.0.0 release as we wouldn't need to run upgrade tests from 1.x afterward.
         if: |
           matrix.selinux-mode != 'enforcing' ||
           !inputs.run_upgrade_tests ||

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -109,7 +109,7 @@ jobs:
         with:
           role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
-          role-duration-seconds: 7200
+          role-duration-seconds: ${{ inputs.run_upgrade_tests && 7200 || 14400 }}
       - name: Install tools
         env:
           ACTION: "install_tools"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -131,6 +131,12 @@ jobs:
         run: |
           tests/e2e-kubernetes/scripts/run.sh
       - name: Run E2E Tests
+        # The CSI Driver v1 doesn't support running on SELinux enabled hosts,
+        # so we're skipping upgrade tests from v1 if SELinux is enabled.
+        if: |
+          matrix.selinux-mode != 'enforcing' ||
+          !inputs.run_upgrade_tests ||
+          !startsWith(inputs.upgrade_tests_old_version, '1.')
         env:
           ACTION: "${{ inputs.run_upgrade_tests && 'run_upgrade_tests' || 'run_tests' }}"
         run: |

--- a/.github/workflows/e2e-upgrade-test.yaml
+++ b/.github/workflows/e2e-upgrade-test.yaml
@@ -24,6 +24,6 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       environment: "trusted"
-      ref: ${{ github.ref }}
+      ref: ${{ github.sha }}
       run_upgrade_tests: true
     secrets: inherit

--- a/.github/workflows/e2e-upgrade-test.yaml
+++ b/.github/workflows/e2e-upgrade-test.yaml
@@ -14,10 +14,6 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  MOUNTPOINT_CSI_DRIVER_PREVIOUS_VERSION: "${{ inputs.old_version }}"
-  MOUNTPOINT_CSI_DRIVER_NEW_VERSION: "${{ inputs.new_version }}"
-
 jobs:
   e2e:
     name: E2E Upgrade Tests
@@ -26,4 +22,6 @@ jobs:
       environment: "trusted"
       ref: ${{ github.sha }}
       run_upgrade_tests: true
+      upgrade_tests_old_version: "${{ inputs.old_version }}"
+      upgrade_tests_new_version: "${{ inputs.new_version }}"
     secrets: inherit

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -182,7 +182,7 @@ elif [[ "${ACTION}" == "run_tests" ]]; then
 elif [[ "${ACTION}" == "run_upgrade_tests" ]]; then
   set +e
   pushd tests/e2e-kubernetes
-  KUBECONFIG=${KUBECONFIG} ginkgo -p -vv -timeout 10h -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=true --cluster-name=${CLUSTER_NAME} --run-upgrade-tests
+  KUBECONFIG=${KUBECONFIG} ginkgo -vv -timeout 10h -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=true --cluster-name=${CLUSTER_NAME} --run-upgrade-tests
   EXIT_CODE=$?
   print_cluster_info
   exit $EXIT_CODE

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -9,8 +9,8 @@ AWS_PARTITION=$(aws sts get-caller-identity --query Arn --output text | cut -d: 
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 REGISTRY=${REGISTRY:-${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com}
 IMAGE_NAME=${IMAGE_NAME:-}
-REPOSITORY="${REGISTRY}/${IMAGE_NAME}"
 TAG=${TAG:-}
+export REPOSITORY="${REGISTRY}/${IMAGE_NAME}"
 
 BASE_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 source "${BASE_DIR}"/eksctl.sh

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -9,6 +9,7 @@ AWS_PARTITION=$(aws sts get-caller-identity --query Arn --output text | cut -d: 
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 REGISTRY=${REGISTRY:-${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com}
 IMAGE_NAME=${IMAGE_NAME:-}
+REPOSITORY="${REGISTRY}/${IMAGE_NAME}"
 TAG=${TAG:-}
 
 BASE_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -34,7 +34,7 @@ import (
 const UPGRADE_TEST_DURATION_IN_MINUTES = 150
 
 const helmRepo = "https://awslabs.github.io/mountpoint-s3-csi-driver"
-const helmChartSource = "charts/aws-mountpoint-s3-csi-driver" // This assumes the test script will run from the project root.
+const helmChartSource = "../../charts/aws-mountpoint-s3-csi-driver"
 const helmChartName = "aws-mountpoint-s3-csi-driver"
 const helmReleaseName = "mountpoint-s3-csi-driver"
 const helmReleaseNamespace = "kube-system"
@@ -339,7 +339,7 @@ func upgradeCSIDriver(cfg *action.Configuration, version string, chartPath strin
 	chart, err := loader.Load(chartPath)
 	framework.ExpectNoError(err)
 
-	release, err := upgradeClient.RunWithContext(context.Background(), helmChartName, chart, map[string]any{})
+	release, err := upgradeClient.RunWithContext(context.Background(), helmReleaseName, chart, map[string]any{})
 	framework.ExpectNoError(err)
 
 	framework.Logf("Helm release %q updated to %v (from %q)", release.Name, version, chartPath)

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -36,7 +36,7 @@ const UPGRADE_TEST_DURATION_IN_MINUTES = 150
 const helmRepo = "https://awslabs.github.io/mountpoint-s3-csi-driver"
 const helmChartSource = "../../charts/aws-mountpoint-s3-csi-driver"
 const helmChartName = "aws-mountpoint-s3-csi-driver"
-const helmReleaseName = "aws-mountpoint-s3-csi-driver"
+const helmReleaseName = "mountpoint-s3-csi-driver"
 const helmReleaseNamespace = "kube-system"
 
 var helmChartPreviousVersion = os.Getenv("MOUNTPOINT_CSI_DRIVER_PREVIOUS_VERSION")

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -34,7 +34,7 @@ import (
 const UPGRADE_TEST_DURATION_IN_MINUTES = 150
 
 const helmRepo = "https://awslabs.github.io/mountpoint-s3-csi-driver"
-const helmChartSource = "../../charts/aws-mountpoint-s3-csi-driver"
+const helmChartSource = "charts/aws-mountpoint-s3-csi-driver" // This assumes the test script will run from the project root.
 const helmChartName = "aws-mountpoint-s3-csi-driver"
 const helmReleaseName = "mountpoint-s3-csi-driver"
 const helmReleaseNamespace = "kube-system"

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -41,8 +41,8 @@ const helmReleaseNamespace = "kube-system"
 
 var helmChartPreviousVersion = os.Getenv("MOUNTPOINT_CSI_DRIVER_PREVIOUS_VERSION")
 var helmChartNewVersion = os.Getenv("MOUNTPOINT_CSI_DRIVER_NEW_VERSION")
-var helmChartContainerRepository = os.Getenv("MOUNTPOINT_CSI_DRIVER_CONTAINER_REPOSITORY")
-var helmChartContainerTag = os.Getenv("MOUNTPOINT_CSI_DRIVER_CONTAINER_TAG")
+var helmChartContainerRepository = os.Getenv("REGISTRY")
+var helmChartContainerTag = os.Getenv("TAG")
 
 type s3CSIUpgradeTestSuite struct {
 	tsInfo storageframework.TestSuiteInfo
@@ -271,7 +271,7 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 // packageHelmChartFromSource creates a Helm package from the CSI Driver's source.
 func packageHelmChartFromSource(version string) string {
 	if helmChartContainerRepository == "" || helmChartContainerTag == "" {
-		Fail("Please set container repository and tag using `MOUNTPOINT_CSI_DRIVER_CONTAINER_REPOSITORY` and `MOUNTPOINT_CSI_DRIVER_CONTAINER_TAG` environment variables if you want to test a source build")
+		Fail("Please set container repository and tag using `REGISTRY` and `TAG` environment variables if you want to test a source build")
 	}
 
 	out := GinkgoT().TempDir()

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -41,7 +41,7 @@ const helmReleaseNamespace = "kube-system"
 
 var helmChartPreviousVersion = os.Getenv("MOUNTPOINT_CSI_DRIVER_PREVIOUS_VERSION")
 var helmChartNewVersion = os.Getenv("MOUNTPOINT_CSI_DRIVER_NEW_VERSION")
-var helmChartContainerRepository = os.Getenv("REGISTRY")
+var helmChartContainerRepository = os.Getenv("REPOSITORY")
 var helmChartContainerTag = os.Getenv("TAG")
 
 type s3CSIUpgradeTestSuite struct {
@@ -271,7 +271,7 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 // packageHelmChartFromSource creates a Helm package from the CSI Driver's source.
 func packageHelmChartFromSource(version string) string {
 	if helmChartContainerRepository == "" || helmChartContainerTag == "" {
-		Fail("Please set container repository and tag using `REGISTRY` and `TAG` environment variables if you want to test a source build")
+		Fail("Please set container repository and tag using `REPOSITORY` and `TAG` environment variables if you want to test a source build")
 	}
 
 	out := GinkgoT().TempDir()

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -323,7 +323,13 @@ func installCSIDriver(cfg *action.Configuration, version string, chartPath strin
 	chart, err := loader.Load(chartPath)
 	framework.ExpectNoError(err)
 
-	release, err := installClient.RunWithContext(context.Background(), chart, map[string]any{})
+	release, err := installClient.RunWithContext(context.Background(), chart, map[string]any{
+		"node": map[string]any{
+			"podInfoOnMountCompat": map[string]any{
+				"enable": "true",
+			},
+		},
+	})
 	framework.ExpectNoError(err)
 
 	framework.Logf("Helm release %q created", release.Name)


### PR DESCRIPTION
This is a follow-up PR for https://github.com/awslabs/mountpoint-s3-csi-driver/pull/532 to fix problems with GitHub workflow. Triggered a successful upgrade test from 1.15.0 to 2.0.0-source on https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/16503618110.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
