### PR TITLE
reconciler: recover from duplicate S3PodAttachments by deleting empty ones

### DIFF
--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -311,11 +311,14 @@ func (r *Reconciler) spawnOrDeleteMountpointPodIfNeeded(
 		return Requeue, err
 	}
 	fieldFilters := r.buildFieldFilters(workloadPod, pv, roleArn)
-	s3pa, err := r.getExistingS3PodAttachment(ctx, fieldFilters)
+	log := r.setupLogger(ctx, workloadPod, pvc, workloadUID, fieldFilters)
+	s3pa, err := r.getExistingS3PodAttachment(ctx, fieldFilters, log)
 	if err != nil {
 		return Requeue, err
 	}
-	log := r.setupLogger(ctx, workloadPod, pvc, workloadUID, fieldFilters, s3pa)
+	if s3pa != nil {
+		log = log.WithValues("s3pa", s3pa.Name)
+	}
 
 	if !isPodActive(workloadPod) {
 		return r.handleInactivePod(ctx, s3pa, workloadUID, fieldFilters, log)
@@ -328,25 +331,20 @@ func (r *Reconciler) spawnOrDeleteMountpointPodIfNeeded(
 	}
 }
 
-// setupLogger creates and configures logger that includes pod namespace/name, PVC name, and workload UID fields.
-// If an S3PodAttachment is provided, its name is added. All fieldFilters are appended as additional key-value pairs.
+// setupLogger creates and configures logger that includes pod namespace/name, PVC name, and workload UID fields,
+// plus any provided fieldFilters.
 func (r *Reconciler) setupLogger(
 	ctx context.Context,
 	workloadPod *corev1.Pod,
 	pvc *corev1.PersistentVolumeClaim,
 	workloadUID string,
 	fieldFilters client.MatchingFields,
-	s3pa *crdv2.MountpointS3PodAttachment,
 ) logr.Logger {
 	logger := logf.FromContext(ctx).WithValues(
 		"workloadPod", types.NamespacedName{Namespace: workloadPod.Namespace, Name: workloadPod.Name},
 		"pvc", pvc.Name,
 		"workloadUID", workloadUID,
 	)
-
-	if s3pa != nil {
-		logger = logger.WithValues("s3pa", s3pa.Name)
-	}
 
 	var keyValues []any
 	for k, v := range fieldFilters {
@@ -407,8 +405,11 @@ func (r *Reconciler) getFSGroup(workloadPod *corev1.Pod) string {
 // It returns:
 // - The matching MountpointS3PodAttachment if exactly one is found
 // - nil if no matching resource is found
-// - An error if multiple matching resources are found or if the list operation fails
-func (r *Reconciler) getExistingS3PodAttachment(ctx context.Context, fieldFilters client.MatchingFields) (*crdv2.MountpointS3PodAttachment, error) {
+// - An error if multiple matching resources are found and cannot be auto-resolved, or if the list operation fails
+//
+// When the API server holds multiple S3PAs for the same field-tuple, we attempt to recover in-place by dropping
+// empty-map duplicates.
+func (r *Reconciler) getExistingS3PodAttachment(ctx context.Context, fieldFilters client.MatchingFields, log logr.Logger) (*crdv2.MountpointS3PodAttachment, error) {
 	s3paList := &crdv2.MountpointS3PodAttachmentList{}
 	if err := r.List(ctx, s3paList, fieldFilters); err != nil {
 		return nil, fmt.Errorf("failed to list MountpointS3PodAttachments: %w", err)
@@ -420,8 +421,52 @@ func (r *Reconciler) getExistingS3PodAttachment(ctx context.Context, fieldFilter
 	case 1:
 		return &s3paList.Items[0], nil
 	default:
-		return nil, fmt.Errorf("found %d MountpointS3PodAttachments when expecting 0 or 1", len(s3paList.Items))
+		return r.recoverFromDuplicateS3PodAttachments(ctx, s3paList.Items, fieldFilters, log)
 	}
+}
+
+// recoverFromDuplicateS3PodAttachments is a defense-in-depth handler for duplicate S3PAs sharing
+// the same field-tuple. Deletes duplicates that reference no Mountpoint Pods. Returns:
+//   - the surviving S3PA, if exactly one duplicate references Mountpoint Pods
+//   - nil, if all duplicates referenced no Mountpoint Pods and have been deleted
+//     (caller should re-create through handleNewS3PodAttachment)
+//   - an error, if more than one duplicate references Mountpoint Pods
+func (r *Reconciler) recoverFromDuplicateS3PodAttachments(ctx context.Context, duplicates []crdv2.MountpointS3PodAttachment, fieldFilters client.MatchingFields, log logr.Logger) (*crdv2.MountpointS3PodAttachment, error) {
+	log.Info(fmt.Sprintf("Found %d MountpointS3PodAttachments for the same field-tuple, attempting recovery", len(duplicates)))
+
+	var withMountpointPods []*crdv2.MountpointS3PodAttachment
+	var noMountpointPods []*crdv2.MountpointS3PodAttachment
+	for i := range duplicates {
+		if len(duplicates[i].Spec.MountpointS3PodAttachments) == 0 {
+			noMountpointPods = append(noMountpointPods, &duplicates[i])
+		} else {
+			withMountpointPods = append(withMountpointPods, &duplicates[i])
+		}
+	}
+
+	if len(withMountpointPods) > 1 {
+		return nil, fmt.Errorf("found %d MountpointS3PodAttachments referencing Mountpoint Pods when expecting 0 or 1", len(withMountpointPods))
+	}
+
+	for _, s3pa := range noMountpointPods {
+		log.Info("Deleting duplicate MountpointS3PodAttachment that references no Mountpoint Pods", "s3pa", s3pa.Name)
+		if err := r.deleteS3PodAttachment(ctx, s3pa); err != nil {
+			return nil, fmt.Errorf("failed to delete duplicate %q referencing no Mountpoint Pods: %w", s3pa.Name, err)
+		}
+	}
+
+	if len(withMountpointPods) == 1 {
+		return withMountpointPods[0], nil
+	}
+
+	// All duplicates referenced no Mountpoint Pods AND every delete succeeded. Clear any stale pending
+	// creation expectation so the caller's handleNewS3PodAttachment can create a fresh S3PA instead of
+	// requeuing forever.
+	if len(noMountpointPods) > 0 && r.s3paExpectations.isPending(fieldFilters) {
+		log.Info("Clearing stale creation expectation after deleting all duplicates that referenced no Mountpoint Pods")
+		r.s3paExpectations.clear(fieldFilters)
+	}
+	return nil, nil
 }
 
 // handleInactivePod handles inactive workload pod.
@@ -628,7 +673,7 @@ func (r *Reconciler) removeWorkloadFromS3PodAttachment(ctx context.Context, s3pa
 	// Delete MountpointS3PodAttachment if map is empty
 	if len(s3pa.Spec.MountpointS3PodAttachments) == 0 {
 		log.Info("MountpointS3PodAttachment has zero Mountpoint Pods. Will delete it")
-		err := r.Delete(ctx, s3pa)
+		err := r.deleteS3PodAttachment(ctx, s3pa)
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				log.Info("Failed to delete MountpointS3PodAttachment due to resource conflict, requeuing")
@@ -732,6 +777,15 @@ func (r *Reconciler) createS3PodAttachmentWithMPPod(
 
 	log.Info("MountpointS3PodAttachment is created", "s3pa", s3pa.Name)
 	return nil
+}
+
+// deleteS3PodAttachment deletes the given S3PA with a resourceVersion precondition.
+// The precondition makes the apiserver reject the Delete with 409 Conflict if the
+// S3PA was modified since the caller read it; the caller can then retry/requeue.
+// Always use this instead of a bare r.Delete(ctx, s3pa) so the precondition is
+// not accidentally skipped.
+func (r *Reconciler) deleteS3PodAttachment(ctx context.Context, s3pa *crdv2.MountpointS3PodAttachment) error {
+	return r.Delete(ctx, s3pa, client.Preconditions{ResourceVersion: &s3pa.ResourceVersion})
 }
 
 // spawnMountpointPod spawns a new Mountpoint Pod for given `workloadPod` and volume.

--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler_recover_test.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler_recover_test.go
@@ -1,0 +1,234 @@
+package csicontroller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	crdv2 "github.com/awslabs/mountpoint-s3-csi-driver/pkg/api/v2"
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/podmounter/mppod"
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestRecoverFromDuplicateS3PodAttachments(t *testing.T) {
+	t.Run("returns the S3PA that references Mountpoint Pods and deletes the duplicate that references none", func(t *testing.T) {
+		withMountpointPods := newS3PA("s3pa-live", map[string][]crdv2.WorkloadAttachment{
+			"mp-1": {{WorkloadPodUID: "uid-1", AttachmentTime: metav1.NewTime(metav1.Now().Time)}},
+		})
+		noMountpointPods := newS3PA("s3pa-orphan", map[string][]crdv2.WorkloadAttachment{})
+		c, r := newReconcilerWithObjects(t, withMountpointPods, noMountpointPods)
+
+		got, err := r.recoverFromDuplicateS3PodAttachments(context.Background(), []crdv2.MountpointS3PodAttachment{*withMountpointPods, *noMountpointPods}, testFilters(), logr.Discard())
+		assert.NoError(t, err)
+		if got == nil || got.Name != withMountpointPods.Name {
+			t.Fatalf("expected to return %q, got %v", withMountpointPods.Name, got)
+		}
+		assertS3PAExists(t, c, withMountpointPods.Name)
+		assertS3PADeleted(t, c, noMountpointPods.Name)
+	})
+
+	t.Run("returns nil and deletes all duplicates when none reference Mountpoint Pods", func(t *testing.T) {
+		noMountpointPodsA := newS3PA("s3pa-empty-a", map[string][]crdv2.WorkloadAttachment{})
+		noMountpointPodsB := newS3PA("s3pa-empty-b", map[string][]crdv2.WorkloadAttachment{})
+		c, r := newReconcilerWithObjects(t, noMountpointPodsA, noMountpointPodsB)
+
+		got, err := r.recoverFromDuplicateS3PodAttachments(context.Background(), []crdv2.MountpointS3PodAttachment{*noMountpointPodsA, *noMountpointPodsB}, testFilters(), logr.Discard())
+		assert.NoError(t, err)
+		if got != nil {
+			t.Fatalf("expected nil S3PA when no duplicate references Mountpoint Pods, got %q", got.Name)
+		}
+		assertS3PADeleted(t, c, noMountpointPodsA.Name)
+		assertS3PADeleted(t, c, noMountpointPodsB.Name)
+	})
+
+	t.Run("clears stale pending creation expectation when all duplicates referenced no Mountpoint Pods are deleted", func(t *testing.T) {
+		noMountpointPodsA := newS3PA("s3pa-stuck-a", map[string][]crdv2.WorkloadAttachment{})
+		noMountpointPodsB := newS3PA("s3pa-stuck-b", map[string][]crdv2.WorkloadAttachment{})
+		c, r := newReconcilerWithObjects(t, noMountpointPodsA, noMountpointPodsB)
+		filters := testFilters()
+		r.s3paExpectations.setPending(filters)
+
+		got, err := r.recoverFromDuplicateS3PodAttachments(context.Background(), []crdv2.MountpointS3PodAttachment{*noMountpointPodsA, *noMountpointPodsB}, filters, logr.Discard())
+		assert.NoError(t, err)
+		if got != nil {
+			t.Fatalf("expected nil S3PA when no duplicate references Mountpoint Pods, got %q", got.Name)
+		}
+		assertS3PADeleted(t, c, noMountpointPodsA.Name)
+		assertS3PADeleted(t, c, noMountpointPodsB.Name)
+		if r.s3paExpectations.isPending(filters) {
+			t.Errorf("expected pending creation expectation to be cleared after deleting all duplicates that referenced no Mountpoint Pods")
+		}
+	})
+
+	t.Run("does not clear pending expectation when a duplicate that references Mountpoint Pods survives", func(t *testing.T) {
+		// When recovery returns a surviving S3PA, the same reconcile continues into
+		// handleExistingS3PodAttachment (active-pod path), which clears pending.
+		withMountpointPods := newS3PA("s3pa-live", map[string][]crdv2.WorkloadAttachment{
+			"mp-1": {{WorkloadPodUID: "uid-1", AttachmentTime: metav1.NewTime(metav1.Now().Time)}},
+		})
+		noMountpointPods := newS3PA("s3pa-orphan", map[string][]crdv2.WorkloadAttachment{})
+		c, r := newReconcilerWithObjects(t, withMountpointPods, noMountpointPods)
+		filters := testFilters()
+		r.s3paExpectations.setPending(filters)
+
+		got, err := r.recoverFromDuplicateS3PodAttachments(context.Background(), []crdv2.MountpointS3PodAttachment{*withMountpointPods, *noMountpointPods}, filters, logr.Discard())
+		assert.NoError(t, err)
+		if got == nil || got.Name != withMountpointPods.Name {
+			t.Fatalf("expected to return %q, got %v", withMountpointPods.Name, got)
+		}
+		assertS3PADeleted(t, c, noMountpointPods.Name)
+		if !r.s3paExpectations.isPending(filters) {
+			t.Errorf("expected pending creation expectation to remain when a surviving S3PA references Mountpoint Pods")
+		}
+	})
+
+	t.Run("returns error when more than one duplicate references Mountpoint Pods", func(t *testing.T) {
+		withMountpointPodsA := newS3PA("s3pa-live-a", map[string][]crdv2.WorkloadAttachment{
+			"mp-a": {{WorkloadPodUID: "uid-a", AttachmentTime: metav1.NewTime(metav1.Now().Time)}},
+		})
+		withMountpointPodsB := newS3PA("s3pa-live-b", map[string][]crdv2.WorkloadAttachment{
+			"mp-b": {{WorkloadPodUID: "uid-b", AttachmentTime: metav1.NewTime(metav1.Now().Time)}},
+		})
+		noMountpointPods := newS3PA("s3pa-orphan", map[string][]crdv2.WorkloadAttachment{})
+		c, r := newReconcilerWithObjects(t, withMountpointPodsA, withMountpointPodsB, noMountpointPods)
+
+		got, err := r.recoverFromDuplicateS3PodAttachments(context.Background(), []crdv2.MountpointS3PodAttachment{*withMountpointPodsA, *withMountpointPodsB, *noMountpointPods}, testFilters(), logr.Discard())
+		if err == nil {
+			t.Fatalf("expected an error when multiple S3PAs reference Mountpoint Pods, got nil")
+		}
+		if !strings.Contains(err.Error(), "referencing Mountpoint Pods") {
+			t.Errorf("expected error to mention S3PAs referencing Mountpoint Pods, got: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil S3PA on error, got %q", got.Name)
+		}
+		assertS3PAExists(t, c, withMountpointPodsA.Name)
+		assertS3PAExists(t, c, withMountpointPodsB.Name)
+		assertS3PAExists(t, c, noMountpointPods.Name)
+	})
+
+	t.Run("returns error and preserves pending when deleting a duplicate that references no Mountpoint Pods fails with conflict", func(t *testing.T) {
+		noMountpointPodsA := newS3PA("s3pa-empty-a", map[string][]crdv2.WorkloadAttachment{})
+		noMountpointPodsB := newS3PA("s3pa-empty-b", map[string][]crdv2.WorkloadAttachment{})
+
+		c := fake.NewClientBuilder().
+			WithScheme(testScheme()).
+			WithObjects(noMountpointPodsA, noMountpointPodsB).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if s3pa, ok := obj.(*crdv2.MountpointS3PodAttachment); ok && s3pa.Name == noMountpointPodsA.Name {
+						current := &crdv2.MountpointS3PodAttachment{}
+						if err := c.Get(ctx, client.ObjectKey{Name: noMountpointPodsA.Name}, current); err != nil {
+							return err
+						}
+						current.Spec.MountpointS3PodAttachments = map[string][]crdv2.WorkloadAttachment{
+							"mp-x": {{WorkloadPodUID: "uid-x", AttachmentTime: metav1.NewTime(metav1.Now().Time)}},
+						}
+						if err := c.Update(ctx, current); err != nil {
+							return err
+						}
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			}).
+			Build()
+		r := &Reconciler{Client: c, mountpointPodConfig: testPodConfig(), s3paExpectations: newExpectations()}
+		filters := testFilters()
+		r.s3paExpectations.setPending(filters)
+
+		got, err := r.recoverFromDuplicateS3PodAttachments(context.Background(), []crdv2.MountpointS3PodAttachment{*noMountpointPodsA, *noMountpointPodsB}, filters, logr.Discard())
+		if err == nil {
+			t.Fatalf("expected error when delete fails, got nil (got=%v)", got)
+		}
+		if !apierrors.IsConflict(errors.Unwrap(err)) {
+			t.Errorf("expected error to wrap an IsConflict, got: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil S3PA on error, got %q", got.Name)
+		}
+		if !r.s3paExpectations.isPending(filters) {
+			t.Errorf("expected pending creation expectation to remain after a failed delete")
+		}
+		assertS3PAExists(t, c, noMountpointPodsA.Name)
+	})
+}
+
+// helpers
+
+const (
+	testNodeName = "test-node"
+	testPVName   = "test-pv"
+	testVolumeID = "test-vol-id"
+)
+
+func newS3PA(name string, attachments map[string][]crdv2.WorkloadAttachment) *crdv2.MountpointS3PodAttachment {
+	return &crdv2.MountpointS3PodAttachment{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: crdv2.MountpointS3PodAttachmentSpec{
+			NodeName:                   testNodeName,
+			PersistentVolumeName:       testPVName,
+			VolumeID:                   testVolumeID,
+			MountpointS3PodAttachments: attachments,
+		},
+	}
+}
+
+func newReconcilerWithObjects(t *testing.T, objs ...client.Object) (client.Client, *Reconciler) {
+	t.Helper()
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		Build()
+	return c, &Reconciler{Client: c, mountpointPodConfig: testPodConfig(), s3paExpectations: newExpectations()}
+}
+
+func testPodConfig() mppod.Config {
+	return mppod.Config{
+		Namespace:         "mount-s3",
+		PodLabels:         map[string]string{},
+		HeadroomPodLabels: map[string]string{},
+	}
+}
+
+func testFilters() client.MatchingFields {
+	return client.MatchingFields{
+		crdv2.FieldNodeName:             testNodeName,
+		crdv2.FieldPersistentVolumeName: testPVName,
+		crdv2.FieldVolumeID:             testVolumeID,
+	}
+}
+
+func testScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(crdv2.AddToScheme(scheme))
+	return scheme
+}
+
+func assertS3PAExists(t *testing.T, c client.Client, name string) {
+	t.Helper()
+	if err := c.Get(context.Background(), client.ObjectKey{Name: name}, &crdv2.MountpointS3PodAttachment{}); err != nil {
+		t.Errorf("expected S3PodAttachment %q to exist, got error: %v", name, err)
+	}
+}
+
+func assertS3PADeleted(t *testing.T, c client.Client, name string) {
+	t.Helper()
+	err := c.Get(context.Background(), client.ObjectKey{Name: name}, &crdv2.MountpointS3PodAttachment{})
+	if err == nil {
+		t.Errorf("expected S3PodAttachment %q to be deleted, but it still exists", name)
+	} else if !apierrors.IsNotFound(err) {
+		t.Errorf("unexpected error checking S3PodAttachment %q: %v", name, err)
+	}
+}

--- a/cmd/aws-s3-csi-controller/csicontroller/stale_attachment_cleaner.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/stale_attachment_cleaner.go
@@ -132,7 +132,7 @@ func (cm *StaleAttachmentCleaner) cleanupStaleWorkloads(ctx context.Context, s3p
 	// Update the S3PodAttachment if modified
 	if modified {
 		if len(s3pa.Spec.MountpointS3PodAttachments) == 0 {
-			return cm.reconciler.Delete(ctx, s3pa)
+			return cm.reconciler.deleteS3PodAttachment(ctx, s3pa)
 		}
 		return cm.reconciler.Update(ctx, s3pa)
 	}

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -2172,4 +2172,3 @@ func newEmptyS3PodAttachment(node string, pv *corev1.PersistentVolume) *crdv2.Mo
 		},
 	}
 }
-

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -959,6 +959,63 @@ var _ = Describe("Mountpoint Controller", func() {
 		})
 	})
 
+	Context("Duplicate S3PodAttachments recovery", func() {
+		It("should delete duplicate empty S3PodAttachments and create a fresh one with the workload UID", func() {
+			vol := createVolume()
+			vol.bind()
+
+			// Pre-create two empty S3PAs sharing the same field-tuple as the workload pod
+			// will produce.
+			emptyA := newEmptyS3PodAttachment(testNode, vol.pv)
+			emptyB := newEmptyS3PodAttachment(testNode, vol.pv)
+			Expect(k8sClient.Create(ctx, emptyA)).To(Succeed())
+			Expect(k8sClient.Create(ctx, emptyB)).To(Succeed())
+			waitForObject(emptyA)
+			waitForObject(emptyB)
+
+			pod := createPod(withPVC(vol.pvc))
+			pod.schedule(testNode)
+
+			// Both empties get deleted by recovery.
+			waitForObjectToDisappear(emptyA)
+			waitForObjectToDisappear(emptyB)
+
+			// Recovery returns nil, caller creates a fresh S3PA, workload UID lands in it.
+			waitAndVerifyS3PodAttachmentAndMountpointPod(testNode, vol, pod)
+		})
+
+		It("should keep the duplicate that references Mountpoint Pods, delete the empty one, and assign the new workload to the survivor's existing Mountpoint Pod", func() {
+			vol := createVolume()
+			vol.bind()
+
+			// Schedule a first workload so the reconciler naturally creates the live S3PA and a
+			// real Mountpoint Pod that the second workload can be assigned to.
+			pod1 := createPod(withPVC(vol.pvc))
+			pod1.schedule(testNode)
+			live, mpPod := waitAndVerifyS3PodAttachmentAndMountpointPod(testNode, vol, pod1)
+
+			// Inject an empty duplicate sharing the same field-tuple as `live`.
+			empty := newEmptyS3PodAttachment(testNode, vol.pv)
+			Expect(k8sClient.Create(ctx, empty)).To(Succeed())
+			waitForObject(empty)
+
+			// Schedule a second workload onto the same node/volume.
+			pod2 := createPod(withPVC(vol.pvc))
+			pod2.schedule(testNode)
+
+			// Empty duplicate deleted; the live S3PA survives and the second workload UID is
+			// added to the existing Mountpoint Pod entry alongside pod1's UID.
+			waitForObjectToDisappear(empty)
+			waitForObject(live, func(g Gomega, s3pa *crdv2.MountpointS3PodAttachment) {
+				g.Expect(s3pa.Spec.MountpointS3PodAttachments).To(HaveLen(1))
+				g.Expect(s3pa.Spec.MountpointS3PodAttachments[mpPod.Name]).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{"WorkloadPodUID": Equal(string(pod1.UID))}),
+					MatchFields(IgnoreExtras, Fields{"WorkloadPodUID": Equal(string(pod2.UID))}),
+				))
+			})
+		})
+	})
+
 	Context("Mountpoint Pod Customization", func() {
 		It("should use configured service account name in PV", func() {
 			sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
@@ -2097,3 +2154,22 @@ func findVolumeMountFromContainer(container corev1.Container, name string) *core
 func generateRandomNodeName() string {
 	return fmt.Sprintf("test-node-%s", uuid.New().String()[:8])
 }
+
+// newEmptyS3PodAttachment builds an S3PA whose field-tuple matches what the reconciler will
+// look up for a workload scheduled to `node` with PV `pv` (auth=driver, no fsGroup), but with
+// an empty `MountpointS3PodAttachments` map.
+func newEmptyS3PodAttachment(node string, pv *corev1.PersistentVolume) *crdv2.MountpointS3PodAttachment {
+	return &crdv2.MountpointS3PodAttachment{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "s3pa-empty-"},
+		Spec: crdv2.MountpointS3PodAttachmentSpec{
+			NodeName:                   node,
+			PersistentVolumeName:       pv.Name,
+			VolumeID:                   pv.Spec.CSI.VolumeHandle,
+			MountOptions:               strings.Join(pv.Spec.MountOptions, ","),
+			AuthenticationSource:       "driver",
+			WorkloadFSGroup:            "",
+			MountpointS3PodAttachments: map[string][]crdv2.WorkloadAttachment{},
+		},
+	}
+}
+


### PR DESCRIPTION
*Issue:* N/A

*Description of changes:* 

**Problem**: In case of duplicate S3PAs with no MP pod attachments reconciler will get stuck with `found 2 MountpointS3PodAttachments when expecting 0 or 1` error.

**Solution**: Recover from duplicate S3PodAttachments by deleting empty ones directly in reconciler.

**Implementation**:
  - `getExistingS3PodAttachment`: on List returning >1 S3PA, hand off to `recoverFromDuplicateS3PodAttachments` instead of erroring.
  - `recoverFromDuplicateS3PodAttachments`:
    - Deletes duplicates that reference no Mountpoint Pods.
    - Returns the surviving S3PA if exactly one references Mountpoint Pods.
    - Returns `nil` if none did (caller re-creates via handleNewS3PodAttachment).
    - Errors if >1 references Mountpoint Pods -> return error as before (handling this case is out of scope of this PR/problem)
  - `setupLogger` refactor: logger is built before the List and enriched with the S3PA name afterward; no functional change.
  - Drive-by: Wrap Delete with a `ResourceVersion` precondition so a stale-cache `Delete` races to 409 instead of
  overwriting concurrent state. 

**Alternatives considered:**
 - Delete these duplicates in `stale_attachment_cleaner.go` periodic job. Discarded for now because: (we might consider doing in the future as well, in addition to this change)
    - In the worst case, customer workload will be stuck in the reconcile loop for up to 2min waiting for the periodic job cleanup
    - There are more edge cases to handle because we need to ensure that `Delete` (and clearing of expectation) does not interfere with reconciler. (Currently, it's not racing with reconciler because the cleaner only deletes if attachment is stale (>2min old))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
