### PR TITLE
Fix upgrade tests to use default charts when installing prev version

### DIFF
--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -465,15 +465,22 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 	}
 }
 
-// buildHelmValues creates common Helm values for install/upgrade
-func buildHelmValues() map[string]any {
-	values := map[string]any{
+// buildHelmValuesBase creates Helm values for installation of the previous version,
+// without image overrides so the chart's default image would be used.
+func buildHelmValuesBase() map[string]any {
+	return map[string]any{
 		"node": map[string]any{
 			"podInfoOnMountCompat": map[string]any{
 				"enable": "true",
 			},
 		},
 	}
+}
+
+// buildHelmValuesForUpgrade creates Helm values for install/upgrade of the new version,
+// overriding the image fields to use the CI-built container from the current commit.
+func buildHelmValuesForUpgrade() map[string]any {
+	values := buildHelmValuesBase()
 	if helmChartContainerRepository != "" && helmChartContainerTag != "" {
 		values["image"] = map[string]any{
 			"repository": helmChartContainerRepository,
@@ -608,7 +615,7 @@ func installCSIDriver(cfg *action.Configuration, version string, chartPath strin
 	chart, err := loader.Load(chartPath)
 	framework.ExpectNoError(err)
 
-	release, err := installClient.RunWithContext(context.Background(), chart, buildHelmValues())
+	release, err := installClient.RunWithContext(context.Background(), chart, buildHelmValuesBase())
 	framework.ExpectNoError(err)
 
 	framework.Logf("Helm release %q created", release.Name)
@@ -651,7 +658,7 @@ func upgradeCSIDriver(cfg *action.Configuration, f *framework.Framework, version
 	chart, err := loader.Load(chartPath)
 	framework.ExpectNoError(err)
 
-	release, err := upgradeClient.RunWithContext(context.Background(), helmReleaseName, chart, buildHelmValues())
+	release, err := upgradeClient.RunWithContext(context.Background(), helmReleaseName, chart, buildHelmValuesForUpgrade())
 	framework.ExpectNoError(err)
 
 	framework.Logf("Helm release %q updated to %v (from %q)", release.Name, version, chartPath)


### PR DESCRIPTION
### Changes

Cherry-picks https://github.com/awslabs/mountpoint-s3-csi-driver/pull/829 back to main.

Before, `buildHelmValues()` overrode the image for both 'install' (previous version) and 'upgrade' (new version), causing old chart + new binary mismatch during upgrade tests. We split into `buildHelmValuesBase` (no override) and `buildHelmValuesForUpgrade` (with override) to fix this.

### Context

When running upgrade tests for v2.7.0 release, they were failing (upgrade test runs
[#26](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/27337606928), [#27](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/27343411372)).

They were timing out during `util.go:183] Creating Pod in aws-s3-csi-e2e-upgrade-7835 (SA: default)` step with these errors:
```sh
[FAILED] pod "pvc-tester-nwzhj" is not Running: Timed out after 300.000s.
...
E0611 11:17:44.873225   95422 driver.go:182] GRPC error: rpc error: code = Internal desc = Could not mount "s3-csi-k8s-e2e-6rgkg5qhkzx2t5ngcjmft8zt59m49vp8mzq6swsrszfvxn2t" at "/var/lib/kubelet/pods/5e0b1755-56c0-4bc7-b6a9-e1ae940038ff/volumes/kubernetes.io~csi/s3-e2e-pv-174fbb2a-4e5d-4af3-8e89-9c848f7f7cb6/mount": Failed to find corresponding MountpointS3PodAttachment custom resource: context deadline exceeded. You can see the controller logs by running `kubectl logs -n kube-system -lapp=s3-csi-controller`.
```

The suspected PR was the leader election PR #814, but its E2E tests pass where upgrade tests fail which led us to suspect the upgrade test file.

It turns out the upgrade tests installs the v2.6.0 (previous) release with v2.6.0 helm charts but overrides the image to the new v2.7.0 image in our `helmChartContainerRepository`. It wasn't detected until this release where we added leader election code which requires our `s3-csi-driver-controller-leader-election-role` to be in the helm charts.

What happens with the v2.6.0 charts + v2.7.0 image combo (AI analysis): _The controller pod starts, retries lease acquisition every 2s (RBAC 403), never acquires leadership, and never starts reconcilers. Workload pods then hang because no MountpointS3PodAttachment or Mountpoint Pod is ever created._

### Testing

I tested in my github cluster:
- Before: Fails in exact same way as in the release branch upgrade tests -
https://github.com/jet-tong/mountpoint-s3-csi-driver/actions/runs/27347404827 (I cancelled some of them so I can start test of 'after' quicker)
- After: Tests start properly - https://github.com/jet-tong/mountpoint-s3-csi-driver/actions/runs/27347823839


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
