### PR TITLE
Update Helm-chart to disable hostPID on OpenShift, add isOpenShift Helm value, disable hostPID on Kustomize

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/_helpers.tpl
@@ -71,3 +71,14 @@ Convert the `--extra-tags` command line arg from a map.
 {{- printf "- \"--extra-tags=%s\"" (join "," $result.pairs) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Determine if running on OpenShift (incl. ROSA)
+*/}}
+{{- define "aws-mountpoint-s3-csi-driver.isOpenShift" -}}
+{{- $isOpenShift := .Values.isOpenShift -}}
+{{- if eq $isOpenShift nil -}}
+{{- $isOpenShift = .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" -}}
+{{- end -}}
+{{- $isOpenShift -}}
+{{- end -}}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -47,7 +47,14 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+
+      {{- if eq (include "aws-mountpoint-s3-csi-driver.isOpenShift" .) "false" }}
       hostPID: true  # Support Mountpoint semantics which require PID visibility
+      {{- else }}
+      # hostPID is not supported by the driver when running in OpenShift.
+      # Impacts Mountpoint semantics, see tracking issue: https://github.com/awslabs/mountpoint-s3-csi-driver/issues/626
+      hostPID: false
+      {{- end }}
 
       containers:
         - name: s3-plugin

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -1,6 +1,10 @@
 # Default values for Mountpoint for Amazon S3 CSI Driver Helm chart.
 # You can customize any values here during installation.
 
+# Set to true if running on OpenShift/ROSA.
+# If not set, auto-detects OpenShift where possible.
+isOpenShift: null
+
 image:
   # Our regional ECR repositories are labelled `eks/aws-s3-csi-driver`.
   # See https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html for the per-region registry list.

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -33,7 +33,12 @@ spec:
                       - hybrid
       tolerations:
         - operator: Exists
-      hostPID: true  # Support Mountpoint semantics which require PID visibility
+
+      # hostPID=true is required to support Mountpoint semantics which require PID visibility
+      # Unfortunately, we cannot turn it on for OpenShift at this time.
+      # This is disabled when installing via Kustomize since it is not possible to know if the manifest is being applied to an OpenShift cluster or not.
+      # See tracking issue: https://github.com/awslabs/mountpoint-s3-csi-driver/issues/626
+      hostPID: false
 
       containers:
         - name: s3-plugin


### PR DESCRIPTION
This is a cherry-pick of #667 onto `release-2.2`.

This change should be followed by a release commit for v2.2.2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
