### PR TITLE
Update error log for 'Failed to receive mount options' error

### DIFF
--- a/cmd/aws-s3-csi-mounter/main.go
+++ b/cmd/aws-s3-csi-mounter/main.go
@@ -43,8 +43,8 @@ func main() {
 		}
 
 		klog.Fatalf("Failed to receive mount options from %s: %v. "+
-			"This error is frequently caused by an invalid configuration, "+
-			"please refer to the following page for details: "+
+			"This error is often caused by invalid config, "+
+			"see the troubleshooting doc: "+
 			"https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/TROUBLESHOOTING.md#mountpoint-pods-are-failing-with-failed-to-receive-mount-options-from-commmountsock\n",
 			mountSockPath, err)
 	}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/mountpoint-s3-csi-driver/issues/583

*Description of changes:*

Add a link to the troubleshooting page to the error log.

*Testing:*

```bash
docker run -it --entrypoint /bin/aws-s3-csi-mounter 4c165c216dd2
I1201 13:51:30.655330       1 main.go:68] Trying to receive mount options from /comm/mount.sock
F1201 13:51:30.655522       1 main.go:45] Failed to receive mount options from /comm/mount.sock: failed to listen unix socket /comm/mount.sock: listen unix /comm/mount.sock: bind: no such file or directory. This error is frequently caused by an invalid configuration, please refer to the following page for details: https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/TROUBLESHOOTING.md#mountpoint-pods-are-failing-with-failed-to-receive-mount-options-from-commmountsock
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
