### PR TITLE
Fix workflow-complete jobs for GitHub workflows

### DIFF
--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -41,8 +41,10 @@ jobs:
           make e2e-controller
 
   post_test:
-    needs: controller_test
+    if: always()
+    needs:
+      - controller_test
     runs-on: ubuntu-latest
     steps:
-      - name: Controller tests completed
-        run: echo "All controller tests passed"
+      - name: Verify jobs succeeded
+        run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -154,13 +154,17 @@ jobs:
         run: |
           tests/e2e-kubernetes/scripts/run.sh
   post_test:
-    needs: test
+    if: always()
+    needs:
+      - test
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
       id-token: write
       contents: read
     steps:
+      - name: Verify jobs succeeded
+        run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Configure AWS Credentials


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Updates jobs to always run and then fail, rather than be skipped when needed jobs fail.
This will allow GitHub to correctly block when tests fail.

Equivalent fix for MP repo: https://github.com/awslabs/mountpoint-s3/pull/1723

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
