### PR TITLE
Add daemonset mode E2E tests with dev charts gating

### DIFF
--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -66,12 +66,22 @@ jobs:
       contents: read
     env:
       AWS_REGION: "${{ vars.AWS_REGION }}"
+      DAEMONSET_CHARTS_DIR: "dev/daemonset-charts/aws-mountpoint-s3-csi-driver"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+      - name: Check daemonset charts availability
+        id: check_daemonset_charts
+        run: |
+          if [ -d "${{ env.DAEMONSET_CHARTS_DIR }}" ]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::notice::Daemonset charts not found at ${{ env.DAEMONSET_CHARTS_DIR }}, skipping daemonset tests"
+          fi
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -200,27 +210,28 @@ jobs:
           ACTION: "uninstall_driver"
         run: tests/e2e-kubernetes/scripts/run.sh
       - name: Install the driver (daemonset mode)
-        if: ${{ always() && steps.openshift_login.conclusion == 'success' }}
+        if: ${{ always() && steps.openshift_login.conclusion == 'success' && steps.check_daemonset_charts.outputs.available == 'true' }}
         env:
           ACTION: "install_driver"
           MOUNTER_MODE: "daemonset"
+          CHARTS_DIR: ${{ env.DAEMONSET_CHARTS_DIR }}
           TAG: "untested_${{ inputs.ref }}"
           CSI_DRIVER_IRSA_ROLE_ARN: "arn:aws:iam::${{ steps.aws-creds.outputs.aws-account-id }}:role/s3-csi-${{ inputs.environment }}-driver-irsa"
         run: tests/e2e-kubernetes/scripts/run.sh
       - name: Run E2E Tests (daemonset mode)
-        if: ${{ always() && steps.openshift_login.conclusion == 'success' }}
+        if: ${{ always() && steps.openshift_login.conclusion == 'success' && steps.check_daemonset_charts.outputs.available == 'true' }}
         env:
           ACTION: "run_tests"
           MOUNTER_MODE: "daemonset"
           IMDS_AVAILABLE: "false"
         run: tests/e2e-kubernetes/scripts/run.sh
       - name: Post e2e cleanup (daemonset mode)
-        if: ${{ always() && steps.openshift_login.conclusion == 'success' }}
+        if: ${{ always() && steps.openshift_login.conclusion == 'success' && steps.check_daemonset_charts.outputs.available == 'true' }}
         env:
           ACTION: "e2e_cleanup"
         run: tests/e2e-kubernetes/scripts/run.sh
       - name: Uninstall the driver (daemonset mode)
-        if: ${{ always() && steps.openshift_login.conclusion == 'success' }}
+        if: ${{ always() && steps.openshift_login.conclusion == 'success' && steps.check_daemonset_charts.outputs.available == 'true' }}
         env:
           ACTION: "uninstall_driver"
         run: tests/e2e-kubernetes/scripts/run.sh

--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -199,3 +199,28 @@ jobs:
         env:
           ACTION: "uninstall_driver"
         run: tests/e2e-kubernetes/scripts/run.sh
+      - name: Install the driver (daemonset mode)
+        if: ${{ always() && steps.openshift_login.conclusion == 'success' }}
+        env:
+          ACTION: "install_driver"
+          MOUNTER_MODE: "daemonset"
+          TAG: "untested_${{ inputs.ref }}"
+          CSI_DRIVER_IRSA_ROLE_ARN: "arn:aws:iam::${{ steps.aws-creds.outputs.aws-account-id }}:role/s3-csi-${{ inputs.environment }}-driver-irsa"
+        run: tests/e2e-kubernetes/scripts/run.sh
+      - name: Run E2E Tests (daemonset mode)
+        if: ${{ always() && steps.openshift_login.conclusion == 'success' }}
+        env:
+          ACTION: "run_tests"
+          MOUNTER_MODE: "daemonset"
+          IMDS_AVAILABLE: "false"
+        run: tests/e2e-kubernetes/scripts/run.sh
+      - name: Post e2e cleanup (daemonset mode)
+        if: ${{ always() && steps.openshift_login.conclusion == 'success' }}
+        env:
+          ACTION: "e2e_cleanup"
+        run: tests/e2e-kubernetes/scripts/run.sh
+      - name: Uninstall the driver (daemonset mode)
+        if: ${{ always() && steps.openshift_login.conclusion == 'success' }}
+        env:
+          ACTION: "uninstall_driver"
+        run: tests/e2e-kubernetes/scripts/run.sh

