### PR TITLE
Add Kubernetes v1.35.0 to CI

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -10,7 +10,7 @@ matrix:
       "Ubuntu2404",
     ]
   kubernetes-version:
-    ["1.29.8", "1.30.4", "1.31.0", "1.32.1", "1.33.2", "1.34.1"]
+    ["1.29.8", "1.30.4", "1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0"]
   include:
     # Ubuntu2004 is only supported on EKS <= 1.29.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
@@ -34,6 +34,10 @@ matrix:
     - cluster-type: "eksctl"
       family: "AmazonLinux2"
       kubernetes-version: "1.34.1"
+    # AL2 is not supported by Kubernetes 1.35.
+    - cluster-type: "eksctl"
+      family: "AmazonLinux2"
+      kubernetes-version: "1.35.0"
     # Ubuntu2204 is only supported on EKS >= 1.29 && EKS < 1.33.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
     - cluster-type: "eksctl"
@@ -42,6 +46,9 @@ matrix:
     - cluster-type: "eksctl"
       family: "Ubuntu2204"
       kubernetes-version: "1.34.1"
+    - cluster-type: "eksctl"
+      family: "Ubuntu2204"
+      kubernetes-version: "1.35.0"
     # Ubuntu2404 is only supported on EKS >= 1.31.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
     - cluster-type: "eksctl"


### PR DESCRIPTION
*Description of changes*: EKS now supports v1.35.

Added support for Kubernetes v1.35.0 to CI


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
