### PR TITLE
Add retries to go mod download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ login_registry:
 
 .PHONY: download_go_deps
 download_go_deps:
-	go mod download
+	go mod download || (echo "go mod download failed, retrying (1/2)..." && sleep 5 && go mod download) || (echo "go mod download failed, retrying (2/2)..." && sleep 10 && go mod download)
 
 .PHONY: bin
 bin:


### PR DESCRIPTION
### Changes

We've had CI failures from honnef.co TLS handshake timeout lately, e.g.:
```bash
ERROR: failed to build: failed to solve: process "/bin/sh -c TARGETARCH=${TARGETARCH} make generate_licenses bin" did not complete successfully: exit code: 2  
honnef.co/go/tools@v0.0.0-20190523083050-ea95bdfd59fc: unrecognized import path "honnef.co/go/tools": https fetch: Get "https://honnef.co/go/tools?go-get=1": net/http: TLS handshake timeout
```

This PR adds 2 retry attempts with 'exponential backoff' 5s/10s waits on go mod download in Makefile. 

Note we use GOPROXY=direct right now, and we could use proxy.golang.org as cache to fix as a long term solution later. 

### Testing

<details>
<summary>Testing outputs (Expand to view)</summary>

```bash
<0> % rm -rf $(go env GOPATH)/pkg/mod/cache/download/honnef.co
<0> % echo "127.0.0.1 honnef.co" | sudo tee -a /etc/hosts
<0> % make download_go_deps
go mod download || (echo "go mod download failed, retrying (1/2)..." && sleep 5 && go mod download) || (echo "go mod download failed, retrying (2/2)..." && sleep 10 && go mod download)
go: go.opencensus.io@v0.24.0 requires
        google.golang.org/grpc@v1.33.2 requires
        google.golang.org/genproto@v0.0.0-20200526211855-cb27e3aa2013 requires
        honnef.co/go/tools@v0.0.0-20190523083050-ea95bdfd59fc: unrecognized import path "honnef.co/go/tools": https fetch: Get "https://honnef.co/go/tools?go-get=1": dial tcp 127.0.0.1:443: connect: connection refused
go mod download failed, retrying (1/2)...
go: go.opencensus.io@v0.24.0 requires
        google.golang.org/grpc@v1.33.2 requires
        google.golang.org/genproto@v0.0.0-20200526211855-cb27e3aa2013 requires
        honnef.co/go/tools@v0.0.0-20190523083050-ea95bdfd59fc: unrecognized import path "honnef.co/go/tools": https fetch: Get "https://honnef.co/go/tools?go-get=1": dial tcp 127.0.0.1:443: connect: connection refused
go mod download failed, retrying (2/2)...
go: go.opencensus.io@v0.24.0 requires
        google.golang.org/grpc@v1.33.2 requires
        google.golang.org/genproto@v0.0.0-20200526211855-cb27e3aa2013 requires
        honnef.co/go/tools@v0.0.0-20190523083050-ea95bdfd59fc: unrecognized import path "honnef.co/go/tools": https fetch: Get "https://honnef.co/go/tools?go-get=1": dial tcp 127.0.0.1:443: connect: connection refused
make: *** [download_go_deps] Error 1
<2> % sudo sed -i '/honnef.co/d' /etc/hosts
<0> % make download_go_deps                
go mod download || (echo "go mod download failed, retrying (1/2)..." && sleep 5 && go mod download) || (echo "go mod download failed, retrying (2/2)..." && sleep 10 && go mod download)

<0> % ...
```

</details>


<details>
<summary>Retry worked! (Expand to view)</summary>

It didn't print the echos (contrary to what I thought) but the retry is working. (In [this workflow](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/828#issue-4633500826))
```
#14 [builder 4/4] RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod     TARGETARCH=arm64 make generate_licenses bin
#14 0.114 go mod download || (echo "go mod download failed, retrying (1/2)..." && sleep 5 && go mod download) || (echo "go mod download failed, retrying (2/2)..." && sleep 10 && go mod download)
#13 [builder 4/4] RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod     TARGETARCH=amd64 make generate_licenses bin
#13 0.115 go mod download || (echo "go mod download failed, retrying (1/2)..." && sleep 5 && go mod download) || (echo "go mod download failed, retrying (2/2)..." && sleep 10 && go mod download)
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
