### PR TITLE
Add concurrency group to build jobs to prevent image push races

### DIFF
--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -27,6 +27,9 @@ jobs:
   build:
     runs-on: ubuntu-22.04 # FIXME - https://github.com/actions/runner-images/issues/11471
     environment: ${{ inputs.environment }}
+    concurrency:
+      group: build-image-${{ inputs.ref }}
+      queue: max
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -42,6 +42,9 @@ jobs:
   build:
     runs-on: ubuntu-22.04 # FIXME - https://github.com/actions/runner-images/issues/11471
     environment: ${{ inputs.environment }}
+    concurrency:
+      group: build-image-${{ inputs.ref }}
+      queue: max
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/26569273266/job/78279273122#step:7:1184
- https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/26577104622/job/78326177013?pr=807#step:7:1214

*Description of changes:*

Both e2e-tests and e2e-rosa-tests workflows build and push the same image for the same commit. With ECR immutable tags, the second workflow to push fails. Adding a per-commit concurrency group on the build job ensures only one workflow builds at a time for a given commit SHA. The second workflow will wait, then skip via the existing manifest inspect check.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
