### PR TITLE
Force image rebuild in mp-dev.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ REGISTRY?=""
 IMAGE_NAME?=""
 IMAGE?=$(REGISTRY)/${IMAGE_NAME}
 TAG?=$(GIT_COMMIT)
+FORCE_BUILD?=false
 
 DOCKERFILE?="Dockerfile"
 
@@ -107,7 +108,7 @@ sub-image-%:
 .PHONY: image
 image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION):
-	@if [ "$(OUTPUT_TYPE)" = "registry" ] && docker manifest inspect $(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) > /dev/null 2>&1; then \
+	@if [ "$(FORCE_BUILD)" != "true" ] && [ "$(OUTPUT_TYPE)" = "registry" ] && docker manifest inspect $(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) > /dev/null 2>&1; then \
 		echo "Image $(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) already exists in registry, skipping build"; \
 	else \
 		DOCKER_BUILDKIT=1 docker buildx build \

--- a/dev/mp-dev.sh
+++ b/dev/mp-dev.sh
@@ -176,6 +176,7 @@ deploy_containers() {
     ALL_ARCH_linux="amd64" \
     TAG="latest" \
     DOCKERFILE="${dockerfile}" \
+    FORCE_BUILD=true \
       make login_registry all-push
 
     # Restart the node and controller pods


### PR DESCRIPTION
### Description

Makefile registry-exists check skips build if image tag already exists (#812), which works perfectly for our CI, but mp-dev.sh uses `TAG="latest"` so would silently skip builds. Added `FORCE_BUILD` to force builds for mp-dev.sh (Now skips build if `FORCE_BUILD` not true && the other 2 original conditions).

(Please do let me know if there are better approaches / ideas to address this issue that works well with the skip build feature in Makefile).

### Testing

`./dev/mp-dev.sh deploy` builds images in consecutive runs with this change. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
