### PR TITLE
Use workload pod tolerations on mountpointpod

### DIFF
--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -721,7 +721,7 @@ func (r *Reconciler) spawnMountpointPod(
 ) (*corev1.Pod, error) {
 	log.Info("Spawning Mountpoint Pod")
 
-	mpPod, err := r.mountpointPodCreator.MountpointPod(workloadPod.Spec.NodeName, pv, priorityClassKind)
+	mpPod, err := r.mountpointPodCreator.MountpointPod(workloadPod, pv, priorityClassKind)
 	if err != nil {
 		log.Error(err, "Failed to create Mountpoint Pod Spec")
 		return nil, err


### PR DESCRIPTION
*Issue:* #595

*Description of changes:*

This changes the tolerations set on the mountpointPod from tolerating _everything_ to only tolerating the same as the workload pod which is running on the same node and thereby already tolerates enough to land on the node.

The motivation for this change is that some environments use taints/tolerations as a way to enforce that certain workloads can't be scheduled on certain nodes. In our case we use a validating webhook to check pod specs and prevent too permissive tolerations as described in #595. Without this change the mountpointPod gets blocked from creation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
