### PR TITLE
Make the env variables passed to the initContainer configurable

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -67,6 +67,9 @@ spec:
           env:
             - name: MOUNTPOINT_INSTALL_DIR
               value: /target
+          {{- with .Values.initContainer.installMountpoint.env }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: mp-install
               mountPath: /target

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -81,6 +81,7 @@ sidecars:
 initContainer:
   installMountpoint:
     resources: {}
+    env: []
 
 controller:
   serviceAccount:


### PR DESCRIPTION
*Issue #568 :*
*Description of changes:*
To pass in env variables to the init container.
**Testing Evidence**
Ran helm-template to test that the change doesn't break 
<img width="707" height="397" alt="image" src="https://github.com/user-attachments/assets/60910657-52c9-4532-954a-301fb9b17938" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
