### PR TITLE
Ensure `helm-publish` workflow is only called from main

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -1,3 +1,6 @@
+# Changes here may need to be backported to the latest 2.x and 1.x release branches.
+# Backport if AWS is removing support for an EKS version, or if we're actively choosing to support a new k8s version on
+# an old release.
 matrix:
   cluster-type: ["eksctl"]
   arch: ["x86", "arm"]

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Ensure only the latest version of the workflow can run, as this is global for the project
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- Ensure `helm-publish` workflow only runs on `main`
- Add comments to `matrix.yaml` telling operators it may need to be backported


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
