### PR TITLE
Update eksctl_delete_cluster_cf_stack to disable termination protection

### DIFF
--- a/tests/e2e-kubernetes/scripts/eksctl.sh
+++ b/tests/e2e-kubernetes/scripts/eksctl.sh
@@ -124,9 +124,11 @@ function eksctl_delete_cluster() {
   REGION=${3}
   FORCE=${4:-false}
 
+  STACK_NAME="eksctl-${CLUSTER_NAME}-cluster"
   if ! eksctl_cluster_exists "${BIN}" "${CLUSTER_NAME}"; then
     # Try to delete CloudFormation stack even if the cluster does not exists just in case
     # if the stack is stuck in `ROLLBACK_COMPLETE` status.
+    aws cloudformation update-termination-protection --no-enable-termination-protection --region "${REGION}" --stack-name "${STACK_NAME}"
     eksctl_delete_cluster_cf_stack "${CLUSTER_NAME}" "${REGION}"
     return 0
   fi
@@ -137,6 +139,8 @@ function eksctl_delete_cluster() {
     return 0
   fi
 
+
+  aws cloudformation update-termination-protection --no-enable-termination-protection --region "${REGION}" --stack-name "${STACK_NAME}"
   ${BIN} delete cluster "${CLUSTER_NAME}"
   eksctl_delete_cluster_cf_stack "${CLUSTER_NAME}" "${REGION}"
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Update the eksctl delete cluster script to support deleting stacks with termination protection enabled.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
