### PR TITLE
Revert ROSA env regionalization

### DIFF
--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -30,15 +30,11 @@ jobs:
       ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
   e2e-rosa:
-    name: "E2E ROSA Tests (${{ matrix.region }})"
+    name: E2E ROSA Tests
     uses: ./.github/workflows/e2e-rosa-tests.yaml
-    strategy:
-      matrix:
-        region:
-          - 'us-east-1'
     needs: approval
     with:
-      environment: "${{ matrix.region }}-rosa-untrusted"
+      environment: "rosa-untrusted"
       ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
   outcome:


### PR DESCRIPTION
*Issue #, if available:* -

*Description of changes:* ROSA's `operator_role_prefix` ({cluster_name}-operator) has a 32-character limit. The regionalized cluster name `s3-csi-us-east-1-rosa-untrusted-operator` exceeds this limit. This commit reverts the ROSA e2e job to use the non-regionalized "rosa-untrusted" environment. (Partially reverts #702.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
