### PR TITLE
Assigns pods to nodes directly instead of using affinity

### DIFF
--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -146,22 +146,9 @@ func (c *Creator) MountpointPod(node string, pv *corev1.PersistentVolume, priori
 				},
 			}},
 			PriorityClassName: priorityClassName,
-			Affinity: &corev1.Affinity{
-				NodeAffinity: &corev1.NodeAffinity{
-					// This is to making sure Mountpoint Pod gets scheduled into same node as the Workload Pod
-					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							{
-								MatchFields: []corev1.NodeSelectorRequirement{{
-									Key:      metav1.ObjectNameField,
-									Operator: corev1.NodeSelectorOpIn,
-									Values:   []string{node},
-								}},
-							},
-						},
-					},
-				},
-			},
+			// Direct node assignment instead of using node affinity with labels
+			// This ensures the pod is scheduled on the specific node without relying on labels
+			NodeName: node,
 			Tolerations: []corev1.Toleration{
 				// Tolerate all taints.
 				// - "NoScheduled" – If the Workload Pod gets scheduled to a node, Mountpoint Pod should also get


### PR DESCRIPTION
Switches from node affinity with label matching to explicit node assignment for pod scheduling. This simplifies pod placement and avoids reliance on node labels.

This pull request updates the scheduling logic for Mountpoint Pods in the `pkg/podmounter/mppod/creator.go` file. Instead of using node affinity with labels, it now directly assigns the pod to the target node using the `NodeName` field. This change simplifies pod scheduling and ensures more reliable placement.

Pod scheduling improvements:

* Replaced node affinity configuration with direct assignment via the `NodeName` field in the Mountpoint Pod spec, ensuring pods are scheduled on the intended node without relying on node labels.

#566