### PR TITLE
Add All E2E Tests Passed outcome job to trusted workflow

### DIFF
--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -28,3 +28,13 @@ jobs:
       environment: "rosa-trusted"
       ref: ${{ (github.event_name == 'push' && github.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.event.merge_group.head_sha }}
     secrets: inherit
+  outcome:
+    name: All E2E Tests Passed
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - e2e
+      - e2e-rosa
+    steps:
+      - name: Verify jobs succeeded
+        run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'


### PR DESCRIPTION
*Issue:*

Following https://github.com/awslabs/mountpoint-s3-csi-driver/pull/702, now that we renamed test from `E2E Tests / post_test` to `E2E Tests (us-east-1) / post_test`, the merge requirements no longer work for trusted PRs (e.g. dependabot PRs like https://github.com/awslabs/mountpoint-s3-csi-driver/pull/748 / https://github.com/awslabs/mountpoint-s3-csi-driver/pull/774).

*Description of changes:* 

I don't want to change merge requirements to `E2E Tests (us-east-1)  / post_test` from the non-regionalized version since we don't have multiple region support in trusted environment yet. The better long term solution would be to add "All E2E Tests Passed" to `e2e-test-trusted.yaml` so we can use "All E2E Tests Passed" for both trusted / untrusted workflows as the only E2E test passing indicator. (Copying #702)

I changed requirements from `E2E Tests / post_test` and `E2E ROSA Tests / test` to `All E2E Tests Passed` to unblock fork 'untrusted' PRs for now - pending this PR to merge to unblock 'trusted' PRs. 

*Testing:* 

This commit is in workflow/** branch which will trigger this updated `e2e-test-trusted.yaml` - if this PR passes merge requirements (i.e. [E2E Tests (Trusted) workflow](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/24409420280?pr=772) "All E2E Tests Passed" job passes) then it should be able to unblock other same-repo 'trusted' PRs too. 

Update: Workflow passed: https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/24409420280?pr=772 (the workflow triggered by 'push' is not passed yet, but the one triggered by 'pull_request' is)
Update 2: Workflow triggered by 'push' also passed now: https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/24409419160?pr=772


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
