### PR TITLE
Add Helm NOTES.txt for post-install/upgrade messages

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
@@ -1,0 +1,8 @@
+Thank you for using Mountpoint for Amazon S3 CSI Driver v{{ .Chart.Version }}.
+
+Learn more about the FS operations Mountpoint supports: https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md
+
+{{- if .Release.IsUpgrade }}
+
+While the CSI driver has been upgraded, existing Mountpoint Pods remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted. You can view the Mountpoint versions in use by V2 of the CSI driver using `kubectl get pods -n mount-s3 --label-columns="s3.csi.aws.com/mountpoint-version"`.
+{{- end }}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
@@ -4,5 +4,5 @@ Learn more about the file system operations Mountpoint supports: https://github.
 
 {{- if .Release.IsUpgrade }}
 
-While the CSI driver has been upgraded, existing Mountpoint Pods remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted. You can view which pods exist created by older V2 versions of the CSI driver using `kubectl get pods -n mount-s3 --label-columns="s3.csi.aws.com/created-by-csi-driver-version"`.
+While the CSI driver has been upgraded, existing Mountpoint Pods remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted. You can view which pods exist created by older V2 versions of the CSI driver using `kubectl get pods -n mount-s3 --label-columns="s3.csi.aws.com/mounted-by-csi-driver-version"`.
 {{- end }}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
@@ -1,8 +1,8 @@
 Thank you for using Mountpoint for Amazon S3 CSI Driver v{{ .Chart.Version }}.
 
-Learn more about the FS operations Mountpoint supports: https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md
+Learn more about the file system operations Mountpoint supports: https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md
 
 {{- if .Release.IsUpgrade }}
 
-While the CSI driver has been upgraded, existing Mountpoint Pods remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted. You can view the Mountpoint versions in use by V2 of the CSI driver using `kubectl get pods -n mount-s3 --label-columns="s3.csi.aws.com/mountpoint-version"`.
+While the CSI driver has been upgraded, existing Mountpoint Pods remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted. You can view which pods exist created by older V2 versions of the CSI driver using `kubectl get pods -n mount-s3 --label-columns="s3.csi.aws.com/created-by-csi-driver-version"`.
 {{- end }}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This change introduces the first iteration of `NOTES.txt`, which is a template message shown following an install or upgrade of the Helm chart.

The initial content describes the version installed, where to learn what file system operations are supported, and also displays information about how the Mountpoint processes are updated during an upgrade.

Follow-up from this PR review: https://github.com/awslabs/mountpoint-s3-csi-driver/pull/596#pullrequestreview-3303661282

This is the output from an upgrade:

    ❯ helm upgrade --install aws-mountpoint-s3-csi-driver \
        --namespace kube-system \
       ./charts/aws-mountpoint-s3-csi-driver
    Release "aws-mountpoint-s3-csi-driver" has been upgraded. Happy Helming!
    NAME: aws-mountpoint-s3-csi-driver
    LAST DEPLOYED: Tue Oct  7 10:46:18 2025
    NAMESPACE: kube-system
    STATUS: deployed
    REVISION: 5
    TEST SUITE: None
    NOTES:
    Thank you for using Mountpoint for Amazon S3 CSI Driver v2.1.0.
    
    Learn more about the file system operations Mountpoint supports: https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md
    
    While the CSI driver has been upgraded, existing Mountpoint Pods remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted. You can view which pods exist created by older V2 versions of the CSI driver using `kubectl get pods -n mount-s3 --label-columns="s3.csi.aws.com/mounted-by-csi-driver-version"`.

The following is the output from the `kubectl` command. Ignore the failed pod!

    ❯ kubectl get pods -n mount-s3 --label-columns="s3.csi.aws.com/mounted-by-csi-driver-version"
    NAME       READY   STATUS             RESTARTS         AGE   MOUNTED-BY-CSI-DRIVER-VERSION
    mp-9sz2r   0/1     CrashLoopBackOff   166 (2m5s ago)   16h   2.1.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
