### PR TITLE
Increase max retries even further in CI and also apply to AWS CLI calls

### DIFF
--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -2,6 +2,9 @@
 
 set -euox pipefail
 
+export AWS_RETRY_MODE=standard
+export AWS_MAX_ATTEMPTS=10
+
 ACTION=${ACTION:-}
 REGION=${AWS_REGION}
 
@@ -169,14 +172,14 @@ elif [[ "${ACTION}" == "install_driver" ]]; then
 elif [[ "${ACTION}" == "run_tests" ]]; then
   set +e
   pushd tests/e2e-kubernetes
-  KUBECONFIG=${KUBECONFIG} ginkgo -p -vv -timeout 60m -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=true --cluster-name=${CLUSTER_NAME}
+  KUBECONFIG=${KUBECONFIG} ginkgo -p -vv --github-output -timeout 60m -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=true --cluster-name=${CLUSTER_NAME}
   EXIT_CODE=$?
   print_cluster_info
   exit $EXIT_CODE
 elif [[ "${ACTION}" == "run_upgrade_tests" ]]; then
   set +e
   pushd tests/e2e-kubernetes
-  KUBECONFIG=${KUBECONFIG} ginkgo -vv -timeout 10h -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=true --cluster-name=${CLUSTER_NAME} --run-upgrade-tests
+  KUBECONFIG=${KUBECONFIG} ginkgo -vv --github-output -timeout 10h -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=true --cluster-name=${CLUSTER_NAME} --run-upgrade-tests
   EXIT_CODE=$?
   print_cluster_info
   exit $EXIT_CODE

--- a/tests/e2e-kubernetes/testsuites/util.go
+++ b/tests/e2e-kubernetes/testsuites/util.go
@@ -316,7 +316,7 @@ func awsConfig(ctx context.Context) aws.Config {
 		config.WithRegion(DefaultRegion),
 		config.WithRetryer(func() aws.Retryer {
 			return retry.NewStandard(func(opts *retry.StandardOptions) {
-				opts.MaxAttempts = 5
+				opts.MaxAttempts = 10
 				opts.MaxBackoff = 2 * time.Minute
 			})
 		}))


### PR DESCRIPTION
Max retries of 5 even [sometimes fails](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/16671525652/job/47189139429?pr=555#step:10:9055), this PR increases that to 10. Also, we get throttles as part of [our CI scripts as well](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/16671525652/job/47189139544?pr=555#step:8:98), this PR also applies some retry configuration to AWS CLI calls.

Also added `--github-output` to our Ginkgo calls to make output more friendly in GitHub console.

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
