### PR TITLE
Gate `selectableFields` in CRD definition for Kubernetes <1.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,7 @@ TMP_POD_ATTACHMENT_CRD_FILE ?= "./hack/s3.csi.aws.com_mountpoints3podattachments
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./pkg/api/..."
 	$(CONTROLLER_GEN) crd paths="./pkg/api/..." output:crd:dir=./hack/
+	patch $(TMP_POD_ATTACHMENT_CRD_FILE) < ./hack/patches/selectablefields-k8s-version.patch
 	echo '# Auto-generated file via `make generate`. Do not edit.' > $(HELM_POD_ATTACHMENT_CRD_FILE)
 	cat $(TMP_POD_ATTACHMENT_CRD_FILE) >> $(HELM_POD_ATTACHMENT_CRD_FILE)
 	rm $(TMP_POD_ATTACHMENT_CRD_FILE)

--- a/charts/aws-mountpoint-s3-csi-driver/templates/mountpoints3podattachments-crd.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/mountpoints3podattachments-crd.yaml
@@ -124,8 +124,10 @@ spec:
             - workloadFSGroup
             type: object
         type: object
+    {{- if semverCompare ">=1.32.0-0" .Capabilities.KubeVersion.Version }}
     selectableFields:
     - jsonPath: .spec.nodeName
+    {{- end }}
     served: true
     storage: true
     subresources:

--- a/hack/patches/selectablefields-k8s-version.patch
+++ b/hack/patches/selectablefields-k8s-version.patch
@@ -1,0 +1,13 @@
+--- ./hack/s3.csi.aws.com_mountpoints3podattachments.yaml.orig	2025-07-31 14:45:10
++++ ./hack/s3.csi.aws.com_mountpoints3podattachments.yaml	2025-07-31 14:45:42
+@@ -123,8 +123,10 @@
+             - workloadFSGroup
+             type: object
+         type: object
++    {{- if semverCompare ">=1.32.0-0" .Capabilities.KubeVersion.Version }}
+     selectableFields:
+     - jsonPath: .spec.nodeName
++    {{- end }}
+     served: true
+     storage: true
+     subresources:

--- a/tests/e2e-kubernetes/scripts/helm.sh
+++ b/tests/e2e-kubernetes/scripts/helm.sh
@@ -76,7 +76,7 @@ function helm_validate_driver() {
   echo "Validating $RELEASE_NAME on the server side..."
 
   # Get all installed manifests and validate them on the server side
-  $HELM_BIN get manifest --namespace kube-system $RELEASE_NAME | \
+  $HELM_BIN get manifest --namespace kube-system --kubeconfig ${KUBECONFIG} $RELEASE_NAME | \
     $KUBECTL_BIN replace --kubeconfig $KUBECONFIG --dry-run=server --validate=strict --warnings-as-errors -f -
 }
 


### PR DESCRIPTION
[Selectable fields for custom resources](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#crd-selectable-fields) GA'd on Kubernetes 1.32. We [check Kubernetes version at the runtime](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/d9cc082b6c27922f4efb54b742b47841bd9fb590/pkg/cluster/cluster.go#L58-L70) before using this feature, but our Helm template contains this field regardless of the Kubernetes version. 

This could either cause a validation error or a warning ([as in our CI](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/16598473580/job/46952783952#step:9:151)) like:
```
I0729 14:24:39.116674    4077 warnings.go:110] "Warning: unknown field \"spec.versions[0].selectableFields\""
```

This PR also adds a new validation step to ensure we validate the CSI Driver's Kubernetes manifests on the server-side using strict validation rules. Hoping that this will help us to catch any incompatibilities on the manifests like this in different Kubernetes versions in the future. Also [verified that the new validation step can catch this issue](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/16650915211/job/47125853890#step:9:220) before applying the fix.

--- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
