### PR TITLE
Remove exclusion of Bottlerocket on ARM tests

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -23,9 +23,6 @@ matrix:
     - family: "AmazonLinux2023"
       selinux-mode: "enforcing"
   exclude:
-    - cluster-type: "eksctl"
-      arch: "arm"
-      family: "Bottlerocket"
     # AL2 is not supported by Kubernetes 1.33.
     - cluster-type: "eksctl"
       family: "AmazonLinux2"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The end-to-end test workflows currently exclude ARM-based Bottlerocket runs. No reason is given, so removing this exclusion.

The workflow is tested here by pushing to the workflow testing branch prefix: https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/21716747095

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
