### PR TITLE
Temp pin terraform to 1.14.9 to avoid 1.15.0 regression

### DIFF
--- a/.github/workflows/delete-rosa-cluster.yaml
+++ b/.github/workflows/delete-rosa-cluster.yaml
@@ -28,6 +28,8 @@ jobs:
           persist-credentials: false
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.14.9" # FIXME - Remove pin once Terraform >= 1.15.1 is released
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -77,6 +77,8 @@ jobs:
           go-version-file: "go.mod"
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.14.9" # FIXME - Remove pin once Terraform >= 1.15.1 is released
       - name: Configure AWS Credentials
         id: aws-creds
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Pin terraform to 1.14.9 in ROSA workflow files for now to workaround regression for 1.15.0 (released on Apr 29) which resulted in Missing required argument error below (since we use `-backend-config` to supply them during `terraform init`). They don't have an ETA to share yet so we can consider merging this PR in to unblock CI in the meantime. 

Related issue: https://github.com/hashicorp/terraform/issues/38466 (this one is closed but there are currently many more open issues with similar problems)

Error seen ([E2E ROSA test](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/25015090021/job/73741478343?pr=782)):
```
Run terraform validate
╷
│ Error: Missing required argument
│ 
│   on main.tf line 14, in terraform:
│   14:   backend "s3" {}
│ 
│ The argument "key" is required, but no definition was found.
╵
╷
│ Error: Missing required argument
│ 
│   on main.tf line 14, in terraform:
│   14:   backend "s3" {}
│ 
│ The argument "bucket" is required, but no definition was found.
╵
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```

Alt approach not taken: Use placeholders like in [this comment](https://github.com/hashicorp/terraform/issues/38466#issuecomment-4345269747).

*Follow up:*

Update (May 2026): https://github.com/hashicorp/terraform/issues/38466#issuecomment-4360727859 - 1.15.1 released that resolves the issue.

- [ ] Follow up with removing the version pin once Terraform >= 1.15.1 is released.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


