### PR TITLE
ci: skip e2e trusted outcome for fork PRs, not fail

### DIFF
--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -30,7 +30,7 @@ jobs:
     secrets: inherit
   outcome:
     name: All E2E Tests Passed
-    if: always()
+    if: ${{ always() && github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id }}
     runs-on: ubuntu-latest
     needs:
       - e2e

--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -30,7 +30,7 @@ jobs:
     secrets: inherit
   outcome:
     name: All E2E Tests Passed
-    if: ${{ always() && github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id }}
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id) }}
     runs-on: ubuntu-latest
     needs:
       - e2e


### PR DESCRIPTION
*Problem:*

In https://github.com/awslabs/mountpoint-s3-csi-driver/pull/776, the trusted e2e outcome `E2E Tests (Trusted) / All E2E Tests Passed (pull_request)` fails for the fork PR even though it should be skipped. This is not urgent and should only be a cosmetic failure for now, since the untrusted e2e outcome `E2E Tests (Untrusted) / All E2E Tests Passed (pull_request)` should pass, and our merge requirement is `All E2E Tests Passed` (if either untrusted/trusted passes, merge requirement is satisfied). 

<img width="998" height="216" alt="image" src="https://github.com/user-attachments/assets/79aa7b84-c0ee-4a73-8207-ff992804ddd9" />

<br> 

This is a silly miss from me in https://github.com/awslabs/mountpoint-s3-csi-driver/pull/772, where I forgot to add the fix I addressed in the other way round (trusted tests sees a failed untrusted e2e test outcome even though they should be skipped): https://github.com/awslabs/mountpoint-s3-csi-driver/pull/761


*Description of changes:*

Symmetrical fix to https://github.com/awslabs/mountpoint-s3-csi-driver/pull/761. 

*Testing:*

I have not tested it in my personal fork this time - I need a PR from a different user. 


Note: not including the PR check and only including `head.repo.id == base.repo.id`, will also work with `on: push` since head.repo.id and base.repo.id are null for push triggers (source: [here](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/contexts): "If you attempt to dereference a nonexistent property, it will evaluate to an empty string."). But kept the PR check just for consistency. So for all cases it would looks like this:

| Trigger | Want | `head.repo.id == base.repo.id` | Result |
|---|---|---|---|
| `push` to main | run | `'' == ''` → true | ✅ runs |
| `merge_group` | run | `'' == ''` → true | ✅ runs |
| Same-repo PR | run | `123 == 123` → true | ✅ runs |
| Fork PR | skip | `456 == 123` → false | ✅ skips |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
