### PR TITLE
ci: Add verify helm images workflow

### DIFF
--- a/.github/workflows/verify-helm-images.yaml
+++ b/.github/workflows/verify-helm-images.yaml
@@ -1,0 +1,28 @@
+name: "Verify Helm Images"
+
+on:
+  push:
+    branches: [ "main", "feature/*" ]
+  pull_request:
+  merge_group:
+    types: [ "checks_requested" ]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify chart images exist in public ECR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install crane
+        run: |
+          cd /tmp
+          curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" > crane.tar.gz
+          tar -xzf crane.tar.gz crane
+          sudo mv crane /usr/local/bin/crane
+          sudo chmod +x /usr/local/bin/crane
+          crane version
+      - name: Verify public ECR images referenced in chart
+        run: ./scripts/verify-helm-images.sh --public-only

--- a/scripts/verify-helm-images.sh
+++ b/scripts/verify-helm-images.sh
@@ -12,11 +12,24 @@ set -euo pipefail
 #   - Liveness probe sidecar
 #   - Headroom pod image (pause container)
 #
+# Usage:
+#   ./verify-helm-images.sh                # Full verification (incl. EKS-addon private ECR repo; needs AWS creds)
+#   ./verify-helm-images.sh --public-only  # Verify only public ECR images (no AWS creds needed)
+#
 # Prerequisites:
 #   - yq: YAML processor (https://github.com/mikefarah/yq)
 #   - crane: Container registry tool (https://github.com/google/go-containerregistry/tree/main/cmd/crane)
 #
-# Note: AWS credentials are required with ecr:GetAuthorizationToken and ecr:BatchGetImage permissions to access EKS add-on repositories.
+# Note: For the default (full) mode, AWS credentials with ecr:GetAuthorizationToken and
+# ecr:BatchGetImage permissions are required to access EKS add-on repositories.
+
+PUBLIC_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --public-only) PUBLIC_ONLY=1 ;;
+    *) echo "ERROR: Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
 
 CHART_DIR="charts/aws-mountpoint-s3-csi-driver"
 VALUES_FILE="${CHART_DIR}/values.yaml"
@@ -54,9 +67,11 @@ fi
 echo "Verifying all images referenced in ${VALUES_FILE}..."
 echo ""
 
-if ! aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${EKS_REGISTRY}"; then
-  echo "ERROR: Failed to authenticate with ECR"
-  exit 1
+if [[ ${PUBLIC_ONLY} -eq 0 ]]; then
+  if ! aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${EKS_REGISTRY}"; then
+    echo "ERROR: Failed to authenticate with ECR"
+    exit 1
+  fi
 fi
 
 FAILED=0
@@ -109,8 +124,10 @@ verify_sidecar_images_in_chart() {
 echo "== Verifying standard images =="
 verify_sidecar_images_in_chart "helm template $CHART_DIR"
 
-echo "== Verifying EKS Addon images =="
-verify_sidecar_images_in_chart "helm template $CHART_DIR --set isEKSAddon=true --set sidecars.livenessProbe.image.containerRegistry=$EKS_REGISTRY --set sidecars.nodeDriverRegistrar.image.containerRegistry=$EKS_REGISTRY"
+if [[ ${PUBLIC_ONLY} -eq 0 ]]; then
+  echo "== Verifying EKS Addon images =="
+  verify_sidecar_images_in_chart "helm template $CHART_DIR --set isEKSAddon=true --set sidecars.livenessProbe.image.containerRegistry=$EKS_REGISTRY --set sidecars.nodeDriverRegistrar.image.containerRegistry=$EKS_REGISTRY"
+fi
 
 # Verify headroom pod image (used when experimental.reserveHeadroomForMountpointPods is enabled)
 HEADROOM_IMAGE=$(yq eval '.experimental.headroomPodImage' "${VALUES_FILE}")


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Need to ensure that we do not push changes to main and feature branches that reference non-existent images.

Create new  `.github/workflows/verify-helm-images.yaml` that runs on PRs, and pushes to main and feature branches, and merge queue. 

Only check Public Images (due to no AWS credentials, does not require approval). 

Private ECR Addon images are verified separately via `Publish Helm` workflow before publishing helm chart, which should be enough.

Successful Run: https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/27537580002/job/81390844046?pr=832

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
