### PR TITLE
Revert Release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Unreleased
 
-# v2.6.0
-
-[Documentation](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/v2.6.0/README.md)
-
-### Notable changes
-* Add proxy support via `HTTPS_PROXY` and `NO_PROXY` volume attributes. ([#663](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/663))
-* Update container base image from Amazon Linux 2 to Amazon Linux 2023. ([#753](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/753))
-* Fix reconciler getting stuck when duplicate `MountpointS3PodAttachments` exist by deleting empty duplicates. ([#799](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/799))
 * Support Mountpoint [version 1.22.3](https://github.com/awslabs/mountpoint-s3/releases/tag/mountpoint-s3-1.22.3) ([#795](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/795))
   * Improve error message when S3 Express session creation fails. ([#1793](https://github.com/awslabs/mountpoint-s3/pull/1793))
   * Update the internal S3 client to use the latest release of the AWS Common Runtime (CRT) libraries. ([#1819](https://github.com/awslabs/mountpoint-s3/pull/1819))

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 SHELL = /bin/bash
 
 # MP CSI Driver version
-VERSION=2.6.0
+VERSION=2.5.0
 
 PKG=github.com/awslabs/mountpoint-s3-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/README.md
+++ b/README.md
@@ -24,14 +24,13 @@ Mountpoint for Amazon S3 does not implement all the features of a POSIX file sys
 ## Container Images
 | Driver Version | [ECR Public](https://gallery.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|
-| v2.6.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.6.0                       |
+| v2.5.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.5.0                       |
 
 <details>
 <summary>Previous Images</summary>
 
 | Driver Version | [ECR Public](https://gallery.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|
-| v2.5.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.5.0                       |
 | v2.4.1         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.4.1                       |
 | v2.4.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.4.0                       |
 | v2.3.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.3.0                       |

--- a/charts/aws-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-mountpoint-s3-csi-driver
 description: A Helm chart for installing the Mountpoint for Amazon S3 CSI Driver. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface.
-version: 2.6.0
+version: 2.5.0
 kubeVersion: ">=1.30.0-0"
 home: https://github.com/awslabs/mountpoint-s3-csi-driver
 sources:

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v2.6.0"
+  tag: "v2.5.0"
 
 node:
   kubeletPath: /var/lib/kubelet

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: csi-driver
     newName: public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
-    newTag: v2.6.0
+    newTag: v2.5.0
 replacements:
   # Replace value of `MOUNTPOINT_IMAGE` env variable of the CSI Controller with the image path of the CSI Node.
   - source:


### PR DESCRIPTION
This reverts commit "Release v2.6.0" which updated the Helm charts.

--

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
