### PR TITLE
Move MP Pod VolumeID and PV name to Annotations instead of Labels

### DIFF
--- a/pkg/driver/node/mounter/pod_unmounter.go
+++ b/pkg/driver/node/mounter/pod_unmounter.go
@@ -227,8 +227,14 @@ func (u *PodUnmounter) writeExitFile(podPath string) error {
 
 // cleanupCredentials removes credentials associated with the Mountpoint Pod
 func (u *PodUnmounter) cleanupCredentials(mpPod *corev1.Pod) error {
+	volumeID := mpPod.Annotations[mppod.AnnotationVolumeId]
+	if volumeID == "" {
+		// Fallback to legacy label for backward compatibility with old MP pods (v2.0.0)
+		volumeID = mpPod.Labels[mppod.DeprecatedLabelVolumeId]
+	}
+
 	return u.credProvider.Cleanup(credentialprovider.CleanupContext{
-		VolumeID:  mpPod.Labels[mppod.LabelVolumeId],
+		VolumeID:  volumeID,
 		PodID:     string(mpPod.UID),
 		WritePath: mppod.PathOnHost(u.podPath(string(mpPod.UID)), mppod.KnownPathCredentials),
 		MountKind: credentialprovider.MountKindPod,

--- a/pkg/driver/node/mounter/pod_unmounter_test.go
+++ b/pkg/driver/node/mounter/pod_unmounter_test.go
@@ -107,9 +107,7 @@ func TestHandleS3PodAttachmentUpdate(t *testing.T) {
 					UID:       "uid1",
 					Annotations: map[string]string{
 						mppod.AnnotationNeedsUnmount: "true",
-					},
-					Labels: map[string]string{
-						mppod.LabelVolumeId: "vol1",
+						mppod.AnnotationVolumeId:     "vol1",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -149,9 +147,7 @@ func TestHandleS3PodAttachmentUpdate(t *testing.T) {
 					UID:       "uid1",
 					Annotations: map[string]string{
 						mppod.AnnotationNeedsUnmount: "true",
-					},
-					Labels: map[string]string{
-						mppod.LabelVolumeId: "vol1",
+						mppod.AnnotationVolumeId:     "vol1",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -173,9 +169,7 @@ func TestHandleS3PodAttachmentUpdate(t *testing.T) {
 					UID:       "uid1",
 					Annotations: map[string]string{
 						mppod.AnnotationNeedsUnmount: "true",
-					},
-					Labels: map[string]string{
-						mppod.LabelVolumeId: "vol1",
+						mppod.AnnotationVolumeId:     "vol1",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -277,9 +271,30 @@ func TestCleanupDanglingMounts(t *testing.T) {
 						UID:       "uid1",
 						Annotations: map[string]string{
 							mppod.AnnotationNeedsUnmount: "true",
+							mppod.AnnotationVolumeId:     "vol1",
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: nodeName,
+					},
+				},
+			},
+			expectedCalls: 1,
+		},
+		{
+			name: "pod marked for unmount with legacy label fallback",
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: mountpointPodNamespace,
+						UID:       "uid1",
+						Annotations: map[string]string{
+							mppod.AnnotationNeedsUnmount: "true",
+							// No AnnotationVolumeId - should fallback to legacy label
 						},
 						Labels: map[string]string{
-							mppod.LabelVolumeId: "vol1",
+							mppod.DeprecatedLabelVolumeId: "vol1-legacy",
 						},
 					},
 					Spec: corev1.PodSpec{
@@ -299,9 +314,7 @@ func TestCleanupDanglingMounts(t *testing.T) {
 						UID:       "uid1",
 						Annotations: map[string]string{
 							mppod.AnnotationNeedsUnmount: "true",
-						},
-						Labels: map[string]string{
-							mppod.LabelVolumeId: "vol1",
+							mppod.AnnotationVolumeId:     "vol1",
 						},
 					},
 					Spec: corev1.PodSpec{

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -18,9 +18,8 @@ import (
 
 // Labels populated on spawned Mountpoint Pods.
 const (
-	LabelMountpointVersion = "s3.csi.aws.com/mountpoint-version"
-	LabelVolumeName        = "s3.csi.aws.com/volume-name"
-	LabelVolumeId          = "s3.csi.aws.com/volume-id"
+	LabelMountpointVersion  = "s3.csi.aws.com/mountpoint-version"
+	DeprecatedLabelVolumeId = "s3.csi.aws.com/volume-id"
 	// LabelCSIDriverVersion specifies the CSI Driver's version used during creation of the Mountpoint Pod.
 	// The controller checks this label against the current CSI Driver version before assigning a new workload to the Mountpoint Pod,
 	// if they differ, the controller won't send new workload to the Mountpoint Pod and instead creates a new one.
@@ -39,6 +38,8 @@ const (
 	// The existing workloads won't affected with this annotation, and would keep running until termination as per their regular lifecycle.
 	// The controller ensures to not send new workload after the Mountpoint Pod annotated with this annotation.
 	AnnotationNoNewWorkload = "s3.csi.aws.com/no-new-workload"
+	AnnotationVolumeName    = "s3.csi.aws.com/volume-name"
+	AnnotationVolumeId      = "s3.csi.aws.com/volume-id"
 )
 
 const (
@@ -108,9 +109,11 @@ func (c *Creator) MountpointPod(node string, pv *corev1.PersistentVolume, priori
 			Namespace:    c.config.Namespace,
 			Labels: map[string]string{
 				LabelMountpointVersion: c.config.MountpointVersion,
-				LabelVolumeName:        pv.Name,
-				LabelVolumeId:          pv.Spec.CSI.VolumeHandle,
 				LabelCSIDriverVersion:  c.config.CSIDriverVersion,
+			},
+			Annotations: map[string]string{
+				AnnotationVolumeName: pv.Name,
+				AnnotationVolumeId:   pv.Spec.CSI.VolumeHandle,
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -282,9 +282,11 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 		assert.Equals(t, map[string]string{
 			mppod.LabelMountpointVersion: mountpointVersion,
 			mppod.LabelCSIDriverVersion:  csiDriverVersion,
-			mppod.LabelVolumeName:        testVolName,
-			mppod.LabelVolumeId:          testVolID,
 		}, mpPod.Labels)
+		assert.Equals(t, map[string]string{
+			mppod.AnnotationVolumeName: testVolName,
+			mppod.AnnotationVolumeId:   testVolID,
+		}, mpPod.Annotations)
 
 		assert.Equals(t, expectedPriorityClassName, mpPod.Spec.PriorityClassName)
 		assert.Equals(t, corev1.RestartPolicyOnFailure, mpPod.Spec.RestartPolicy)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/mountpoint-s3-csi-driver/issues/584

*Description of changes:*

If customers use very long `volumeHandle` or `name` in the PV (or use invalid chars like `s3://amzn-s3-demo-bucket`) then MP Pod creation fails due to error.

Labels value have the following limits: 63 char max, Must start with letter/number, can contain -, _, ., letters and numbers

Whereas Annotations have no such limits (max size is 256KB). 

Solution: Move from Labels to Annotations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
