### PR TITLE
ci: remove terraform 1.14.9 version pin

### DIFF
--- a/.github/workflows/delete-rosa-cluster.yaml
+++ b/.github/workflows/delete-rosa-cluster.yaml
@@ -29,8 +29,6 @@ jobs:
           persist-credentials: false
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v4
-        with:
-          terraform_version: "1.14.9" # FIXME - Remove pin once Terraform >= 1.15.1 is released
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -82,8 +82,6 @@ jobs:
           go-version-file: "go.mod"
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v4
-        with:
-          terraform_version: "1.14.9" # FIXME - Remove pin once Terraform >= 1.15.1 is released
       - name: Configure AWS Credentials
         id: aws-creds
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
*Issue #, if available:*

- Follow-up to #785

*Description of changes:*

Remove temporary terraform 1.14.9 version pin since 1.15.1 has been released which resolves the validate regression that caused 'missing required argument' errors. 

This pin was added in #785 as a workaround; now the fix is upstream we can go back to latest. 

I don't think dependabot can pickup on this version pin anyways so we can run tests before upgrading terraform version, so removing it seems like the only viable option. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.