--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -9,6 +9,11 @@ on:
       ref:
         required: true
         type: string
+      pod_mode_charts_dir:
+        required: false
+        type: string
+        default: ""
+        description: "Helm charts directory to use for pod-mode e2e tests. Leave empty for the default."
 
 concurrency:
   group: e2e-cluster-${{ inputs.environment }}
@@ -192,6 +197,7 @@ jobs:
           ACTION: "install_driver"
           TAG: "untested_${{ inputs.ref }}"
           CSI_DRIVER_IRSA_ROLE_ARN: "arn:aws:iam::${{ steps.aws-creds.outputs.aws-account-id }}:role/s3-csi-${{ inputs.environment }}-driver-irsa"
+          CHARTS_DIR: ${{ inputs.pod_mode_charts_dir }}
         run: tests/e2e-kubernetes/scripts/run.sh
       - name: Run E2E Tests
         env:

--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -6,6 +6,15 @@ on:
   merge_group:
     types: [ "checks_requested" ]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      pod_mode_charts_dir:
+        description: "Helm charts directory to use for pod-mode e2e tests."
+        type: choice
+        default: "charts/aws-mountpoint-s3-csi-driver"
+        options:
+          - "charts/aws-mountpoint-s3-csi-driver"
+          - "dev/daemonset-charts/aws-mountpoint-s3-csi-driver"
 
 permissions:
   id-token: write
@@ -18,7 +27,8 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       environment: "trusted"
-      ref: ${{ (github.event_name == 'push' && github.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.event.merge_group.head_sha }}
+      ref: ${{ (github.event_name == 'push' && github.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.event.merge_group.head_sha || github.sha }}
+      pod_mode_charts_dir: ${{ inputs.pod_mode_charts_dir || '' }}
     secrets: inherit
   e2e-rosa:
     name: E2E ROSA Tests
@@ -26,7 +36,8 @@ jobs:
     uses: ./.github/workflows/e2e-rosa-tests.yaml
     with:
       environment: "rosa-trusted"
-      ref: ${{ (github.event_name == 'push' && github.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.event.merge_group.head_sha }}
+      ref: ${{ (github.event_name == 'push' && github.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.event.merge_group.head_sha || github.sha }}
+      pod_mode_charts_dir: ${{ inputs.pod_mode_charts_dir || '' }}
     secrets: inherit
   outcome:
     name: All E2E Tests Passed

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -94,12 +94,22 @@ jobs:
       SELINUX_MODE: "${{ matrix.selinux-mode }}"
       MOUNTPOINT_CSI_DRIVER_PREVIOUS_VERSION: "${{ inputs.upgrade_tests_old_version }}"
       MOUNTPOINT_CSI_DRIVER_NEW_VERSION: "${{ inputs.upgrade_tests_new_version }}"
+      DAEMONSET_CHARTS_DIR: "dev/daemonset-charts/aws-mountpoint-s3-csi-driver"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+      - name: Check daemonset charts availability
+        id: check_daemonset_charts
+        run: |
+          if [ -d "${{ env.DAEMONSET_CHARTS_DIR }}" ]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::notice::Daemonset charts not found at ${{ env.DAEMONSET_CHARTS_DIR }}, skipping daemonset tests"
+          fi
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -153,27 +163,28 @@ jobs:
         run: |
           tests/e2e-kubernetes/scripts/run.sh
       - name: Install the driver (daemonset mode)
-        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests }}
+        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests && steps.check_daemonset_charts.outputs.available == 'true' }}
         env:
           ACTION: "install_driver"
           MOUNTER_MODE: "daemonset"
