### PR TITLE
Add warnings for main branch helm chart installation deprecation

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -79,6 +79,16 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
+      - name: Mark chart as published via Helm repository
+        # Disables the unsupported-installation warning and tracking label that shows
+        # when installing directly from a GitHub branch.
+        run: |
+          yq -i '.isHelmRepo = true' charts/aws-mountpoint-s3-csi-driver/values.yaml
+          val=$(yq '.isHelmRepo' charts/aws-mountpoint-s3-csi-driver/values.yaml)
+          if [ "$val" != "true" ]; then
+            echo "FATAL: isHelmRepo is '$val', expected 'true'"
+            exit 1
+          fi
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -83,12 +83,8 @@ jobs:
         # Disables the unsupported-installation warning and tracking label that shows
         # when installing directly from a GitHub branch.
         run: |
-          yq -i '.isHelmRepo = true' charts/aws-mountpoint-s3-csi-driver/values.yaml
-          val=$(yq '.isHelmRepo' charts/aws-mountpoint-s3-csi-driver/values.yaml)
-          if [ "$val" != "true" ]; then
-            echo "FATAL: isHelmRepo is '$val', expected 'true'"
-            exit 1
-          fi
+          sed -i 's/^isHelmRepo: false/isHelmRepo: true/' charts/aws-mountpoint-s3-csi-driver/values.yaml
+          grep '^isHelmRepo: true' charts/aws-mountpoint-s3-csi-driver/values.yaml
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The S3 CSI Driver is distributed through the following supported channels:
 
 > [!WARNING]
 > Installing directly from a GitHub branch (`main`, `release-X.Y`, or any other) is not supported. Charts in the GitHub repository may reference unreleased images or contain in-progress changes that are incompatible with published binaries.
+> **After September 1, 2026, charts on the main branch will no longer be installable.** Please migrate to the Helm repository or EKS Addon installation method before this date.
 
 See [Driver Installation](docs/INSTALL.md) for detailed instructions.
 

--- a/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
@@ -2,6 +2,13 @@ Thank you for using Mountpoint for Amazon S3 CSI Driver v{{ .Chart.Version }}.
 
 Learn more about the file system operations Mountpoint supports: https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md
 
+WARNING: You are installing from the a GitHub branch.
+This installation method will stop working after September 1, 2026.
+Please migrate to a supported installation method:
+  - Helm repo: helm repo add aws-mountpoint-s3-csi-driver https://awslabs.github.io/mountpoint-s3-csi-driver
+  - EKS Addon: See https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html
+For more details, see: https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md
+
 {{- if .Release.IsUpgrade }}
 
 While the CSI driver has been upgraded, existing Mountpoint Pods remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted. You can view which pods exist created by older V2 versions of the CSI driver using `kubectl get pods -n mount-s3 --label-columns="s3.csi.aws.com/mounted-by-csi-driver-version"`.

--- a/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
@@ -1,14 +1,15 @@
 Thank you for using Mountpoint for Amazon S3 CSI Driver v{{ .Chart.Version }}.
 
 Learn more about the file system operations Mountpoint supports: https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md
+{{- if and (not .Values.isHelmRepo) (not .Values.isEKSAddon) }}
 
-WARNING: You are installing from the a GitHub branch.
+WARNING: You are installing from a GitHub branch.
 This installation method will stop working after September 1, 2026.
 Please migrate to a supported installation method:
   - Helm repo: helm repo add aws-mountpoint-s3-csi-driver https://awslabs.github.io/mountpoint-s3-csi-driver
   - EKS Addon: See https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html
 For more details, see: https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md
-
+{{- end }}
 {{- if .Release.IsUpgrade }}
 
 While the CSI driver has been upgraded, existing Mountpoint Pods remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted. You can view which pods exist created by older V2 versions of the CSI driver using `kubectl get pods -n mount-s3 --label-columns="s3.csi.aws.com/mounted-by-csi-driver-version"`.

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -14,7 +14,9 @@ spec:
     metadata:
       labels:
         app: s3-csi-node
