### PR TITLE
Add env var for EKS Pod Identity token audience and service principal 

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -81,6 +81,8 @@ spec:
               value: {{ .Values.mountpointPod.namespace }}
             - name: EKS_POD_IDENTITY_AGENT_CONTAINER_CREDENTIALS_FULL_URI
               value: {{ .Values.eksPodIdentityAgent.containerCredentialsFullURI }}
+            - name: POD_IDENTITY_TOKEN_AUDIENCE
+              value: pods.eks.amazonaws.com
             {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/pkg/driver/node/credentialprovider/provider_pod.go
+++ b/pkg/driver/node/credentialprovider/provider_pod.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/renameio"
@@ -17,10 +18,11 @@ import (
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
 )
 
+var serviceAccountTokenAudiencePodIdentity = determineServiceAccountTokenAudienceEKS()
+
 const (
-	serviceAccountTokenAudienceSTS         = "sts.amazonaws.com"
-	serviceAccountTokenAudiencePodIdentity = "pods.eks.amazonaws.com"
-	serviceAccountRoleAnnotation           = "eks.amazonaws.com/role-arn"
+	serviceAccountTokenAudienceSTS = "sts.amazonaws.com"
+	serviceAccountRoleAnnotation   = "eks.amazonaws.com/role-arn"
 )
 
 const podLevelCredentialsDocsPage = "https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#pod-level-credentials"
@@ -235,4 +237,14 @@ func (c *Provider) createEKSPodIdentityCredentialsEnvironment(provideCtx Provide
 		envprovider.EnvContainerCredentialsFullURI:     eksPodIdentityAgentCredentialsURI,
 		envprovider.EnvContainerAuthorizationTokenFile: tokenFile,
 	}, nil
+}
+
+func determineServiceAccountTokenAudienceEKS() string {
+	const envPodIdentityTokenAudience = "POD_IDENTITY_TOKEN_AUDIENCE"
+	fromEnv := strings.TrimSpace(os.Getenv(envPodIdentityTokenAudience))
+	if len(fromEnv) == 0 {
+		return "pods.eks.amazonaws.com"
+	} else {
+		return fromEnv
+	}
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

For testing in internal EKS environments, we may wish to modify the token audience and service principal used. This change allows it to be overridden in the node service and end-to-end tests.

The default value is unchanged, and remains `"pods.eks.amazonaws.com"`.

We may consider making changes to the Helm chart, however I'm leaving it out for this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