+          CHARTS_DIR: ${{ env.DAEMONSET_CHARTS_DIR }}
         run: |
           tests/e2e-kubernetes/scripts/run.sh
       - name: Run E2E Tests (daemonset mode)
-        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests }}
+        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests && steps.check_daemonset_charts.outputs.available == 'true' }}
         env:
           ACTION: "run_tests"
           MOUNTER_MODE: "daemonset"
         run: |
           tests/e2e-kubernetes/scripts/run.sh
       - name: Post e2e cleanup (daemonset mode)
-        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests }}
+        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests && steps.check_daemonset_charts.outputs.available == 'true' }}
         env:
           ACTION: "e2e_cleanup"
         run: |
           tests/e2e-kubernetes/scripts/run.sh
       - name: Uninstall the driver (daemonset mode)
-        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests }}
+        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests && steps.check_daemonset_charts.outputs.available == 'true' }}
         env:
           ACTION: "uninstall_driver"
         run: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
         description: "Only used if `run_upgrade_tests` is true, specifies the new version to test upgrade to."
+      pod_mode_charts_dir:
+        required: false
+        type: string
+        default: ""
+        description: "Helm charts directory to use for pod-mode e2e tests. Leave empty for the default."
 
 concurrency:
   group: e2e-cluster-${{ inputs.environment }}
@@ -142,6 +147,7 @@ jobs:
       - name: Install the driver
         env:
           ACTION: "install_driver"
+          CHARTS_DIR: ${{ inputs.pod_mode_charts_dir }}
         run: |
           tests/e2e-kubernetes/scripts/run.sh
       - name: Run E2E Tests

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -152,6 +152,32 @@ jobs:
           ACTION: "uninstall_driver"
         run: |
           tests/e2e-kubernetes/scripts/run.sh
+      - name: Install the driver (daemonset mode)
+        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests }}
+        env:
+          ACTION: "install_driver"
+          MOUNTER_MODE: "daemonset"
+        run: |
+          tests/e2e-kubernetes/scripts/run.sh
+      - name: Run E2E Tests (daemonset mode)
+        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests }}
+        env:
+          ACTION: "run_tests"
+          MOUNTER_MODE: "daemonset"
+        run: |
+          tests/e2e-kubernetes/scripts/run.sh
+      - name: Post e2e cleanup (daemonset mode)
+        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests }}
+        env:
+          ACTION: "e2e_cleanup"
+        run: |
+          tests/e2e-kubernetes/scripts/run.sh
+      - name: Uninstall the driver (daemonset mode)
+        if: ${{ always() && steps.create_cluster.conclusion == 'success' && !inputs.run_upgrade_tests }}
+        env:
+          ACTION: "uninstall_driver"
+        run: |
+          tests/e2e-kubernetes/scripts/run.sh
       - name: Delete cluster
         if: always()
         env:

--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -32,6 +32,7 @@ func init() {
 	flag.BoolVar(&Performance, "performance", false, "run performance tests")
 	flag.BoolVar(&UpgradeTests, "run-upgrade-tests", false, "run upgrade tests")
 	flag.BoolVar(&IMDSAvailable, "imds-available", false, "indicates whether instance metadata service is available")
+	flag.StringVar(&MounterMode, "mounter-mode", "pod", "mounter mode (pod or daemonset)")
 	flag.Parse()
 
 	s3client.DefaultRegion = BucketRegion
@@ -76,6 +77,18 @@ var CSITestSuites = []func() framework.TestSuite{
 }
 
 func getCSITestSuites() []func() framework.TestSuite {
+	if MounterMode == "daemonset" {
+		// Daemonset mode runs without the controller, CRD, or mount-s3 namespace.
+		// Excluded suites: cache, credentials, pod sharing, eviction order, taint
+		// removal, proxy, headroom.
+		return []func() framework.TestSuite{
+			testsuites.InitVolumesTestSuite,
+			custom_testsuites.InitS3AccessModeTestSuite,
+			custom_testsuites.InitS3MountOptionsTestSuite,
+			custom_testsuites.InitS3CSIMultiVolumeTestSuite,
+		}
+	}
+
 	suites := CSITestSuites
 	// Headroom feature is not supported on OpenShift
 	if ClusterType != "openshift" {

--- a/tests/e2e-kubernetes/scripts/helm.sh
+++ b/tests/e2e-kubernetes/scripts/helm.sh
@@ -49,6 +49,7 @@ function helm_install_driver() {
   KUBECONFIG=${6}
   CSI_DRIVER_IRSA_ROLE_ARN=${7}
   CLUSTER_TYPE=${8}
+  MOUNTER_MODE=${9:-pod}
 
   helm_uninstall_driver \
     "$HELM_BIN" \
@@ -65,16 +66,27 @@ function helm_install_driver() {
     IRSA_FLAG=""
   fi
 
+  MODE_FLAGS=""
+  if [[ "${MOUNTER_MODE}" == "daemonset" ]]; then
+    MODE_FLAGS="--set experimental.mounterMode=daemonset"
+  else
+    MODE_FLAGS="--set experimental.reserveHeadroomForMountpointPods=true"
+  fi
+
   $HELM_BIN upgrade --install $RELEASE_NAME --namespace kube-system ./charts/aws-mountpoint-s3-csi-driver --values \
     ./charts/aws-mountpoint-s3-csi-driver/values.yaml \
     --set image.repository=${REPOSITORY} \
     --set image.tag=${TAG} \
     --set image.pullPolicy=Always \
     --set node.serviceAccount.create=true \
-    --set experimental.reserveHeadroomForMountpointPods=true \
+    ${MODE_FLAGS} \
     ${IRSA_FLAG} \
     --kubeconfig ${KUBECONFIG}
-  $KUBECTL_BIN rollout status daemonset s3-csi-node -n kube-system --timeout=60s --kubeconfig $KUBECONFIG
+  $KUBECTL_BIN rollout status daemonset s3-csi-node -n kube-system --timeout=180s --kubeconfig $KUBECONFIG
+  if [[ "${MOUNTER_MODE}" == "daemonset" ]]; then
+    # Wait for pod readiness directly (rollout status doesn't support OnDelete strategy)
+    $KUBECTL_BIN wait --for=condition=Ready pods -l app=s3-csi-mounter -n kube-system --timeout=180s --kubeconfig $KUBECONFIG
+  fi
   $KUBECTL_BIN get pods -A --kubeconfig $KUBECONFIG
   echo "s3-csi-node-image: $($KUBECTL_BIN get daemonset s3-csi-node -n kube-system -o jsonpath="{$.spec.template.spec.containers[:1].image}" --kubeconfig $KUBECONFIG)"
 

--- a/tests/e2e-kubernetes/scripts/helm.sh
+++ b/tests/e2e-kubernetes/scripts/helm.sh
@@ -52,6 +52,11 @@ function helm_install_driver() {
   MOUNTER_MODE=${9:-pod}
   CHARTS_DIR=${10:-charts/aws-mountpoint-s3-csi-driver}
 
+  # Validate charts directory (can be overridden via workflow_dispatch input)
+  if [[ "${CHARTS_DIR}" =~ [^a-zA-Z0-9_./-] ]]; then
+    echo "ERROR: CHARTS_DIR contains invalid characters: ${CHARTS_DIR}"
+    exit 1
+  fi
   if [[ ! -d "./${CHARTS_DIR}" ]]; then
     echo "ERROR: Charts directory './${CHARTS_DIR}' does not exist."
     exit 1
@@ -79,8 +84,8 @@ function helm_install_driver() {
     MODE_FLAGS="--set experimental.reserveHeadroomForMountpointPods=true"
   fi
 
-  $HELM_BIN upgrade --install $RELEASE_NAME --namespace kube-system ./${CHARTS_DIR} --values \
-    ./${CHARTS_DIR}/values.yaml \
+  $HELM_BIN upgrade --install $RELEASE_NAME --namespace kube-system "./${CHARTS_DIR}" --values \
+    "./${CHARTS_DIR}/values.yaml" \
     --set image.repository=${REPOSITORY} \
     --set image.tag=${TAG} \
     --set image.pullPolicy=Always \

--- a/tests/e2e-kubernetes/scripts/helm.sh
+++ b/tests/e2e-kubernetes/scripts/helm.sh
@@ -50,6 +50,12 @@ function helm_install_driver() {
   CSI_DRIVER_IRSA_ROLE_ARN=${7}
   CLUSTER_TYPE=${8}
   MOUNTER_MODE=${9:-pod}
+  CHARTS_DIR=${10:-charts/aws-mountpoint-s3-csi-driver}
+
+  if [[ ! -d "./${CHARTS_DIR}" ]]; then
+    echo "ERROR: Charts directory './${CHARTS_DIR}' does not exist."
+    exit 1
+  fi
 
   helm_uninstall_driver \
     "$HELM_BIN" \
@@ -73,8 +79,8 @@ function helm_install_driver() {
     MODE_FLAGS="--set experimental.reserveHeadroomForMountpointPods=true"
   fi
 
-  $HELM_BIN upgrade --install $RELEASE_NAME --namespace kube-system ./charts/aws-mountpoint-s3-csi-driver --values \
-    ./charts/aws-mountpoint-s3-csi-driver/values.yaml \
+  $HELM_BIN upgrade --install $RELEASE_NAME --namespace kube-system ./${CHARTS_DIR} --values \
+    ./${CHARTS_DIR}/values.yaml \
     --set image.repository=${REPOSITORY} \
     --set image.tag=${TAG} \
     --set image.pullPolicy=Always \

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -28,6 +28,7 @@ EKSCTL_BIN=${BIN_DIR}/eksctl
 KUBECTL_BIN=${KUBECTL_INSTALL_PATH}/kubectl
 
 CLUSTER_TYPE=${CLUSTER_TYPE:-eksctl}
+MOUNTER_MODE=${MOUNTER_MODE:-pod}
 IMDS_AVAILABLE=${IMDS_AVAILABLE:-true}
 ARCH=${ARCH:-x86}
 AMI_FAMILY=${AMI_FAMILY:-AmazonLinux2}
@@ -168,11 +169,12 @@ elif [[ "${ACTION}" == "install_driver" ]]; then
     "${TAG}" \
     "${KUBECONFIG}" \
     "${CSI_DRIVER_IRSA_ROLE_ARN}" \
-    "${CLUSTER_TYPE}"
+    "${CLUSTER_TYPE}" \
+    "${MOUNTER_MODE}"
 elif [[ "${ACTION}" == "run_tests" ]]; then
   set +e
   pushd tests/e2e-kubernetes
-  KUBECONFIG=${KUBECONFIG} ginkgo -p -vv --github-output -timeout 60m -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=${IMDS_AVAILABLE} --cluster-name=${CLUSTER_NAME} --cluster-type=${CLUSTER_TYPE}
+  KUBECONFIG=${KUBECONFIG} ginkgo -p -vv --github-output -timeout 60m -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=${IMDS_AVAILABLE} --cluster-name=${CLUSTER_NAME} --cluster-type=${CLUSTER_TYPE} --mounter-mode=${MOUNTER_MODE}
   EXIT_CODE=$?
   print_cluster_info
   exit $EXIT_CODE

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -29,6 +29,7 @@ KUBECTL_BIN=${KUBECTL_INSTALL_PATH}/kubectl
 
 CLUSTER_TYPE=${CLUSTER_TYPE:-eksctl}
 MOUNTER_MODE=${MOUNTER_MODE:-pod}
+CHARTS_DIR=${CHARTS_DIR:-charts/aws-mountpoint-s3-csi-driver}
 IMDS_AVAILABLE=${IMDS_AVAILABLE:-true}
 ARCH=${ARCH:-x86}
 AMI_FAMILY=${AMI_FAMILY:-AmazonLinux2}
@@ -170,7 +171,8 @@ elif [[ "${ACTION}" == "install_driver" ]]; then
     "${KUBECONFIG}" \
     "${CSI_DRIVER_IRSA_ROLE_ARN}" \
     "${CLUSTER_TYPE}" \
-    "${MOUNTER_MODE}"
+    "${MOUNTER_MODE}" \
+    "${CHARTS_DIR}"
 elif [[ "${ACTION}" == "run_tests" ]]; then
   set +e
   pushd tests/e2e-kubernetes

--- a/tests/e2e-kubernetes/testdriver.go
+++ b/tests/e2e-kubernetes/testdriver.go
@@ -19,6 +19,7 @@ var (
 	BucketRegion  string // assumed to be the same as k8s cluster's region
 	ClusterName   string
 	ClusterType   string
+	MounterMode   string
 	BucketPrefix  string
 	Performance   bool
 	UpgradeTests  bool


### PR DESCRIPTION
### Description

Add daemonset mode to E2E CI in anticipation of PR #797, running tests only if `dev/daemonset-charts/` exist. 
- ci: add daemonset mode to CI e2e workflows
  - daemonset e2e tests with basic test suites:
    - `testsuites.InitVolumesTestSuite`
    - `custom_testsuites.InitS3AccessModeTestSuite`
    - `custom_testsuites.InitS3MountOptionsTestSuite`
    - `custom_testsuites.InitS3CSIMultiVolumeTestSuite`
  - Added workflow jobs: install + test + cleanup + uninstall after pod mode e2e tests
-  ci: use dev/daemonset-charts/ for daemonset mode E2E tests
   - also gates daemonset steps on directory existence
- ci: add pod_mode_charts_dir input to help drift testing (workflow dispatch)
  - OPTIONAL - adding this as a nicety to allow manual triggering of pod mode + `dev/daemonset-charts/` e2e tests, which is not covered in pod mode + `charts/` and daemonset mode + `dev/daemonset-charts/` tests. 

#### Details on 60s -> 180s timeout:

The 60s timeout was flaky in CI when reinstalling the driver in daemonset mode after pod mode. e.g.:
https://github.com/jet-tong/mountpoint-s3-csi-driver/actions/runs/26028031016/job/76743129645, during my initial testing of commit 'ci: add daemonset mode to CI e2e workflows'. 

```
+ /usr/local/bin/kubectl rollout status daemonset s3-csi-node -n kube-system --timeout=60s --kubeconfig /home/runner/work/mountpoint-s3-csi-driver/mountpoint-s3-csi-driver/tests/e2e-kubernetes/scripts/../csi-test-artifacts/s3-csi-cluster-eksctl-amazonlinux2023-x86-1-30.kubeconfig
Waiting for daemon set "s3-csi-node" rollout to finish: 0 of 2 updated pods are available...
Waiting for daemon set "s3-csi-node" rollout to finish: 1 of 2 updated pods are available...
error: timed out waiting for the condition
```

#### Details on why we added pod_mode_charts_dir input

We already cover (pod mode + `charts/`) and (daemonset mode + `dev/daemonset-charts/`) tests. (pod mode + `dev/daemonset-charts/`) is not covered. Adding this workflow dispatch lets us manually test this case when we want, instead of risking catching these errors only when we merge daemonset charts back to main charts directory. We avoid adding another E2E run just for pod-mode + dev/daemonset-charts/ to avoid increasing CI runtime and flakiness further.

### Testing:

- [ ] TODO rerun manual testing to verify this PR works with #797, if necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
