### PR TITLE
Helm chart value to set awsAccessSecret not optional

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -87,19 +87,19 @@ spec:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .keyId }}
-                  optional: true
+                  optional: {{ .optional }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .accessKey }}
-                  optional: true
+                  optional: {{ .optional }}
             - name: AWS_SESSION_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .sessionToken }}
-                  optional: true
+                  optional: {{ .optional }}
             {{- end }}
           volumeMounts:
             - name: kubelet-dir

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -102,6 +102,7 @@ awsAccessSecret:
   keyId: key_id
   accessKey: access_key
   sessionToken: session_token
+  optional: true
 
 # The default IPv4 address in the credentials URI is in accordance to the references below:
 # Doc: https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html


### PR DESCRIPTION
This PR introduces a new value to the Helm chart, enabling users to configure whether the AWS access secret is optional.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
