### PR TITLE
Queue concurrency group runs not cancel with `queue:max`

### DIFF
--- a/.github/workflows/delete-cluster.yaml
+++ b/.github/workflows/delete-cluster.yaml
@@ -8,6 +8,7 @@ on:
 
 concurrency:
   group: e2e-cluster-${{ inputs.environment }}
+  queue: max
 
 env:
   IMAGE_NAME: "s3-csi-driver"

--- a/.github/workflows/delete-rosa-cluster.yaml
+++ b/.github/workflows/delete-rosa-cluster.yaml
@@ -10,6 +10,7 @@ on:
 
 concurrency:
   group: e2e-cluster-${{ inputs.environment }}
+  queue: max
 
 jobs:
   delete_rosa_cluster:

--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -12,6 +12,7 @@ on:
 
 concurrency:
   group: e2e-cluster-${{ inputs.environment }}
+  queue: max
 
 env:
   IMAGE_NAME: "s3-csi-driver"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -24,6 +24,7 @@ on:
 
 concurrency:
   group: e2e-cluster-${{ inputs.environment }}
+  queue: max
 
 env:
   IMAGE_NAME: "s3-csi-driver"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

Github Team [shipped `queue: max`](https://github.com/orgs/community/discussions/12835#discussioncomment-16602100) around 2 weeks ago which would solve our concurrency group problems. 

Add `queue: max` to concurrency groups - pending runs should now queue in FIFO order instead of cancelling each other. 

Ref: https://github.com/orgs/community/discussions/12835

*Testing:*

I [tested this in my repo](https://github.com/jet-tong/mountpoint-s3-csi-driver/actions/runs/25215331763) in trusted environment 
<img width="2103" height="112" alt="image" src="https://github.com/user-attachments/assets/2b816b78-b835-4bf6-86a3-0eee6e4e4d02" />

*Points that suggest risk:*

- They shipped it without public announcement
- I don't see it in [documentation](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)
- Some problems raised in discussion (but I don't think either of them is blocking for us)
- Recent Github problems suggest we should be cautious about applying this

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
