### PR TITLE
Add controller leader election

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -76,4 +76,36 @@ roleRef:
   kind: ClusterRole
   name: s3-csi-driver-controller-cluster-role
   apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-controller-leader-election-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["aws-s3-csi-controller"]
+    verbs: ["get", "update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-controller-leader-election-role-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: s3-csi-driver-controller-leader-election-role
+  apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/cmd/aws-s3-csi-controller/main.go
+++ b/cmd/aws-s3-csi-controller/main.go
@@ -58,7 +58,11 @@ func main() {
 	conf := config.GetConfigOrDie()
 
 	mgr, err := manager.New(conf, manager.Options{
-		Scheme: scheme,
+		Scheme:                        scheme,
+		LeaderElection:                true,
+		LeaderElectionID:              "aws-s3-csi-controller",
+		LeaderElectionResourceLock:    "leases",
+		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
 		log.Error(err, "Failed to create a new manager")


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* During updates there is a chance that 2 controllers would co-exist briefly and would try to reconcile the same pod which would result in duplicate S3PA attachment. Fix this by introducing leader election so that only at most 1 controller is active at any time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