+        {{- if and (not .Values.isHelmRepo) (not .Values.isEKSAddon) }}
         s3.csi.aws.com/chart-source: "github-main"
+        {{- end }}
         {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 8 }}
         {{- if .Values.node.podLabels }}
         {{- toYaml .Values.node.podLabels | nindent 8 }}

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: s3-csi-node
+        s3.csi.aws.com/chart-source: "github-main"
         {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 8 }}
         {{- if .Values.node.podLabels }}
         {{- toYaml .Values.node.podLabels | nindent 8 }}

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -1,6 +1,12 @@
 # Default values for Mountpoint for Amazon S3 CSI Driver Helm chart.
 # You can customize any values here during installation.
 
+# Automatically set to true when the chart is published to the official Helm repository.
+# Installing directly from a GitHub branch is not supported.
+# Use the Helm repository (https://awslabs.github.io/mountpoint-s3-csi-driver) or EKS Addon instead.
+# See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md for details.
+isHelmRepo: false
+
 # Set to true if running on OpenShift/ROSA.
 # If not set, auto-detects OpenShift where possible.
 isOpenShift: null


### PR DESCRIPTION
## Changes

We don't support main branch helm chart installation method since it is prone to referencing images in our releases that doesn't work with helm charts in main (development) branch. We plan to deprecate this installation method (1, 2026), and we want to warn users ahead of time for them to migrate to support installation methods. 

- Added warnings in README / NOTES.txt, and added a label in node.yaml for node pods installed via main branch helm charts.
- Added gating of NOTES warning / label via isHelmRepo in values.yaml, which is set to true on helm_publish workflow


## Testing

<details>
<summary>Test commands</summary>

```sh
# Main branch charts have label / warning
helm template charts/aws-mountpoint-s3-csi-driver | grep "chart-source"
# output:        s3.csi.aws.com/chart-source: "github-main"
helm install --dry-run=client --generate-name charts/aws-mountpoint-s3-csi-driver | grep "WARNING"
# output: WARNING: You are installing from a GitHub branch.

# sed and grep
sed -i 's/^isHelmRepo: false/isHelmRepo: true/' charts/aws-mountpoint-s3-csi-driver/values.yaml
grep '^isHelmRepo: true' charts/aws-mountpoint-s3-csi-driver/values.yaml
# output: isHelmRepo: true

# Published charts show no warnings / labels
helm template charts/aws-mountpoint-s3-csi-driver | grep -E "chart-source|WARNING"
# output: empty
helm install --dry-run=client --generate-name charts/aws-mountpoint-s3-csi-driver | grep "WARNING"
# output: empty
```

</details>

### Other considerations
- Not added instructions for ArgoCD/FluxCD or other usages to use Helm Repository installation method (e.g. [here](https://fluxcd.io/flux/guides/helmreleases/#helm-repository)) rather than Git Repository installation method (i.e. use our helm repo https://awslabs.github.io/mountpoint-s3-csi-driver link rather than github link), as I haven't confirmed this usage method. 
- We could add `_helpers.tpl` entry if we think `if and (not .Values.isHelmRepo) (not .Values.isEKSAddon)` is too long later
-  yq removes line breaks, so used sed to workaround (unless there are better alternatives?)


### Deprecation code to add

We can add the deprecation change on (or slightly after) September 1, 2026, by 1/ removing deprecation date references and 2/ adding this code to the top of node.yaml: 

```yaml
{{- if and (not .Values.isHelmRepo) (not .Values.isEKSAddon) -}}
{{- fail `

ERROR: This Helm chart cannot be installed directly from the GitHub main branch.

Supported installation methods:
  - Helm repository: helm repo add aws-mountpoint-s3-csi-driver https://awslabs.github.io/mountpoint-s3-csi-driver
  - EKS Addon: https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html

See https://github.com/awslabs/mountpoint-s3-csi-driver#installation for details.
` -}}
{{- end -}}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
