### PR TITLE
Move Helm release to manually dispatched workflow

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -1,0 +1,32 @@
+name: Helm publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag referencing commit to create release from"
+        required: true
+
+jobs:
+  # This job is manually dispatched for now, since we do not have image build fully automated yet.
+  helm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          config: .github/cr.yaml
+          mark_as_latest: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,24 +30,3 @@ jobs:
             See [CHANGELOG](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/CHANGELOG.md) for full list of changes
           draft: true
           prerelease: false
-  helm:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          config: .github/cr.yaml
-          mark_as_latest: false


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

There's currently a small window between where the charts are published and when the images are published. This could mean there's a window of time where installs of the driver will fail to bring up components in clusters.

Move Helm release to a manually dispatched workflow for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
