### PR TITLE
Add Ubuntu 24.04 to list of supported operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The following table provides the support status for various distros with regards
 | Amazon Linux 2023    |         - |   1.0.0 |          - |       - |
 | Ubuntu 20.04         |         - |   1.0.0 |          - |       - |
 | Ubuntu 22.04         |         - |   1.0.0 |          - |       - |
+| Ubuntu 24.04         |         - |   2.0.0 |          - |       - |
 | Bottlerocket >1.19.2 |         - |   1.4.0 |          - |       - |
 
 ## Documentation


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We began support of Ubuntu 24.04 with version 2.0.0 of the CSI driver (https://github.com/awslabs/mountpoint-s3-csi-driver/commit/d9cc082b6c27922f4efb54b742b47841bd9fb590).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
