### PR TITLE
Change Dependabot schedule for GHA to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,5 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    # Use limit of 1 PR, checked daily, to handle rush of updates.
-    # TODO: Remove, update to weekly once the wave is over.
-    open-pull-requests-limit: 1
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Updated the schedule for Dependabot to weekly and removed the limit on open pull requests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
