### PR TITLE
Update container base image from AL2 to AL2023

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,12 @@
 ARG MOUNTPOINT_VERSION=1.22.2
 
 # Download the mountpoint tarball and produce an installable directory
-# Building on Amazon Linux 2 because it has an old libc version. libfuse from the os
-# is being packaged up in the container and a newer version linking to a too new glibc
-# can cause portability issues
-FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as mp_builder
+FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023 as mp_builder
 ARG MOUNTPOINT_VERSION
 ARG TARGETARCH
 ARG TARGETPLATFORM
-# We need the full version of GnuPG
-RUN yum install -y gzip wget gnupg2 tar fuse-libs binutils patchelf
+# gnupg2-minimal is pre-installed in AL2023 and provides gpg for signature verification
+RUN dnf install -y gzip wget tar fuse-libs binutils patchelf
 
 RUN MP_ARCH=`echo ${TARGETARCH} | sed s/amd64/x86_64/` && \
     wget -q "https://s3.amazonaws.com/mountpoint-s3-release/${MOUNTPOINT_VERSION}/$MP_ARCH/mount-s3-${MOUNTPOINT_VERSION}-$MP_ARCH.tar.gz" && \
@@ -44,7 +41,7 @@ RUN MP_ARCH=`echo ${TARGETARCH} | sed s/amd64/x86_64/` && \
     patchelf --set-rpath '$ORIGIN' /mountpoint-s3/bin/mount-s3
 
 # Build driver. Use BUILDPLATFORM not TARGETPLATFORM for cross compilation
-FROM --platform=$BUILDPLATFORM public.ecr.aws/eks-distro-build-tooling/golang:1.26.2 as builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/eks-distro-build-tooling/golang:1.26.2-al23 as builder
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/awslabs/mountpoint-s3-csi-driver
@@ -54,7 +51,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
 
 # `eks-distro-minimal-base-csi` includes `libfuse` and mount utils such as `umount`.
 # We need to make sure to use same Amazon Linux version here and while producing Mountpoint to not have glibc compatibility issues.
-FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi:latest AS linux-amazon
+FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi:latest-al23 AS linux-amazon
 ARG MOUNTPOINT_VERSION
 ENV MOUNTPOINT_VERSION=${MOUNTPOINT_VERSION}
 ENV MOUNTPOINT_BIN_DIR=/mountpoint-s3/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023 as m
 ARG MOUNTPOINT_VERSION
 ARG TARGETARCH
 ARG TARGETPLATFORM
-# gnupg2-minimal is pre-installed in AL2023 and provides gpg for signature verification
 RUN dnf install -y gzip wget tar fuse-libs binutils patchelf
 
 RUN MP_ARCH=`echo ${TARGETARCH} | sed s/amd64/x86_64/` && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@ FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023 as m
 ARG MOUNTPOINT_VERSION
 ARG TARGETARCH
 ARG TARGETPLATFORM
-RUN dnf install -y gzip wget tar fuse-libs binutils patchelf
+RUN dnf install -y gzip wget tar fuse-libs binutils patchelf && \
+    # gnupg2-minimal doesn't include gpg-agent needed for signature verification.
+    # https://docs.aws.amazon.com/linux/al2023/ug/gnupg-minimal.html
+    dnf swap -y gnupg2-minimal gnupg2-full
 
 RUN MP_ARCH=`echo ${TARGETARCH} | sed s/amd64/x86_64/` && \
     wget -q "https://s3.amazonaws.com/mountpoint-s3-release/${MOUNTPOINT_VERSION}/$MP_ARCH/mount-s3-${MOUNTPOINT_VERSION}-$MP_ARCH.tar.gz" && \

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -46,7 +46,7 @@ RUN cd mountpoint-s3 && \
 #
 
 # Use BUILDPLATFORM not TARGETPLATFORM for cross compilation
-FROM --platform=$BUILDPLATFORM public.ecr.aws/eks-distro-build-tooling/golang:1.26.2 as builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/eks-distro-build-tooling/golang:1.26.2-al23 as builder
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/awslabs/mountpoint-s3-csi-driver


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update container base image from Amazon Linux 2 to AL2023.

Manual testing:
Manual E2E tests pass: https://github.com/tadiwa-aizen/mountpoint-s3-csi-driver/actions/runs/23293621981/job/67735199646
 (Disregarding rosa as that isn't set up on my ci)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
