### PR TITLE
Remove unused Python setup steps from GitHub CI

### DIFF
--- a/.github/workflows/delete-cluster.yaml
+++ b/.github/workflows/delete-cluster.yaml
@@ -49,9 +49,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -101,9 +101,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

As discussed in https://github.com/awslabs/mountpoint-s3-csi-driver/pull/618#issuecomment-3468971045, the Python setup steps are not required since the steps depending on Python were removed in this commit: https://github.com/awslabs/mountpoint-s3-csi-driver/commit/72dd1bd3c28bb4610b1cc5b6d94d737102293ce8. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.