### PR TITLE
Use hostname-based affinity for mountpoint pods on EKS Auto Mode.

### DIFF
--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -151,12 +151,15 @@ func (c *Creator) MountpointPod(node string, pv *corev1.PersistentVolume, priori
 			PriorityClassName: priorityClassName,
 			Affinity: &corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{
-					// This is to making sure Mountpoint Pod gets scheduled into same node as the Workload Pod
+					// Ensure the Mountpoint Pod is scheduled onto the same node as the Workload Pod.
+					// We match on the standard hostname label instead of using MatchFields on metadata.name,
+					// since some schedulers (for example EKS Auto Mode's plugin) do not support MatchFields
+					// in node selector terms.
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 						NodeSelectorTerms: []corev1.NodeSelectorTerm{
 							{
-								MatchFields: []corev1.NodeSelectorRequirement{{
-									Key:      metav1.ObjectNameField,
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
+									Key:      corev1.LabelHostname,
 									Operator: corev1.NodeSelectorOpIn,
 									Values:   []string{node},
 								}},

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -305,11 +305,13 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 					NodeSelectorTerms: []corev1.NodeSelectorTerm{
 						{
-							MatchFields: []corev1.NodeSelectorRequirement{{
-								Key:      metav1.ObjectNameField,
-								Operator: corev1.NodeSelectorOpIn,
-								Values:   []string{testNode},
-							}},
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      corev1.LabelHostname,
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{testNode},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Fixes #657 - Mountpoint pods are sometimes unschedulable on EKS Auto Mode.

Description of changes:
- Change mountpoint pod nodeAffinity from matchFields on metadata.name to a label-based selector on kubernetes.io/hostname (corev1.LabelHostname).
- This preserves the behavior of pinning the mountpoint pod to the same node as the workload pod, while avoiding matchFields in node selector terms, which are not supported by the EKS Auto Mode scheduler plugin.
- Update mppod unit tests to assert on the new MatchExpressions-based affinity.