### PR TITLE
ci: pin aws-actions/configure-aws-credentials to v6 in e2e-tests.yaml

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}


### PR DESCRIPTION
*Issue #, if available:* N/A

Warning from CI: 

```
 E2E Upgrade Tests / build
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: aws-actions/configure-aws-credentials@master. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

```

*Description of changes:* The build_matrix job in e2e-tests.yaml was tracking `@master` while every other workflow uses `@v6`. Pin it to `@v6` so all workflows resolve the same release of the action.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
