### PR TITLE
Allow fork PR checkouts

### DIFF
--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          # Allow fork PR checkouts since we gate deployments and the code only has access to ephemeral test cluster
           allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -73,6 +74,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          # Allow fork PR checkouts since we gate deployments and the code only has access to ephemeral test cluster
           allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -72,6 +73,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -51,6 +51,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          # Allow fork PR checkouts since we gate deployments and the code only has access to ephemeral test cluster
           allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -101,6 +102,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          # Allow fork PR checkouts since we gate deployments and the code only has access to ephemeral test cluster
           allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -51,6 +51,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -100,6 +101,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
### Changes

We bumped actions/checkout@v7 in https://github.com/awslabs/mountpoint-s3-csi-driver/pull/836 which block checking out fork pr for pull_request_target and workflow_run.

We allow fork PR checkouts in this case since we gate deployments and the code only has access to ephemeral test cluster. Added in 4 locations where workflows access fork PR code. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
