### PR TITLE
Add annotation to MP pod that its unsafe to evict

### DIFF
--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -37,9 +37,10 @@ const (
 	// AnnotationNoNewWorkload means the Mountpoint Pod shouldn't get a new workload assigned to it.
 	// The existing workloads won't affected with this annotation, and would keep running until termination as per their regular lifecycle.
 	// The controller ensures to not send new workload after the Mountpoint Pod annotated with this annotation.
-	AnnotationNoNewWorkload = "s3.csi.aws.com/no-new-workload"
-	AnnotationVolumeName    = "s3.csi.aws.com/volume-name"
-	AnnotationVolumeId      = "s3.csi.aws.com/volume-id"
+	AnnotationNoNewWorkload                = "s3.csi.aws.com/no-new-workload"
+	AnnotationVolumeName                   = "s3.csi.aws.com/volume-name"
+	AnnotationVolumeId                     = "s3.csi.aws.com/volume-id"
+	AnnotationClusterAutoscalerSafeToEvict = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 )
 
 const (
@@ -114,6 +115,8 @@ func (c *Creator) MountpointPod(node string, pv *corev1.PersistentVolume, priori
 			Annotations: map[string]string{
 				AnnotationVolumeName: pv.Name,
 				AnnotationVolumeId:   pv.Spec.CSI.VolumeHandle,
+				// It's never safe to evict the MP pod, all customer pods should be evicted first which removes MP pod.
+				AnnotationClusterAutoscalerSafeToEvict: "false",
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -284,8 +284,9 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 			mppod.LabelCSIDriverVersion:  csiDriverVersion,
 		}, mpPod.Labels)
 		assert.Equals(t, map[string]string{
-			mppod.AnnotationVolumeName: testVolName,
-			mppod.AnnotationVolumeId:   testVolID,
+			mppod.AnnotationClusterAutoscalerSafeToEvict: "false",
+			mppod.AnnotationVolumeName:                   testVolName,
+			mppod.AnnotationVolumeId:                     testVolID,
 		}, mpPod.Annotations)
 
 		assert.Equals(t, expectedPriorityClassName, mpPod.Spec.PriorityClassName)


### PR DESCRIPTION
*Issue #, if available:* #607

*Description of changes:*

Add `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotation to avoid Mountpoint pods being evicted. Kubernetes should evict workload pods, which will remove Mountpoint pods when no pod depends on them.

This may go some way to preventing the scenario created in #607, where MP pods were evicted before their workload pods. However, it may be worth exploring additional mechanisms like finalizers to model this relationship robustly.

[Kubernetes docs describes the `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation](https://kubernetes.io/docs/reference/labels-annotations-taints/#cluster-autoscaler-kubernetes-io-safe-to-evict):

>The cluster autoscaler never evicts Pods that have this annotation explicitly set to "false"; you could set that on an important Pod that you want to keep running. If this annotation is not set then the cluster autoscaler follows its Pod-level behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
