### PR TITLE
Extract shared klog init with newline-escaping stderr writer

### DIFF
--- a/cmd/aws-s3-csi-driver/main.go
+++ b/cmd/aws-s3-csi-driver/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"os"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/version"
+	utillog "github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/log"
 	"k8s.io/klog/v2"
 )
 
@@ -42,14 +42,8 @@ func main() {
 		mpVersion    = flag.String("mp-version", os.Getenv("MOUNTPOINT_VERSION"), "mp version to report in service name")
 		nodeID       = flag.String("node-id", os.Getenv(NodeIDEnvVar), "node-id to report in NodeGetInfo RPC")
 	)
-	klog.InitFlags(nil)
-	// Set logging to stderr false otherwise klog won't call our logger set via
-	// `klog.SetOutput` - which also logs to stderr after escaping newlines.
-	flag.Set("logtostderr", "false")
-	flag.Set("alsologtostderr", "false")
+	utillog.InitKlog()
 	flag.Parse()
-
-	klog.SetOutput(&newlineEscapingStderrWriter{})
 
 	if *printVersion {
 		info, err := version.GetVersionJSON()
@@ -84,21 +78,4 @@ func main() {
 	if err := drv.Run(); err != nil {
 		klog.Fatalln(err)
 	}
-}
-
-var (
-	newline       = []byte("\n")
-	newlineEscape = []byte("")
-)
-
-type newlineEscapingStderrWriter struct{}
-
-// Write writes given log entry to `os.Stderr` after escaping newlines.
-func (*newlineEscapingStderrWriter) Write(b []byte) (int, error) {
-	// Since we escape newlines here, `len` of written bytes might be different from `len(b)`,
-	// `os.Stderr.Write` returns an error when `writtenBytes != len(b)`, so, we should be fine to
-	// just return `n = len(b)`.
-	n := len(b)
-	_, err := os.Stderr.Write(append(bytes.ReplaceAll(b, newline, newlineEscape), newline...))
-	return n, err
 }

--- a/cmd/aws-s3-csi-mounter/main.go
+++ b/cmd/aws-s3-csi-mounter/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/awslabs/mountpoint-s3-csi-driver/cmd/aws-s3-csi-mounter/csimounter"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/mountpoint/mountoptions"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
+	utillog "github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/log"
 )
 
 var mountSockRecvTimeout = flag.Duration("mount-sock-recv-timeout", 2*time.Minute, "Timeout for receiving mount options from passed Unix socket.")
@@ -32,7 +33,7 @@ var mountErrorPath = mppod.PathInsideMountpointPod(mppod.KnownPathMountError)
 const mountpointBin = "mount-s3"
 
 func main() {
-	klog.InitFlags(nil)
+	utillog.InitKlog()
 	flag.Parse()
 
 	mountpointBinFullPath := filepath.Join(*mountpointBinDir, mountpointBin)

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -1,0 +1,32 @@
+// Package log provides shared klog initialization for CSI Driver components.
+package log
+
+import (
+	"bytes"
+	"flag"
+	"os"
+
+	"k8s.io/klog/v2"
+)
+
+var (
+	newline       = []byte("\n")
+	newlineEscape = []byte("")
+)
+
+// newlineEscapingStderrWriter writes log entries to stderr after escaping newlines.
+type newlineEscapingStderrWriter struct{}
+
+func (*newlineEscapingStderrWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	_, err := os.Stderr.Write(append(bytes.ReplaceAll(b, newline, newlineEscape), newline...))
+	return n, err
+}
+
+// InitKlog initializes klog to write to stderr with newlines escaped.
+func InitKlog() {
+	klog.InitFlags(nil)
+	flag.Set("logtostderr", "false")
+	flag.Set("alsologtostderr", "false")
+	klog.SetOutput(&newlineEscapingStderrWriter{})
+}


### PR DESCRIPTION
Move `newlineEscapingStderrWriter` and `klog` initialization into `pkg/util/log` so both `aws-s3-csi-driver` and `aws-s3-csi-mounter` use the same logging setup writing to stderr with escaped newlines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
