### PR TITLE
Simplify GitHub workflow matrix & update some docs

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -1,11 +1,11 @@
 matrix:
   cluster-type: ["eksctl"]
   arch: ["x86", "arm"]
-  family: ["AmazonLinux2", "AmazonLinux2023", "Bottlerocket"]
+  family: ["AmazonLinux2", "AmazonLinux2023", "Bottlerocket", "Ubuntu2204"]
   kubernetes-version:
     ["1.28.13", "1.29.8", "1.30.4", "1.31.0", "1.32.1", "1.33.2"]
   include:
-    # Ubuntu2004 supported for EKS <= 1.29 and Ubuntu2204 supported for EKS >= 1.29.
+    # Ubuntu2004 supported for EKS <= 1.29
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
     - cluster-type: "eksctl"
       arch: "x86"
@@ -15,29 +15,9 @@ matrix:
       arch: "arm"
       family: "Ubuntu2004"
       kubernetes-version: "1.29.8"
-    - cluster-type: "eksctl"
-      arch: "x86"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.30.4"
-    - cluster-type: "eksctl"
-      arch: "arm"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.31.0"
-    - cluster-type: "eksctl"
-      arch: "arm"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.32.1"
-    # TODO: Enable this once EKS 1.33 Ubuntu AMI is available.
-    # - cluster-type: "eksctl"
-    #   arch: "arm"
-    #   family: "Ubuntu2204"
-    #   kubernetes-version: "1.33.2"
-    # Since we only enable enforcing mode for SELinux in AL2023, it's easier to list it in "include"
+    # Enable enforcing mode for SELinux in AL2023, it's easier to list it in "include"
     # field rather than trying to exclude all other variants.
-    - cluster-type: "eksctl"
-      arch: "x86"
-      family: "AmazonLinux2023"
-      kubernetes-version: "1.32.1"
+    - family: "AmazonLinux2023"
       selinux-mode: "enforcing"
   exclude:
     - cluster-type: "eksctl"
@@ -47,3 +27,8 @@ matrix:
     - cluster-type: "eksctl"
       family: "AmazonLinux2"
       kubernetes-version: "1.33.2"
+    # Ubuntu2204 only supported for EKS >= 1.29.
+    # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
+    - cluster-type: "eksctl"
+      family: "Ubuntu2204"
+      kubernetes-version: "1.28.13"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -134,13 +134,6 @@ jobs:
         run: |
           tests/e2e-kubernetes/scripts/run.sh
       - name: Run E2E Tests
-        # The CSI Driver v1 doesn't support running on SELinux enabled hosts,
-        # so we're skipping upgrade tests from v1 if SELinux is enabled.
-        # TODO: Delete this after 2.0.0 release as we wouldn't need to run upgrade tests from 1.x afterward.
-        if: |
-          matrix.selinux-mode != 'enforcing' ||
-          !inputs.run_upgrade_tests ||
-          !startsWith(inputs.upgrade_tests_old_version, '1.')
         env:
           ACTION: "${{ inputs.run_upgrade_tests && 'run_upgrade_tests' || 'run_tests' }}"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 [Documentation](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/v2.0.0/README.md)
 
-### Notable changes
+### Breaking changes
 See [Mountpoint for Amazon S3 CSI Driver v2](https://github.com/awslabs/mountpoint-s3-csi-driver/issues/504) for new features, and [Upgrading Mountpoint for Amazon S3 CSI Driver from v1 to v2](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/UPGRADING_TO_V2.md) for more details on breaking changes and necessary steps for upgrading to v2.
 
 # v1.15.0

--- a/cmd/aws-s3-csi-controller/main.go
+++ b/cmd/aws-s3-csi-controller/main.go
@@ -1,9 +1,9 @@
-// WIP: Part of https://github.com/awslabs/mountpoint-s3-csi-driver/issues/279.
-//
 // `aws-s3-csi-controller` is the entrypoint binary for the CSI Driver's controller component.
 // It is responsible for acting on cluster events and spawning Mountpoint Pods when necessary.
 // It is also responsible for managing Mountpoint Pods, for example it ensures that completed Mountpoint Pods gets deleted.
 // It doesn't implement CSI's controller service as of today.
+//
+// See /docs/ARCHITECTURE.md for more details.
 package main
 
 import (

--- a/cmd/aws-s3-csi-mounter/main.go
+++ b/cmd/aws-s3-csi-mounter/main.go
@@ -1,9 +1,9 @@
-// WIP: Part of https://github.com/awslabs/mountpoint-s3-csi-driver/issues/279.
-//
 // `aws-s3-csi-mounter` is the entrypoint binary running on Mountpoint Pods.
 // It is responsible for receiving mount options from the CSI Driver Node Pod,
 // and spawning a Mountpoint instance in turn.
 // It will then wait until Mountpoint process terminates (which normally happens as a result of `unmount`).
+//
+// See /docs/ARCHITECTURE.md for more details.
 package main
 
 import (

--- a/docs/UPGRADING_TO_V2.md
+++ b/docs/UPGRADING_TO_V2.md
@@ -103,7 +103,7 @@ See [Delegating volume permission and ownership change to CSI driver](https://ku
 ## Upgrading to v2
 
 > [!NOTE]
-> Please note that the CSI Driver v2 has some constrains with node autoscalers like [Karpenter](https://karpenter.sh/) and [Cluster Autoscaler](https://docs.aws.amazon.com/eks/latest/best-practices/cas.html).
+> Please note that the CSI Driver v2 has some constraints with node autoscalers like [Karpenter](https://karpenter.sh/) and [Cluster Autoscaler](https://docs.aws.amazon.com/eks/latest/best-practices/cas.html).
 > For more details please see [this GitHub issue](https://github.com/awslabs/mountpoint-s3-csi-driver/issues/543).
 
 After making necessary changes for the breaking changes described in the [changes](#changes) section, you can follow regular [Installing Mountpoint for Amazon S3 CSI Driver](INSTALL.md) guidance to install the CSI Driver v2 with a method of your choosing.


### PR DESCRIPTION
Simplifying the GitHub workflow after 2.0.0 release to:
- Add `Ubuntu2204` by default and only exclude on `1.28.13` (as it's unsupported)
- Add `Ubuntu2004` only for `1.28.13` and `1.29.8` (as it's only supported in these versions)
- Enable SELinux in all AL2023 variants.

Also, addressed a TODO in upgrade tests regarding skipping tests with SELinux-enabled variants, and updated some documents regarding feedback from previous PRs.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
