### PR TITLE
Add post_test CI target for controller tests, set unit test workflow name

### DIFF
--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -39,3 +39,10 @@ jobs:
       - name: Run Controller Tests
         run: |
           make e2e-controller
+
+  post_test:
+    needs: controller_test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Controller tests completed
+        run: echo "All controller tests passed"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Add a post_test target so we can set a requires relationship for merges. Additionally, update the name of the unit test workflow since "build" doesn't make sense.

After this is merged, we should update the required targets in the repository configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
