### PR TITLE
Install driver in dedicated namespace for ROSA CI

### DIFF
--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -23,6 +23,7 @@ env:
   TAG_PASSED: "test_passed_${{ inputs.ref }}"
   CLUSTER_TYPE: "openshift"
   CLUSTER_NAME: "s3-csi-${{ inputs.environment }}"
+  DRIVER_NAMESPACE: "s3-csi-driver"
 jobs:
   build:
     runs-on: ubuntu-22.04 # FIXME - https://github.com/actions/runner-images/issues/11471

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -59,6 +59,9 @@ You may deploy the Mountpoint for Amazon S3 CSI Driver via [Amazon EKS managed a
 > [!IMPORTANT]
 > When upgrading the CSI Driver, existing [Mountpoint Pods](ARCHITECTURE.md#the-mounter-component--mountpoint-pod-aws-s3-csi-mounter) remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted.
 
+> [!NOTE]
+> If you install the driver into any namespace other than `kube-system`, you must restrict that namespace to cluster administrators only. Do not grant untrusted users access to the driver namespace.
+
 #### Amazon EKS managed add-on
 
 See [the Amazon EKS guide](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html) for more details on installing the Amazon EKS managed add-on of Mountpoint for Amazon S3 CSI Driver.
@@ -101,6 +104,22 @@ We recommend customers to separate the controller components from the nodes runn
 helm upgrade --install aws-mountpoint-s3-csi-driver \
     --namespace kube-system \
     --set controller.nodeSelector."kubernetes\.io/role"="control-plane" \
+    aws-mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
+```
+
+#### OpenShift / ROSA
+
+On OpenShift and ROSA ([Red Hat OpenShift Service on AWS](https://aws.amazon.com/rosa/)) clusters, the driver must be installed in a dedicated namespace rather than `kube-system`. This is because OpenShift's [managed-cluster-validating-webhooks](https://github.com/openshift/managed-cluster-validating-webhooks) block ServiceAccount creation in managed namespaces.
+
+> [!IMPORTANT]
+> The driver namespace must be restricted to cluster admins only. Do not grant untrusted users access to the driver namespace.
+
+```sh
+oc create namespace s3-csi-driver
+oc adm policy add-scc-to-user privileged -z s3-csi-driver-sa -n s3-csi-driver
+
+helm upgrade --install aws-mountpoint-s3-csi-driver \
+    --namespace s3-csi-driver \
     aws-mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
 ```
 

--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -29,6 +29,7 @@ func init() {
 	flag.StringVar(&ClusterName, "cluster-name", "", "name of the cluster")
 	flag.StringVar(&ClusterType, "cluster-type", "eksctl", "type of cluster (eksctl or openshift)")
 	flag.StringVar(&BucketPrefix, "bucket-prefix", "local", "prefix for temporary buckets")
+	flag.StringVar(&DriverNamespace, "driver-namespace", "kube-system", "namespace where the CSI driver is installed")
 	flag.BoolVar(&Performance, "performance", false, "run performance tests")
 	flag.BoolVar(&UpgradeTests, "run-upgrade-tests", false, "run upgrade tests")
 	flag.BoolVar(&IMDSAvailable, "imds-available", false, "indicates whether instance metadata service is available")
@@ -38,6 +39,7 @@ func init() {
 	custom_testsuites.DefaultRegion = BucketRegion
 	custom_testsuites.ClusterName = ClusterName
 	custom_testsuites.ClusterType = ClusterType
+	custom_testsuites.DriverNamespace = DriverNamespace
 	custom_testsuites.IMDSAvailable = IMDSAvailable
 }
 

--- a/tests/e2e-kubernetes/rosa/main.tf
+++ b/tests/e2e-kubernetes/rosa/main.tf
@@ -99,7 +99,7 @@ resource "aws_iam_role" "csi_driver_irsa" {
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
           StringEquals = {
-            "${replace(module.hcp.oidc_endpoint_url, "https://", "")}:sub" = "system:serviceaccount:kube-system:s3-csi-driver-sa"
+            "${replace(module.hcp.oidc_endpoint_url, "https://", "")}:sub" = "system:serviceaccount:s3-csi-driver:s3-csi-driver-sa"
           }
         }
       }

--- a/tests/e2e-kubernetes/scripts/helm.sh
+++ b/tests/e2e-kubernetes/scripts/helm.sh
@@ -22,16 +22,7 @@ function helm_uninstall_driver() {
   CLUSTER_TYPE=${5}
 
   if driver_installed ${HELM_BIN} ${RELEASE_NAME} ${KUBECONFIG}; then
-    if [[ "${CLUSTER_TYPE}" == "openshift" ]]; then
-      echo "OpenShift cluster detected - using graceful Helm uninstall as ClusterRoleBindings and ServiceAccounts cannot be deleted due to admission webhooks."
-      set +e
-      $HELM_BIN uninstall $RELEASE_NAME --namespace $DRIVER_NAMESPACE --kubeconfig $KUBECONFIG
-      set -e
-      $KUBECTL_BIN delete secret --namespace $DRIVER_NAMESPACE sh.helm.release.v1.${RELEASE_NAME}.v1 --ignore-not-found --kubeconfig $KUBECONFIG
-    else
-      $HELM_BIN uninstall $RELEASE_NAME --namespace $DRIVER_NAMESPACE --kubeconfig $KUBECONFIG
-    fi
-
+    $HELM_BIN uninstall $RELEASE_NAME --namespace $DRIVER_NAMESPACE --kubeconfig $KUBECONFIG
     $KUBECTL_BIN wait --for=delete pod --selector="app=s3-csi-node" -n $DRIVER_NAMESPACE --timeout=60s --kubeconfig $KUBECONFIG
   else
     echo "driver does not seem to be installed"

--- a/tests/e2e-kubernetes/scripts/helm.sh
+++ b/tests/e2e-kubernetes/scripts/helm.sh
@@ -25,14 +25,14 @@ function helm_uninstall_driver() {
     if [[ "${CLUSTER_TYPE}" == "openshift" ]]; then
       echo "OpenShift cluster detected - using graceful Helm uninstall as ClusterRoleBindings and ServiceAccounts cannot be deleted due to admission webhooks."
       set +e
-      $HELM_BIN uninstall $RELEASE_NAME --namespace kube-system --kubeconfig $KUBECONFIG
+      $HELM_BIN uninstall $RELEASE_NAME --namespace $DRIVER_NAMESPACE --kubeconfig $KUBECONFIG
       set -e
-      $KUBECTL_BIN delete secret --namespace kube-system sh.helm.release.v1.${RELEASE_NAME}.v1 --ignore-not-found --kubeconfig $KUBECONFIG
+      $KUBECTL_BIN delete secret --namespace $DRIVER_NAMESPACE sh.helm.release.v1.${RELEASE_NAME}.v1 --ignore-not-found --kubeconfig $KUBECONFIG
     else
-      $HELM_BIN uninstall $RELEASE_NAME --namespace kube-system --kubeconfig $KUBECONFIG
+      $HELM_BIN uninstall $RELEASE_NAME --namespace $DRIVER_NAMESPACE --kubeconfig $KUBECONFIG
     fi
 
-    $KUBECTL_BIN wait --for=delete pod --selector="app=s3-csi-node" -n kube-system --timeout=60s --kubeconfig $KUBECONFIG
+    $KUBECTL_BIN wait --for=delete pod --selector="app=s3-csi-node" -n $DRIVER_NAMESPACE --timeout=60s --kubeconfig $KUBECONFIG
   else
     echo "driver does not seem to be installed"
   fi
@@ -65,7 +65,15 @@ function helm_install_driver() {
     IRSA_FLAG=""
   fi
 
-  $HELM_BIN upgrade --install $RELEASE_NAME --namespace kube-system ./charts/aws-mountpoint-s3-csi-driver --values \
+  # OpenShift blocks SA creation in kube-system via admission webhook.
+  # So we install into a dedicated namespace and grant privileged SCC.
+  # https://github.com/openshift/managed-cluster-validating-webhooks/commit/e270e2b5d61009ff595c2443732c126fdd04fa2a
+  if [[ "${CLUSTER_TYPE}" == "openshift" ]]; then
+    $KUBECTL_BIN create namespace $DRIVER_NAMESPACE --kubeconfig $KUBECONFIG 2>/dev/null || true
+    oc adm policy add-scc-to-user privileged -z s3-csi-driver-sa -n $DRIVER_NAMESPACE
+  fi
+
+  $HELM_BIN upgrade --install $RELEASE_NAME --namespace $DRIVER_NAMESPACE ./charts/aws-mountpoint-s3-csi-driver --values \
     ./charts/aws-mountpoint-s3-csi-driver/values.yaml \
     --set image.repository=${REPOSITORY} \
     --set image.tag=${TAG} \
@@ -74,9 +82,9 @@ function helm_install_driver() {
     --set experimental.reserveHeadroomForMountpointPods=true \
     ${IRSA_FLAG} \
     --kubeconfig ${KUBECONFIG}
-  $KUBECTL_BIN rollout status daemonset s3-csi-node -n kube-system --timeout=60s --kubeconfig $KUBECONFIG
+  $KUBECTL_BIN rollout status daemonset s3-csi-node -n $DRIVER_NAMESPACE --timeout=60s --kubeconfig $KUBECONFIG
   $KUBECTL_BIN get pods -A --kubeconfig $KUBECONFIG
-  echo "s3-csi-node-image: $($KUBECTL_BIN get daemonset s3-csi-node -n kube-system -o jsonpath="{$.spec.template.spec.containers[:1].image}" --kubeconfig $KUBECONFIG)"
+  echo "s3-csi-node-image: $($KUBECTL_BIN get daemonset s3-csi-node -n $DRIVER_NAMESPACE -o jsonpath="{$.spec.template.spec.containers[:1].image}" --kubeconfig $KUBECONFIG)"
 
   helm_validate_driver \
     "$HELM_BIN" \
@@ -99,7 +107,7 @@ function helm_validate_driver() {
   echo "Validating $RELEASE_NAME on the server side..."
 
   # Get all installed manifests and validate them on the server side
-  $HELM_BIN get manifest --namespace kube-system --kubeconfig ${KUBECONFIG} $RELEASE_NAME | \
+  $HELM_BIN get manifest --namespace $DRIVER_NAMESPACE --kubeconfig ${KUBECONFIG} $RELEASE_NAME | \
     $KUBECTL_BIN replace --kubeconfig $KUBECONFIG --dry-run=server --validate=strict --warnings-as-errors -f -
 }
 

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -180,7 +180,7 @@ elif [[ "${ACTION}" == "run_tests" ]]; then
 elif [[ "${ACTION}" == "run_upgrade_tests" ]]; then
   set +e
   pushd tests/e2e-kubernetes
-  KUBECONFIG=${KUBECONFIG} ginkgo -vv --github-output -timeout 10h -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=${IMDS_AVAILABLE} --cluster-name=${CLUSTER_NAME} --cluster-type=${CLUSTER_TYPE} --run-upgrade-tests
+  KUBECONFIG=${KUBECONFIG} ginkgo -vv --github-output -timeout 10h -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=${IMDS_AVAILABLE} --cluster-name=${CLUSTER_NAME} --cluster-type=${CLUSTER_TYPE}  --driver-namespace=${DRIVER_NAMESPACE} --run-upgrade-tests
   EXIT_CODE=$?
   print_cluster_info
   exit $EXIT_CODE

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -28,6 +28,7 @@ EKSCTL_BIN=${BIN_DIR}/eksctl
 KUBECTL_BIN=${KUBECTL_INSTALL_PATH}/kubectl
 
 CLUSTER_TYPE=${CLUSTER_TYPE:-eksctl}
+DRIVER_NAMESPACE=${DRIVER_NAMESPACE:-kube-system}
 IMDS_AVAILABLE=${IMDS_AVAILABLE:-true}
 ARCH=${ARCH:-x86}
 AMI_FAMILY=${AMI_FAMILY:-AmazonLinux2}
@@ -86,7 +87,7 @@ function kubectl_install() {
 }
 
 function print_cluster_info() {
-  $KUBECTL_BIN logs -l app=s3-csi-node -n kube-system --kubeconfig ${KUBECONFIG}
+  $KUBECTL_BIN logs -l app=s3-csi-node -n $DRIVER_NAMESPACE --kubeconfig ${KUBECONFIG}
   $KUBECTL_BIN version --kubeconfig ${KUBECONFIG}
   $KUBECTL_BIN get nodes -o wide --kubeconfig ${KUBECONFIG}
 }
@@ -148,7 +149,7 @@ function e2e_cleanup() {
 }
 
 function print_cluster_info() {
-  $KUBECTL_BIN logs -l app=s3-csi-node -n kube-system --kubeconfig ${KUBECONFIG}
+  $KUBECTL_BIN logs -l app=s3-csi-node -n $DRIVER_NAMESPACE --kubeconfig ${KUBECONFIG}
   $KUBECTL_BIN version --kubeconfig ${KUBECONFIG}
   $KUBECTL_BIN get nodes -o wide --kubeconfig ${KUBECONFIG}
 }

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -173,7 +173,7 @@ elif [[ "${ACTION}" == "install_driver" ]]; then
 elif [[ "${ACTION}" == "run_tests" ]]; then
   set +e
   pushd tests/e2e-kubernetes
-  KUBECONFIG=${KUBECONFIG} ginkgo -p -vv --github-output -timeout 60m -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=${IMDS_AVAILABLE} --cluster-name=${CLUSTER_NAME} --cluster-type=${CLUSTER_TYPE}
+  KUBECONFIG=${KUBECONFIG} ginkgo -p -vv --github-output -timeout 60m -- --bucket-region=${REGION} --commit-id=${TAG} --bucket-prefix=${CLUSTER_NAME} --imds-available=${IMDS_AVAILABLE} --cluster-name=${CLUSTER_NAME} --cluster-type=${CLUSTER_TYPE} --driver-namespace=${DRIVER_NAMESPACE}
   EXIT_CODE=$?
   print_cluster_info
   exit $EXIT_CODE

--- a/tests/e2e-kubernetes/testdriver.go
+++ b/tests/e2e-kubernetes/testdriver.go
@@ -15,14 +15,15 @@ import (
 )
 
 var (
-	CommitId      string
-	BucketRegion  string // assumed to be the same as k8s cluster's region
-	ClusterName   string
-	ClusterType   string
-	BucketPrefix  string
-	Performance   bool
-	UpgradeTests  bool
-	IMDSAvailable bool
+	CommitId        string
+	BucketRegion    string // assumed to be the same as k8s cluster's region
+	ClusterName     string
+	ClusterType     string
+	BucketPrefix    string
+	DriverNamespace string
+	Performance     bool
+	UpgradeTests    bool
+	IMDSAvailable   bool
 )
 
 type s3Driver struct {

--- a/tests/e2e-kubernetes/testsuites/cache.go
+++ b/tests/e2e-kubernetes/testsuites/cache.go
@@ -424,7 +424,7 @@ func createEBSCacheSC(ctx context.Context, f *framework.Framework) string {
 
 // ebsCSIDriverDaemonSet returns the DaemonSet of EBS CSI Driver if its installed in the cluster.
 func ebsCSIDriverDaemonSet(ctx context.Context, f *framework.Framework) *appsv1.DaemonSet {
-	client := f.ClientSet.AppsV1().DaemonSets(csiDriverDaemonSetNamespace)
+	client := f.ClientSet.AppsV1().DaemonSets(DriverNamespace)
 	ds, err := client.Get(ctx, "ebs-csi-node", metav1.GetOptions{})
 	if err != nil {
 		return nil

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -1246,7 +1246,7 @@ func waitUntilRoleIsAssumableWithEKS(ctx context.Context, f *framework.Framework
 func createCredentialSecret(ctx context.Context, f *framework.Framework, credentials *ststypes.Credentials) (*v1.Secret, func(context.Context) error) {
 	framework.Logf("Creating Kubernetes Secret for AWS Credentials")
 
-	client := f.ClientSet.CoreV1().Secrets(csiDriverDaemonSetNamespace)
+	client := f.ClientSet.CoreV1().Secrets(DriverNamespace)
 
 	secret, err := client.Create(ctx, &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1270,7 +1270,7 @@ func createCredentialSecret(ctx context.Context, f *framework.Framework, credent
 
 func deleteCredentialSecret(ctx context.Context, f *framework.Framework) error {
 	framework.Logf("Deleting Kubernetes Secret")
-	client := f.ClientSet.CoreV1().Secrets(csiDriverDaemonSetNamespace)
+	client := f.ClientSet.CoreV1().Secrets(DriverNamespace)
 
 	err := client.Delete(ctx, credentialSecretName, metav1.DeleteOptions{})
 	if err != nil {
@@ -1407,7 +1407,7 @@ func oidcProviderForCluster(ctx context.Context, f *framework.Framework) string 
 // eksPodIdentityAgentDaemonSetForCluster tries to find configured EKS Pod Identity Agent for the cluster we're testing against.
 func eksPodIdentityAgentDaemonSetForCluster(ctx context.Context, f *framework.Framework) *appsv1.DaemonSet {
 	eksPodIdentityAgentDaemonSetName := "eks-pod-identity-agent"
-	client := f.ClientSet.AppsV1().DaemonSets(csiDriverDaemonSetNamespace)
+	client := f.ClientSet.AppsV1().DaemonSets(DriverNamespace)
 	ds, err := client.Get(ctx, eksPodIdentityAgentDaemonSetName, metav1.GetOptions{})
 	if err != nil {
 		return nil

--- a/tests/e2e-kubernetes/testsuites/taint_removal.go
+++ b/tests/e2e-kubernetes/testsuites/taint_removal.go
@@ -138,7 +138,7 @@ func (t *s3CSITaintRemovalTestSuite) DefineTests(driver storageframework.TestDri
 // getCSIDriverNode returns a node where the CSI driver is running
 func getCSIDriverNode(ctx context.Context, f *framework.Framework) *v1.Node {
 	ds := csiDriverDaemonSet(ctx, f)
-	pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+	pods, err := f.ClientSet.CoreV1().Pods(DriverNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: metav1.FormatLabelSelector(ds.Spec.Selector),
 	})
 	framework.ExpectNoError(err)

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -70,7 +70,6 @@ const helmRepo = "https://awslabs.github.io/mountpoint-s3-csi-driver"
 const helmChartSource = "../../charts/aws-mountpoint-s3-csi-driver"
 const helmChartName = "aws-mountpoint-s3-csi-driver"
 const helmReleaseName = "mountpoint-s3-csi-driver"
-const helmReleaseNamespace = "kube-system"
 
 var helmChartPreviousVersion = os.Getenv("MOUNTPOINT_CSI_DRIVER_PREVIOUS_VERSION")
 var helmChartNewVersion = os.Getenv("MOUNTPOINT_CSI_DRIVER_NEW_VERSION")
@@ -599,7 +598,7 @@ func pullCSIDriver(settings *cli.EnvSettings, cfg *action.Configuration, version
 func installCSIDriver(cfg *action.Configuration, version string, chartPath string) {
 	installClient := action.NewInstall(cfg)
 	installClient.ReleaseName = helmReleaseName
-	installClient.Namespace = helmReleaseNamespace
+	installClient.Namespace = DriverNamespace
 	installClient.Version = version
 	installClient.Wait = true
 	installClient.Timeout = 30 * time.Second
@@ -642,7 +641,7 @@ func monitorWorkloadsForDuration(
 // upgradeCSIDriver upgrades the CSI Driver's Helm chart to the new version.
 func upgradeCSIDriver(cfg *action.Configuration, f *framework.Framework, version string, chartPath string) {
 	upgradeClient := action.NewUpgrade(cfg)
-	upgradeClient.Namespace = helmReleaseNamespace
+	upgradeClient.Namespace = DriverNamespace
 	upgradeClient.Version = version
 	upgradeClient.Wait = true
 	upgradeClient.Timeout = 30 * time.Second
@@ -699,7 +698,7 @@ func initHelmClient() (*cli.EnvSettings, *action.Configuration) {
 	actionConfig := new(action.Configuration)
 	err := actionConfig.Init(
 		settings.RESTClientGetter(),
-		helmReleaseNamespace,
+		DriverNamespace,
 		os.Getenv("HELM_DRIVER"),
 		logger.Printf)
 	framework.ExpectNoError(err)

--- a/tests/e2e-kubernetes/testsuites/util.go
+++ b/tests/e2e-kubernetes/testsuites/util.go
@@ -39,14 +39,7 @@ const NamespacePrefix = "aws-s3-csi-e2e-"
 
 const csiDriverDaemonSetName = "s3-csi-node"
 
-var csiDriverDaemonSetNamespace = getDriverNamespace()
-
-func getDriverNamespace() string {
-	if namespace := os.Getenv("DRIVER_NAMESPACE"); namespace != "" {
-		return namespace
-	}
-	return "kube-system"
-}
+var DriverNamespace string
 
 // genBinDataFromSeed generate binData with random seed
 func genBinDataFromSeed(len int, seed int64) []byte {
@@ -247,7 +240,7 @@ func copySmallFileToPod(ctx context.Context, f *framework.Framework, pod *v1.Pod
 func killCSIDriverPods(ctx context.Context, f *framework.Framework) {
 	framework.Logf("Killing CSI Driver Pods")
 	ds := csiDriverDaemonSet(ctx, f)
-	client := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace)
+	client := f.ClientSet.CoreV1().Pods(DriverNamespace)
 
 	pods, err := client.List(ctx, metav1.ListOptions{
 		LabelSelector: metav1.FormatLabelSelector(ds.Spec.Selector),
@@ -281,7 +274,7 @@ func deletePodIdentityAssociations(ctx context.Context, sa *v1.ServiceAccount) {
 
 func csiDriverPod(ctx context.Context, f *framework.Framework) *v1.Pod {
 	ds := csiDriverDaemonSet(ctx, f)
-	client := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace)
+	client := f.ClientSet.CoreV1().Pods(DriverNamespace)
 
 	pods, err := client.List(ctx, metav1.ListOptions{
 		LabelSelector: metav1.FormatLabelSelector(ds.Spec.Selector),
@@ -293,7 +286,7 @@ func csiDriverPod(ctx context.Context, f *framework.Framework) *v1.Pod {
 }
 
 func csiDriverDaemonSet(ctx context.Context, f *framework.Framework) *appsv1.DaemonSet {
-	client := f.ClientSet.AppsV1().DaemonSets(csiDriverDaemonSetNamespace)
+	client := f.ClientSet.AppsV1().DaemonSets(DriverNamespace)
 	ds, err := client.Get(ctx, csiDriverDaemonSetName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	gomega.Expect(ds).ToNot(gomega.BeNil())
@@ -303,7 +296,7 @@ func csiDriverDaemonSet(ctx context.Context, f *framework.Framework) *appsv1.Dae
 func csiDriverServiceAccount(ctx context.Context, f *framework.Framework) *v1.ServiceAccount {
 	ds := csiDriverDaemonSet(ctx, f)
 
-	client := f.ClientSet.CoreV1().ServiceAccounts(csiDriverDaemonSetNamespace)
+	client := f.ClientSet.CoreV1().ServiceAccounts(DriverNamespace)
 	sa, err := client.Get(ctx, ds.Spec.Template.Spec.ServiceAccountName, metav1.GetOptions{})
 
 	framework.ExpectNoError(err)

--- a/tests/e2e-kubernetes/testsuites/util.go
+++ b/tests/e2e-kubernetes/testsuites/util.go
@@ -37,10 +37,16 @@ type jsonMap = map[string]any
 
 const NamespacePrefix = "aws-s3-csi-e2e-"
 
-const (
-	csiDriverDaemonSetName      = "s3-csi-node"
-	csiDriverDaemonSetNamespace = "kube-system"
-)
+const csiDriverDaemonSetName = "s3-csi-node"
+
+var csiDriverDaemonSetNamespace = getDriverNamespace()
+
+func getDriverNamespace() string {
+	if namespace := os.Getenv("DRIVER_NAMESPACE"); namespace != "" {
+		return namespace
+	}
+	return "kube-system"
+}
 
 // genBinDataFromSeed generate binData with random seed
 func genBinDataFromSeed(len int, seed int64) []byte {


### PR DESCRIPTION
## Changes

OpenShift now [blocks ServiceAccount creation in kube-system via an admission webhook](https://github.com/openshift/managed-cluster-validating-webhooks/commit/e270e2b5d61009ff595c2443732c126fdd04fa2a) which [broke our ROSA CI](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/27537579591/job/81399724260?pr=832). 

- Use the driver in s3-csi-driver namespace on ROSA CI
- Create the namespace and grant privileged SCC to the driver service account before helm install
- Updated csi_driver_irsa trust policy to use s3-csi-driver namespace (hardcode only though).
- Added docs for guidance for ROSA users (and a warning to install into namespace restricted cluster admins only)

## Testing

I used awslabs branch for this PR to invoke trusted workflow - tests are passing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
