### PR TITLE
Group dependabot PRs by package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-root-deps:
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
+    directory: "/tests/e2e-kubernetes"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-e2e-deps:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all-actions:
+      gh-actions:
         patterns:
           - "*"
   - package-ecosystem: "gomod"
@@ -14,14 +14,16 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all-root-deps:
-        patterns:
-          - "*"
+      gomod-root-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "gomod"
     directory: "/tests/e2e-kubernetes"
     schedule:
       interval: "weekly"
     groups:
-      all-e2e-deps:
-        patterns:
-          - "*"
+      gomod-e2e-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Group dependabot PRs to reduce PR noise. This also could mitigate concurrency group being 1 problem, when 3+ dependabot PRs rebase together there'll be cancelled runs. The groupings are:

- `github-actions` - all action bumps in one PR
- `gomod` (`/tests/e2e-kubernetes`) - all e2e test Go dep bumps in one PR
- `gomod` (root `/`) - all production Go dep bumps in one PR
  - I rarely see these PRs (see [v2.5.0 go.mod blame](https://github.com/awslabs/mountpoint-s3-csi-driver/blame/release-2.5/go.mod)) except for security issues (e.g. https://github.com/awslabs/mountpoint-s3-csi-driver/pull/751), so this is a new group that'll create new PRs - we may or may not want this. Also consider reducing frequency to monthly for this one. 


Update 2026-05-01: 

Following this PR https://github.com/awslabs/mountpoint-s3-csi-driver/pull/786 we won't absolutely require aggressive grouping like I proposed before, but it would be nice to keep them for maintainability which might result in e.g. 1 gh-actions dependabot PR, 2 gomod PRs (root / e2e) per week. 

Plan: keep github actions major changes since they're quite frequent, but separate major version changes for gomod groups. (**X**.y.z)
```
groups:
  minor-and-patch:
    update-types:
      - "minor"
      - "patch"
```

Existing open PRs would have to be closed for dependabot to re-open next Monday ofc after merge. 

Reference: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--

*Testing:* 

See https://github.com/jet-tong/mountpoint-s3-csi-driver/pulls for the PRs it generated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

