### PR TITLE
Bump Go to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN MP_ARCH=`echo ${TARGETARCH} | sed s/amd64/x86_64/` && \
     patchelf --set-rpath '$ORIGIN' /mountpoint-s3/bin/mount-s3
 
 # Build driver. Use BUILDPLATFORM not TARGETPLATFORM for cross compilation
-FROM --platform=$BUILDPLATFORM public.ecr.aws/eks-distro-build-tooling/golang:1.26.3-al23 as builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/eks-distro-build-tooling/golang:1.26.4-al23 as builder
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/awslabs/mountpoint-s3-csi-driver

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -46,7 +46,7 @@ RUN cd mountpoint-s3 && \
 #
 
 # Use BUILDPLATFORM not TARGETPLATFORM for cross compilation
-FROM --platform=$BUILDPLATFORM public.ecr.aws/eks-distro-build-tooling/golang:1.26.3-al23 as builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/eks-distro-build-tooling/golang:1.26.4-al23 as builder
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/awslabs/mountpoint-s3-csi-driver

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/awslabs/mountpoint-s3-csi-driver
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2

--- a/tests/e2e-kubernetes/go.mod
+++ b/tests/e2e-kubernetes/go.mod
@@ -1,6 +1,6 @@
 module github.com/awslabs/mountpoint-s3-csi-driver/tests/e2e-kubernetes
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump Go version from 1.26.3 to 1.26.4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
