### PR TITLE
Keep S3 Pod Attachments whilst pods are running and terminating

### DIFF
--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -298,6 +298,10 @@ type workloadVolume struct {
 // the Mountpoint Pod will be scheduled for termination as well. This is because if `workloadPod` never transition into its `Running` state,
 // the Mountpoint Pod might never got a successful mount operation, and thus it might never get unmount operation to cleanly exit
 // and might hang there until it reaches its timeout. We just terminate it in this case to prevent unnecessary waits.
+//
+// If `workloadPod` is `Running` and scheduled for termination (i.e., `DeletionTimestamp` is non-nil during graceful shutdown),
+// it is still treated as active. The pod may still be accessing the S3 volume during its termination grace period
+// (e.g., if it ignores SIGTERM), so the Mountpoint Pod and S3PodAttachment must remain until the pod actually exits.
 func (r *Reconciler) spawnOrDeleteMountpointPodIfNeeded(
 	ctx context.Context,
 	workloadPod *corev1.Pod,
@@ -1108,12 +1112,11 @@ func extractCSISpecFromPV(pv *corev1.PersistentVolume) *corev1.CSIPersistentVolu
 	return csi
 }
 
-// isPodActive returns whether given the Pod is active and not in the process of termination.
-// Copied from https://github.com/kubernetes/kubernetes/blob/8770bd58d04555303a3a15b30c245a58723d0f4a/pkg/controller/controller_utils.go#L1009-L1013.
+// isPodActive returns whether the given Pod is active.
+// A pod is active if it is running (regardless of terminating status, to allow shut-downs
+// which access the volume), or if it is pending and not terminating.
 func isPodActive(p *corev1.Pod) bool {
-	return corev1.PodSucceeded != p.Status.Phase &&
-		corev1.PodFailed != p.Status.Phase &&
-		p.DeletionTimestamp == nil
+	return isPodRunning(p) || (p.Status.Phase == corev1.PodPending && p.DeletionTimestamp == nil)
 }
 
 // isPodTerminating returns whether the given Pod is terminating.

--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler_test.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler_test.go
@@ -1,0 +1,42 @@
+package csicontroller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestIsPodActive(t *testing.T) {
+	now := metav1.Now()
+	isDeleting := &now
+	var noDeleting *metav1.Time
+
+	tests := []struct {
+		name              string
+		phase             corev1.PodPhase
+		deletionTimestamp *metav1.Time
+		expect            bool
+	}{
+		{"Pending", corev1.PodPending, noDeleting, true},
+		{"Pending + terminating", corev1.PodPending, isDeleting, false},
+		{"Running", corev1.PodRunning, noDeleting, true},
+		{"Running + terminating", corev1.PodRunning, isDeleting, true},
+		{"Succeeded", corev1.PodSucceeded, noDeleting, false},
+		{"Succeeded + terminating", corev1.PodSucceeded, isDeleting, false},
+		{"Failed", corev1.PodFailed, noDeleting, false},
+		{"Failed + terminating", corev1.PodFailed, isDeleting, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: tt.deletionTimestamp},
+				Status:     corev1.PodStatus{Phase: tt.phase},
+			}
+			assert.Equals(t, tt.expect, isPodActive(pod))
+		})
+	}
+}

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -957,6 +957,30 @@ var _ = Describe("Mountpoint Controller", func() {
 			waitForObjectToDisappear(pod.Pod)
 			waitForObjectToDisappear(s3pa)
 		})
+
+		It("should keep S3 Pod Attachment while workload pod is terminating but still running", func() {
+			vol := createVolume()
+			vol.bind()
+
+			gracePeriod := int64(300)
+			pod := createPod(withPVC(vol.pvc), func(p *corev1.Pod) {
+				p.Spec.TerminationGracePeriodSeconds = &gracePeriod
+			})
+			pod.schedule(testNode)
+
+			// Pod gets a Mountpoint Pod and transitions to Running
+			s3pa, _ := waitAndVerifyS3PodAttachmentAndMountpointPod(testNode, vol, pod)
+			pod.running()
+
+			// Pod is deleted but ignores SIGTERM — still Running with DeletionTimestamp set
+			pod.terminate()
+
+			// S3PA should persist while the pod is still running during graceful termination
+			Consistently(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(s3pa), s3pa)).To(Succeed())
+				g.Expect(findMountpointPodNameForWorkload(s3pa, string(pod.UID))).ToNot(BeEmpty())
+			}, defaultWaitTimeout, defaultWaitRetryPeriod).Should(Succeed())
+		})
 	})
 
 	Context("Duplicate S3PodAttachments recovery", func() {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

When a workload pod is terminating after previously running, keep S3 Pod Attachments associated until the pod terminates.

Ran a manual test and saw that with a grace period, the S3PA stays around until force deletion, where it lasts another ~2 minutes until the StaleAttachmentCleaner kicks in

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
