### PR TITLE
ci: Skip per-arch image build when already present in registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,17 +107,21 @@ sub-image-%:
 .PHONY: image
 image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION):
-	DOCKER_BUILDKIT=1 docker buildx build \
-		-f ${DOCKERFILE} \
-		--platform=$(OS)/$(ARCH) \
-		--progress=plain \
-		--target=$(OS)-$(OSVERSION) \
-		--output=type=$(OUTPUT_TYPE) \
-		-t=$(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) \
-		--build-arg=GOPROXY=$(GOPROXY) \
-		--build-arg=VERSION=$(VERSION) \
-		--provenance=false \
-		.
+	@if [ "$(OUTPUT_TYPE)" = "registry" ] && docker manifest inspect $(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) > /dev/null 2>&1; then \
+		echo "Image $(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) already exists in registry, skipping build"; \
+	else \
+		DOCKER_BUILDKIT=1 docker buildx build \
+			-f ${DOCKERFILE} \
+			--platform=$(OS)/$(ARCH) \
+			--progress=plain \
+			--target=$(OS)-$(OSVERSION) \
+			--output=type=$(OUTPUT_TYPE) \
+			-t=$(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) \
+			--build-arg=GOPROXY=$(GOPROXY) \
+			--build-arg=VERSION=$(VERSION) \
+			--provenance=false \
+			.; \
+	fi
 	touch $@
 
 .PHONY: push_image


### PR DESCRIPTION
*Issue #, if available:* N/A

E2E CI build step is not idempotent and causes failures on retry in case e.g. ARM image succeeds publishing and AMD image fails:
- https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/26569273266/job/78279273122#step:7:1184
- https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/26577104622/job/78326177013?pr=807#step:7:1214

This required PR authors to push dummy commit or amend existing commits to bypass this CI blockage/failure.

*Description of changes:*

Add idempotency check to the image target so that individual architecture images are not rebuilt if they already exist in the registry. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
