### PR TITLE
Remove overrides for EKS PLI token audience, keep for AWS service principal

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -81,8 +81,6 @@ spec:
               value: {{ .Values.mountpointPod.namespace }}
             - name: EKS_POD_IDENTITY_AGENT_CONTAINER_CREDENTIALS_FULL_URI
               value: {{ .Values.eksPodIdentityAgent.containerCredentialsFullURI }}
-            - name: POD_IDENTITY_TOKEN_AUDIENCE
-              value: pods.eks.amazonaws.com
             {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/pkg/driver/node/credentialprovider/provider_pod.go
+++ b/pkg/driver/node/credentialprovider/provider_pod.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/google/renameio"
@@ -18,11 +17,10 @@ import (
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
 )
 
-var serviceAccountTokenAudiencePodIdentity = determineServiceAccountTokenAudienceEKS()
-
 const (
-	serviceAccountTokenAudienceSTS = "sts.amazonaws.com"
-	serviceAccountRoleAnnotation   = "eks.amazonaws.com/role-arn"
+	serviceAccountTokenAudienceSTS         = "sts.amazonaws.com"
+	serviceAccountTokenAudiencePodIdentity = "pods.eks.amazonaws.com"
+	serviceAccountRoleAnnotation           = "eks.amazonaws.com/role-arn"
 )
 
 const podLevelCredentialsDocsPage = "https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#pod-level-credentials"
@@ -237,14 +235,4 @@ func (c *Provider) createEKSPodIdentityCredentialsEnvironment(provideCtx Provide
 		envprovider.EnvContainerCredentialsFullURI:     eksPodIdentityAgentCredentialsURI,
 		envprovider.EnvContainerAuthorizationTokenFile: tokenFile,
 	}, nil
-}
-
-func determineServiceAccountTokenAudienceEKS() string {
-	const envPodIdentityTokenAudience = "POD_IDENTITY_TOKEN_AUDIENCE"
-	fromEnv := strings.TrimSpace(os.Getenv(envPodIdentityTokenAudience))
-	if len(fromEnv) == 0 {
-		return "pods.eks.amazonaws.com"
-	} else {
-		return fromEnv
-	}
 }

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -73,7 +73,10 @@ const serviceAccountTokenAudienceSTS = "sts.amazonaws.com"
 const roleARNAnnotation = "eks.amazonaws.com/role-arn"
 const credentialSecretName = "aws-secret"
 
-var serviceAccountTokenAudienceEKS = determineServiceAccountTokenAudienceEKS()
+const serviceAccountTokenAudienceEKS = "pods.eks.amazonaws.com"
+
+// AWS Service Principal for EKS Pod Identity
+var eksPodsServicePrincipal = determineEksPodsServicePrincipal()
 
 // DefaultRegion specifies the STS region explicitly.
 var DefaultRegion string
@@ -87,9 +90,9 @@ type s3CSICredentialsTestSuite struct {
 	tsInfo storageframework.TestSuiteInfo
 }
 
-func determineServiceAccountTokenAudienceEKS() string {
-	const envPodIdentityTokenAudience = "POD_IDENTITY_TOKEN_AUDIENCE"
-	fromEnv := strings.TrimSpace(os.Getenv(envPodIdentityTokenAudience))
+func determineEksPodsServicePrincipal() string {
+	const envVarKey = "POD_IDENTITY_SERVICE_PRINCIPAL"
+	fromEnv := strings.TrimSpace(os.Getenv(envVarKey))
 	if len(fromEnv) == 0 {
 		return "pods.eks.amazonaws.com"
 	} else {
@@ -1006,7 +1009,7 @@ func eksPodIdentityRoleTrustPolicyDocument() string {
 			{
 				"Effect": "Allow",
 				"Principal": jsonMap{
-					"Service": serviceAccountTokenAudienceEKS,
+					"Service": eksPodsServicePrincipal,
 				},
 				"Action": []string{"sts:AssumeRole", "sts:TagSession"},
 			},


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The project previously conflated JWT token audiences and AWS service principals, hence an earlier change was not quite the right one: https://github.com/awslabs/mountpoint-s3-csi-driver/commit/2660105356d03e056f0126d4aafc7b8d197cdaa0

This change partially reverts that, and introduces configuration for the AWS service principal only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
