### PR TITLE
Update node daemonset to use host PID namespace

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -47,11 +47,17 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      hostPID: true  # Support Mountpoint semantics which require PID visibility
 
       containers:
         - name: s3-plugin
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           securityContext:
+            # `privileged: true` grants all Kernel capabilities, runs as root, etc..
+            # Required for opening FUSE device and creating mounts.
+            # It may be possible to remove this and use the `capabilities` field,
+            # but Kubernetes API validator currently enforces that this is set to `true` for bidirectional mounts.
+            # https://github.com/kubernetes/kubernetes/blob/v1.34.2/pkg/apis/core/validation/validation.go#L1410-L1413
             privileged: true
             {{- with .Values.node.seLinuxOptions }}
             seLinuxOptions:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -33,10 +33,17 @@ spec:
                       - hybrid
       tolerations:
         - operator: Exists
+      hostPID: true  # Support Mountpoint semantics which require PID visibility
+
       containers:
         - name: s3-plugin
           image: csi-driver
           securityContext:
+            # `privileged: true` grants all Kernel capabilities, runs as root, etc..
+            # Required for opening FUSE device and creating mounts.
+            # It may be possible to remove this and use the `capabilities` field,
+            # but Kubernetes API validator currently enforces that this is set to `true` for bidirectional mounts.
+            # https://github.com/kubernetes/kubernetes/blob/v1.34.2/pkg/apis/core/validation/validation.go#L1410-L1413
             privileged: true
             seLinuxOptions:
               user: system_u


### PR DESCRIPTION
*Issue #, if available:* #626

*Description of changes:*

With Mountpoint CSI Driver V2, the opening of the FUSE device moved from the invocation of Mountpoint as a host process to the node daemon which now hands it over to an unprivileged Mountpoint. Unfortunately, this changed the PID namespace from the host namespace to a namespace specific to the node daemon impacting how the kernel sends PIDs to Mountpoint. All PIDs result in zero, as the FUSE daemon should not have visibility into other namespaces according to the kernel.

This change moves the node daemon to the host PID namespace. The FUSE device will now be opened in the host PID namespace, and the FUSE driver in the kernel will hand over host PIDs to Mountpoint allowing it to correctly implement Mountpoint semantics.

The change has been tested manually by rerunning an application that was impacted by this bug, and it has additionally been tested by installing in an ROSA cluster and verifying pods can be started (but no verification of Mountpoint behavior itself).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
