### PR TITLE
Add wait flag to end-to-end test eksctl delete usage, and disable safety checks

### DIFF
--- a/tests/e2e-kubernetes/scripts/eksctl.sh
+++ b/tests/e2e-kubernetes/scripts/eksctl.sh
@@ -141,7 +141,7 @@ function eksctl_delete_cluster() {
 
 
   aws cloudformation update-termination-protection --no-enable-termination-protection --region "${REGION}" --stack-name "${STACK_NAME}"
-  ${BIN} delete cluster "${CLUSTER_NAME}"
+  ${BIN} delete cluster "${CLUSTER_NAME}" --wait --disable-nodegroup-eviction
   eksctl_delete_cluster_cf_stack "${CLUSTER_NAME}" "${REGION}"
 }
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This change updates the invocation of `eksctl` CLI to correctly wait for the deletion of the cluster. Additionally, I disable some eviction safety checks since we do not care to ensure that the cluster is torn down 'safely' since this is just for end-to-end tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
