### PR TITLE
Fix untrusted rosa e2e skip for daemonset feature branch

### DIFF
--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -32,7 +32,7 @@ jobs:
   e2e-rosa:
     name: E2E ROSA Tests
     # Temporarily skipping rosa tests for feature/daemonset-architecture branch
-    if: github.ref_name != 'feature/daemonset-architecture' 
+    if: ${{ github.event.pull_request.base.ref != 'feature/daemonset-architecture' }}
     uses: ./.github/workflows/e2e-rosa-tests.yaml
     needs: approval
     with:
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Verify jobs succeeded
         run: |
-          if [[ "${{ github.base_ref }}" == "feature/daemonset-architecture" ]]; then
+          if [[ "${{ github.event.pull_request.base.ref }}" == "feature/daemonset-architecture" ]]; then
             echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'
           else
             echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'


### PR DESCRIPTION
### Description of changes

Previously in https://github.com/awslabs/mountpoint-s3-csi-driver/pull/825, untrusted workflow isn't properly skipping ROSA since ref_name is main instead of feature/daemonset-architecture for pull_request_target. We use `github.event.pull_request.base.ref` instead (following stack exchange example) for. 

### Testing

trusted yaml tests (verify no changes needed there): Tests on https://github.com/jet-tong/mountpoint-s3-csi-driver/pull/16
- Both jobs run on main PR: https://github.com/jet-tong/mountpoint-s3-csi-driver/actions/runs/27287934871ROSA skips on 
- ROSA skips on feature/daemonset-architecture PR: https://github.com/jet-tong/mountpoint-s3-csi-driver/actions/runs/27288065436?pr=16

untrusted yaml tests: Tests on https://github.com/jet-tong/mountpoint-s3-csi-driver/pull/17 & this PR
- Both jobs run on main PR: (as seen in this PR)
- ROSA skips on feature/daemonset-architecture PR: https://github.com/jet-tong/mountpoint-s3-csi-driver/actions/runs/27290194890/attempts/1?pr=17

### References
- https://stackoverflow.com/questions/76235374/how-do-i-run-a-github-actions-workflow-only-on-pull-request-reviews-for-certain
- https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
