### PR TITLE
Configure Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,6 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directories:
-      - "./"
-      - "./tests/e2e-kubernetes"
-    schedule:
-      interval: "monthly"
-    # ensure updates are batched into one PR
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     # Use limit of 1 PR, checked daily, to handle rush of updates.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This change configures Dependabot for Mountpoint's CSI Driver repository. This will allow our dependencies to be updated on a schedule, to avoid them getting too outdated and ensure we stay relatively up-to-date.

For GitHub Actions, we allow each one to be updated separately. I feel these are more challenging to review and will be best reviewed individually. Note, this has been neglected and will launch a lot of PRs. Initially, this change checks for updates daily and allows at most 1 PR to be open at a time. This is to manage the number of PRs appearing. We should relax this later once we're in a better position.

This does not address Golang dependencies. Unfortunately, 0.x minor releases are not treated as breaking changes and would introduce noise to the repository. For now, we'll leave this out of scope.

This does not address Helm charts. Helm chart updates are currently impacted by this bug in Dependabot: https://github.com/dependabot/dependabot-core/issues/11921. Once resolved, I recommend we additionally configure Helm chart updates which covers both Helm dependencies and the container images referenced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
