### PR TITLE
Add Kubernetes v1.36.1 to CI

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -13,7 +13,7 @@ matrix:
       "Ubuntu2404",
     ]
   kubernetes-version:
-    ["1.30.4", "1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0"]
+    ["1.30.4", "1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0", "1.36.1"]
   include:
     # Enable enforcing mode for SELinux in AL2023, it's easier to list it in "include"
     # field rather than trying to exclude all other variants.
@@ -32,6 +32,10 @@ matrix:
     - cluster-type: "eksctl"
       family: "AmazonLinux2"
       kubernetes-version: "1.35.0"
+    # AL2 is not supported by Kubernetes 1.36.
+    - cluster-type: "eksctl"
+      family: "AmazonLinux2"
+      kubernetes-version: "1.36.1"
     # Ubuntu2204 is only supported on EKS >= 1.29 && EKS < 1.33.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
     - cluster-type: "eksctl"
@@ -43,6 +47,9 @@ matrix:
     - cluster-type: "eksctl"
       family: "Ubuntu2204"
       kubernetes-version: "1.35.0"
+    - cluster-type: "eksctl"
+      family: "Ubuntu2204"
+      kubernetes-version: "1.36.1"
     # Ubuntu2404 is only supported on EKS >= 1.31.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
     - cluster-type: "eksctl"


### PR DESCRIPTION
### Changes

Adds EKS 1.36 to CI for e2e tests. 

I'm aware there's [k8s 1.36.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md), but `aws eks describe-cluster-versions` shows `"kubernetesPatchVersion": "1.36.1"`. https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html also shows newest EKS version as 1.36.1. 


### Ubuntu 24.04 EKS 1.36 (x86/ARM) failure: SSM parameters reference unavailable AMI

```bash
2026-06-23 09:26:12 [ℹ]  nodegroup "ng-ca480b02" will use "ami-0f76a3cd85d0989a3" [Ubuntu2404/1.36]
Error: unable to find AMI ami-0f76a3cd85d0989a3

# Checked this doesn't exist
aws ec2 describe-images --image-ids ami-0f76a3cd85d0989a3 --region us-east-1
{
    "Images": []
}
```


With AI help found https://github.com/eksctl-io/eksctl/blob/main/pkg/ami/ssm_resolver.go which has `fmt.Sprint("/aws/service/canonical/ubuntu/", eksProduct, "/", ubuntuReleaseName(imageFamily), "/", version, "/stable/current/", ubuntuArchName(instanceType), "/hvm/ebs-gp3/ami-id")`, and confirmed SSM references this AMI but seems to not exist. 
```
aws ssm get-parameter \
    --name /aws/service/canonical/ubuntu/eks/24.04/1.36/stable/current/arm64/hvm/ebs-gp3/ami-id \
    --region us-east-1
{
    "Parameter": {
        "Name": "/aws/service/canonical/ubuntu/eks/24.04/1.36/stable/current/arm64/hvm/ebs-gp3/ami-id",
        "Type": "String",
        "Value": "ami-0f76a3cd85d0989a3",
        "Version": 1,
        "LastModifiedDate": "2026-06-15T13:45:48.270000+00:00",
        "ARN": "arn:aws:ssm:us-east-1::parameter/aws/service/canonical/ubuntu/eks/24.04/1.36/stable/current/arm64/hvm/ebs-gp3/ami-id",
        "DataType": "aws:ec2:image"
    }
}
```

Reached out internally to check what happened - and the SSM parameter problem is now resolved. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
