### PR TITLE
Add explicit permissions to all GHA workflows

### DIFF
--- a/.github/workflows/build_matrix.yaml
+++ b/.github/workflows/build_matrix.yaml
@@ -4,6 +4,10 @@ on:
       matrix:
         description: "Matrix"
         value: ${{ jobs.build_matrix.outputs.matrix }}
+
+permissions:
+  contents: read
+
 jobs:
   build_matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -8,6 +8,9 @@ on:
   merge_group:
     types: ["checks_requested"]
 
+permissions:
+  contents: read
+
 jobs:
   build_matrix:
     name: Build Matrix

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -6,6 +6,8 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest
@@ -32,4 +34,4 @@ jobs:
             {
               "action": "${{ github.event.action }}",
               "url": "${{ github.event.pull_request.html_url }}"
-            } 
+            }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,6 @@ jobs:
     environment: release
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: write
     steps:
       - name: Create Release
@@ -34,6 +33,8 @@ jobs:
   helm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,6 +8,9 @@ on:
   merge_group:
     types: [ "checks_requested" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -47,11 +50,9 @@ jobs:
         name: cover
         path: cover.html
 
-    - name: Comment test coverage
+    - name: Post test coverage to step summary
       if: ${{ github.event_name == 'pull_request' }}
       env:
-        TOTAL_COVERAGE: ${{ steps.go-test-coverage.outputs.total-coverage }}
         ARTIFACT_URL: ${{ steps.uploaded-report.outputs.artifact-url }}
       run: |
-        echo "### Total test coverage: ${{ env.TOTAL_COVERAGE }}%" >> $GITHUB_STEP_SUMMARY
-        echo "Download report: ${{ env.ARTIFACT_URL }}" >> $GITHUB_STEP_SUMMARY
+        echo "Test coverage report: ${{ env.ARTIFACT_URL }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adding explicit permissions to adopt least-privilege principle in workflows.

Some permissions were no longer used: for example, we no longer publish the test coverage although we still tried to write it to the job summary. This removes that for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
