### PR TITLE
Update nodedriverregistrar and livenessprobe sidecar versions

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -57,7 +57,7 @@ sidecars:
   nodeDriverRegistrar:
     image:
       repository: public.ecr.aws/csi-components/csi-node-driver-registrar
-      tag: v2.16.0-eksbuild.3
+      tag: v2.16.0-eksbuild.5
       pullPolicy: IfNotPresent
     env:
       - name: KUBE_NODE_NAME
@@ -73,7 +73,7 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/csi-components/livenessprobe
-      tag: v2.18.0-eksbuild.3
+      tag: v2.18.0-eksbuild.5
       pullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /csi


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Update `nodedriverregistrar` and `livenessprobe` sidecar versions to `v2.16.0-eksbuild.5` and `v2.18.0-eksbuild.5` respectively

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.