### PR TITLE
Add ExpectNoError to ExecInPod calls

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -13,7 +13,7 @@ matrix:
       "Ubuntu2404",
     ]
   kubernetes-version:
-    ["1.30.4", "1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0"]
+    ["1.30.4", "1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0", "1.36.1"]
   include:
     # Enable enforcing mode for SELinux in AL2023, it's easier to list it in "include"
     # field rather than trying to exclude all other variants.
@@ -32,6 +32,10 @@ matrix:
     - cluster-type: "eksctl"
       family: "AmazonLinux2"
       kubernetes-version: "1.35.0"
+    # AL2 is not supported by Kubernetes 1.36.
+    - cluster-type: "eksctl"
+      family: "AmazonLinux2"
+      kubernetes-version: "1.36.1"
     # Ubuntu2204 is only supported on EKS >= 1.29 && EKS < 1.33.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
     - cluster-type: "eksctl"
@@ -43,6 +47,9 @@ matrix:
     - cluster-type: "eksctl"
       family: "Ubuntu2204"
       kubernetes-version: "1.35.0"
+    - cluster-type: "eksctl"
+      family: "Ubuntu2204"
+      kubernetes-version: "1.36.1"
     # Ubuntu2404 is only supported on EKS >= 1.31.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
     - cluster-type: "eksctl"

--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -6,10 +6,8 @@ matrix:
   arch: ["x86", "arm"]
   family:
     [
-      "AmazonLinux2",
       "AmazonLinux2023",
       "Bottlerocket",
-      "Ubuntu2204",
       "Ubuntu2404",
     ]
   kubernetes-version:
@@ -20,38 +18,14 @@ matrix:
     - family: "AmazonLinux2023"
       selinux-mode: "enforcing"
   exclude:
-    # AL2 is not supported by Kubernetes 1.33.
-    - cluster-type: "eksctl"
-      family: "AmazonLinux2"
-      kubernetes-version: "1.33.2"
-    # AL2 is not supported by Kubernetes 1.34.
-    - cluster-type: "eksctl"
-      family: "AmazonLinux2"
-      kubernetes-version: "1.34.1"
-    # AL2 is not supported by Kubernetes 1.35.
-    - cluster-type: "eksctl"
-      family: "AmazonLinux2"
-      kubernetes-version: "1.35.0"
-    # AL2 is not supported by Kubernetes 1.36.
-    - cluster-type: "eksctl"
-      family: "AmazonLinux2"
-      kubernetes-version: "1.36.1"
-    # Ubuntu2204 is only supported on EKS >= 1.29 && EKS < 1.33.
-    # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
-    - cluster-type: "eksctl"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.33.2"
-    - cluster-type: "eksctl"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.34.1"
-    - cluster-type: "eksctl"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.35.0"
-    - cluster-type: "eksctl"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.36.1"
-    # Ubuntu2404 is only supported on EKS >= 1.31.
+    # Ubuntu2404 is only supported on EKS >= 1.33.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
     - cluster-type: "eksctl"
       family: "Ubuntu2404"
       kubernetes-version: "1.30.4"
+    - cluster-type: "eksctl"
+      family: "Ubuntu2404"
+      kubernetes-version: "1.31.0"
+    - cluster-type: "eksctl"
+      family: "Ubuntu2404"
+      kubernetes-version: "1.32.1"

--- a/.github/workflows/build_matrix.yaml
+++ b/.github/workflows/build_matrix.yaml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       matrix: ${{ steps.parse_yaml.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Parse matrix.yaml file
         id: parse_yaml
         run: |

--- a/.github/workflows/cleanup-old-buckets.yaml
+++ b/.github/workflows/cleanup-old-buckets.yaml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       ENVTEST_K8S_VERSION: "${K8S_VERSION%.*}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/delete-cluster.yaml
+++ b/.github/workflows/delete-cluster.yaml
@@ -44,7 +44,7 @@ jobs:
       SELINUX_MODE: "${{ matrix.selinux-mode }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           persist-credentials: false

--- a/.github/workflows/delete-rosa-cluster.yaml
+++ b/.github/workflows/delete-rosa-cluster.yaml
@@ -23,7 +23,7 @@ jobs:
       AWS_REGION: "${{ vars.AWS_REGION }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           persist-credentials: false

--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -36,6 +36,8 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          # Allow fork PR checkouts since we gate deployments and the code only has access to ephemeral test cluster
+          allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -72,6 +74,8 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          # Allow fork PR checkouts since we gate deployments and the code only has access to ephemeral test cluster
+          allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/e2e-rosa-tests.yaml
+++ b/.github/workflows/e2e-rosa-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
@@ -68,7 +68,7 @@ jobs:
       AWS_REGION: "${{ vars.AWS_REGION }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -47,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
@@ -96,7 +96,7 @@ jobs:
       MOUNTPOINT_CSI_DRIVER_NEW_VERSION: "${{ inputs.upgrade_tests_new_version }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -51,6 +51,8 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          # Allow fork PR checkouts since we gate deployments and the code only has access to ephemeral test cluster
+          allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -100,6 +102,8 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          # Allow fork PR checkouts since we gate deployments and the code only has access to ephemeral test cluster
+          allow-unsafe-pr-checkout: true
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -79,6 +79,12 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
+      - name: Mark chart as published via Helm repository
+        # Disables the unsupported-installation warning and tracking label that shows
+        # when installing directly from a GitHub branch.
+        run: |
+          sed -i 's/^isHelmRepo: false/isHelmRepo: true/' charts/aws-mountpoint-s3-csi-driver/values.yaml
+          grep '^isHelmRepo: true' charts/aws-mountpoint-s3-csi-driver/values.yaml
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -21,12 +21,12 @@ jobs:
     environment: "trusted"
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
       - name: Checkout verification script from main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
           path: main-branch
@@ -75,7 +75,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' && !inputs.dry-run }}
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Send issue notification to Slack
         if: github.event_name == 'issues'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
           webhook-type: incoming-webhook
@@ -26,7 +26,7 @@ jobs:
 
       - name: Send pull request notification to Slack
         if: github.event_name == 'pull_request_target'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
           webhook-type: incoming-webhook

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Set up Go
       uses: actions/setup-go@v6

--- a/.github/workflows/verify-helm-images.yaml
+++ b/.github/workflows/verify-helm-images.yaml
@@ -1,0 +1,28 @@
+name: "Verify Helm Images"
+
+on:
+  push:
+    branches: [ "main", "feature/*" ]
+  pull_request:
+  merge_group:
+    types: [ "checks_requested" ]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify chart images exist in public ECR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install crane
+        run: |
+          cd /tmp
+          curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" > crane.tar.gz
+          tar -xzf crane.tar.gz crane
+          sudo mv crane /usr/local/bin/crane
+          sudo chmod +x /usr/local/bin/crane
+          crane version
+      - name: Verify public ECR images referenced in chart
+        run: ./scripts/verify-helm-images.sh --public-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Notable changes
+* Removed support for AL2, and Ubuntu 22.04.
+
 # v2.7.0
 
 [Documentation](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/v2.7.0/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+# v2.7.0
+
+[Documentation](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/v2.7.0/README.md)
+
+### Notable changes
+* Add controller leader election to prevent duplicate MountpointS3PodAttachment resources from being created during controller rolling updates, when the old and new controller pods briefly co-exist. ([#814](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/814))
+* Update Go to 1.26.4. ([#823](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/823))
+* Update csi-node-driver-registrar to v2.17.0-eksbuild.2 and livenessprobe to v2.19.0-eksbuild.2. ([#824](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/824))
+
 # v2.6.0
 
 [Documentation](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/v2.6.0/README.md)

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ login_registry:
 
 .PHONY: download_go_deps
 download_go_deps:
-	go mod download
+	go mod download || (echo "go mod download failed, retrying (1/2)..." && sleep 5 && go mod download) || (echo "go mod download failed, retrying (2/2)..." && sleep 10 && go mod download)
 
 .PHONY: bin
 bin:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 SHELL = /bin/bash
 
 # MP CSI Driver version
-VERSION=2.6.0
+VERSION=2.7.0
 
 PKG=github.com/awslabs/mountpoint-s3-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ See [Driver Installation](docs/INSTALL.md) for detailed instructions.
 ## Container Images
 | Driver Version | [ECR Public](https://gallery.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|
-| v2.6.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.6.0                       |
+| v2.7.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.7.0                       |
 
 <details>
 <summary>Previous Images</summary>
 
 | Driver Version | [ECR Public](https://gallery.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|
+| v2.6.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.6.0                       |
 | v2.5.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.5.0                       |
 | v2.4.1         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.4.1                       |
 | v2.4.0         | public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.4.0                       |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The S3 CSI Driver is distributed through the following supported channels:
 
 > [!WARNING]
 > Installing directly from a GitHub branch (`main`, `release-X.Y`, or any other) is not supported. Charts in the GitHub repository may reference unreleased images or contain in-progress changes that are incompatible with published binaries.
+> **After September 1, 2026, charts on the main branch will no longer be installable.** Please migrate to the Helm repository or EKS Addon installation method before this date.
 
 See [Driver Installation](docs/INSTALL.md) for detailed instructions.
 

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ The Mountpoint for S3 CSI Driver is compatible with Kubernetes versions v1.30+ a
 
 The following table provides the support status for various distros with regards to CSI Driver version:
 
-| Distro                                  | Experimental | Stable | Deprecated | Removed |
-|-----------------------------------------|-------------:|-------:|-----------:|--------:|
-| Amazon Linux 2       |         - |   1.0.0 |          - |       - |
-| Amazon Linux 2023    |         - |   1.0.0 |          - |       - |
-| Ubuntu 20.04         |         - |   1.0.0 |          - |   2.5.0 |
-| Ubuntu 22.04         |         - |   1.0.0 |          - |       - |
-| Ubuntu 24.04         |         - |   2.0.0 |          - |       - |
-| Bottlerocket >1.19.2 |         - |   1.4.0 |          - |       - |
+| Distro               | Stable     | Removed | Currently Supported EKS Versions |
+|----------------------|-----------:|--------:|----------------------------------|
+| Amazon Linux 2       |      1.0.0 |   2.8.0 | —                                |
+| Amazon Linux 2023    |      1.0.0 |       — | 1.30 – 1.36                      |
+| Ubuntu 20.04         |      1.0.0 |   2.5.0 | —                                |
+| Ubuntu 22.04         |      1.0.0 |   2.8.0 | —                                |
+| Ubuntu 24.04         |      2.0.0 |       — | 1.33 – 1.36                      |
+| Bottlerocket >1.19.2 |      1.4.0 |       — | 1.30 – 1.36                      |
 
 ## Documentation
 

--- a/charts/aws-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-mountpoint-s3-csi-driver
 description: A Helm chart for installing the Mountpoint for Amazon S3 CSI Driver. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface. Install via the Helm repository at https://awslabs.github.io/mountpoint-s3-csi-driver — do not install directly from a GitHub branch.
-version: 2.6.0
+version: 2.7.0
 kubeVersion: ">=1.30.0-0"
 home: https://github.com/awslabs/mountpoint-s3-csi-driver
 sources:

--- a/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
@@ -1,7 +1,15 @@
 Thank you for using Mountpoint for Amazon S3 CSI Driver v{{ .Chart.Version }}.
 
 Learn more about the file system operations Mountpoint supports: https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md
+{{- if and (not .Values.isHelmRepo) (not .Values.isEKSAddon) }}
 
+WARNING: You are installing from a GitHub branch.
+This installation method will stop working after September 1, 2026.
+Please migrate to a supported installation method:
+  - Helm repo: helm repo add aws-mountpoint-s3-csi-driver https://awslabs.github.io/mountpoint-s3-csi-driver
+  - EKS Addon: See https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html
+For more details, see: https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md
+{{- end }}
 {{- if .Release.IsUpgrade }}
 
 While the CSI driver has been upgraded, existing Mountpoint Pods remain unchanged to avoid disrupting your active workloads. New Mountpoint Pods with the updated version are created only when workload pods are started or restarted. You can view which pods exist created by older V2 versions of the CSI driver using `kubectl get pods -n mount-s3 --label-columns="s3.csi.aws.com/mounted-by-csi-driver-version"`.

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         app: s3-csi-node
+        {{- if and (not .Values.isHelmRepo) (not .Values.isEKSAddon) }}
+        s3.csi.aws.com/chart-source: "github-main"
+        {{- end }}
         {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 8 }}
         {{- if .Values.node.podLabels }}
         {{- toYaml .Values.node.podLabels | nindent 8 }}

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -18,7 +18,7 @@ image:
   repository: public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v2.6.0"
+  tag: "v2.7.0"
 
 node:
   kubeletPath: /var/lib/kubelet

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -1,6 +1,12 @@
 # Default values for Mountpoint for Amazon S3 CSI Driver Helm chart.
 # You can customize any values here during installation.
 
+# Automatically set to true when the chart is published to the official Helm repository.
+# Installing directly from a GitHub branch is not supported.
+# Use the Helm repository (https://awslabs.github.io/mountpoint-s3-csi-driver) or EKS Addon instead.
+# See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md for details.
+isHelmRepo: false
+
 # Set to true if running on OpenShift/ROSA.
 # If not set, auto-detects OpenShift where possible.
 isOpenShift: null

--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler.go
@@ -298,6 +298,10 @@ type workloadVolume struct {
 // the Mountpoint Pod will be scheduled for termination as well. This is because if `workloadPod` never transition into its `Running` state,
 // the Mountpoint Pod might never got a successful mount operation, and thus it might never get unmount operation to cleanly exit
 // and might hang there until it reaches its timeout. We just terminate it in this case to prevent unnecessary waits.
+//
+// If `workloadPod` is `Running` and scheduled for termination (i.e., `DeletionTimestamp` is non-nil during graceful shutdown),
+// it is still treated as active. The pod may still be accessing the S3 volume during its termination grace period
+// (e.g., if it ignores SIGTERM), so the Mountpoint Pod and S3PodAttachment must remain until the pod actually exits.
 func (r *Reconciler) spawnOrDeleteMountpointPodIfNeeded(
 	ctx context.Context,
 	workloadPod *corev1.Pod,
@@ -1108,12 +1112,11 @@ func extractCSISpecFromPV(pv *corev1.PersistentVolume) *corev1.CSIPersistentVolu
 	return csi
 }
 
-// isPodActive returns whether given the Pod is active and not in the process of termination.
-// Copied from https://github.com/kubernetes/kubernetes/blob/8770bd58d04555303a3a15b30c245a58723d0f4a/pkg/controller/controller_utils.go#L1009-L1013.
+// isPodActive returns whether the given Pod is active.
+// A pod is active if it is running (regardless of terminating status, to allow shut-downs
+// which access the volume), or if it is pending and not terminating.
 func isPodActive(p *corev1.Pod) bool {
-	return corev1.PodSucceeded != p.Status.Phase &&
-		corev1.PodFailed != p.Status.Phase &&
-		p.DeletionTimestamp == nil
+	return isPodRunning(p) || (p.Status.Phase == corev1.PodPending && p.DeletionTimestamp == nil)
 }
 
 // isPodTerminating returns whether the given Pod is terminating.

--- a/cmd/aws-s3-csi-controller/csicontroller/reconciler_test.go
+++ b/cmd/aws-s3-csi-controller/csicontroller/reconciler_test.go
@@ -1,0 +1,42 @@
+package csicontroller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestIsPodActive(t *testing.T) {
+	now := metav1.Now()
+	isDeleting := &now
+	var noDeleting *metav1.Time
+
+	tests := []struct {
+		name              string
+		phase             corev1.PodPhase
+		deletionTimestamp *metav1.Time
+		expect            bool
+	}{
+		{"Pending", corev1.PodPending, noDeleting, true},
+		{"Pending + terminating", corev1.PodPending, isDeleting, false},
+		{"Running", corev1.PodRunning, noDeleting, true},
+		{"Running + terminating", corev1.PodRunning, isDeleting, true},
+		{"Succeeded", corev1.PodSucceeded, noDeleting, false},
+		{"Succeeded + terminating", corev1.PodSucceeded, isDeleting, false},
+		{"Failed", corev1.PodFailed, noDeleting, false},
+		{"Failed + terminating", corev1.PodFailed, isDeleting, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: tt.deletionTimestamp},
+				Status:     corev1.PodStatus{Phase: tt.phase},
+			}
+			assert.Equals(t, tt.expect, isPodActive(pod))
+		})
+	}
+}

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: csi-driver
     newName: public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
-    newTag: v2.6.0
+    newTag: v2.7.0
 replacements:
   # Replace value of `MOUNTPOINT_IMAGE` env variable of the CSI Controller with the image path of the CSI Node.
   - source:

--- a/scripts/verify-helm-images.sh
+++ b/scripts/verify-helm-images.sh
@@ -12,11 +12,24 @@ set -euo pipefail
 #   - Liveness probe sidecar
 #   - Headroom pod image (pause container)
 #
+# Usage:
+#   ./verify-helm-images.sh                # Full verification (incl. EKS-addon private ECR repo; needs AWS creds)
+#   ./verify-helm-images.sh --public-only  # Verify only public ECR images (no AWS creds needed)
+#
 # Prerequisites:
 #   - yq: YAML processor (https://github.com/mikefarah/yq)
 #   - crane: Container registry tool (https://github.com/google/go-containerregistry/tree/main/cmd/crane)
 #
-# Note: AWS credentials are required with ecr:GetAuthorizationToken and ecr:BatchGetImage permissions to access EKS add-on repositories.
+# Note: For the default (full) mode, AWS credentials with ecr:GetAuthorizationToken and
+# ecr:BatchGetImage permissions are required to access EKS add-on repositories.
+
+PUBLIC_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --public-only) PUBLIC_ONLY=1 ;;
+    *) echo "ERROR: Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
 
 CHART_DIR="charts/aws-mountpoint-s3-csi-driver"
 VALUES_FILE="${CHART_DIR}/values.yaml"
@@ -54,9 +67,11 @@ fi
 echo "Verifying all images referenced in ${VALUES_FILE}..."
 echo ""
 
-if ! aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${EKS_REGISTRY}"; then
-  echo "ERROR: Failed to authenticate with ECR"
-  exit 1
+if [[ ${PUBLIC_ONLY} -eq 0 ]]; then
+  if ! aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${EKS_REGISTRY}"; then
+    echo "ERROR: Failed to authenticate with ECR"
+    exit 1
+  fi
 fi
 
 FAILED=0
@@ -109,8 +124,10 @@ verify_sidecar_images_in_chart() {
 echo "== Verifying standard images =="
 verify_sidecar_images_in_chart "helm template $CHART_DIR"
 
-echo "== Verifying EKS Addon images =="
-verify_sidecar_images_in_chart "helm template $CHART_DIR --set isEKSAddon=true --set sidecars.livenessProbe.image.containerRegistry=$EKS_REGISTRY --set sidecars.nodeDriverRegistrar.image.containerRegistry=$EKS_REGISTRY"
+if [[ ${PUBLIC_ONLY} -eq 0 ]]; then
+  echo "== Verifying EKS Addon images =="
+  verify_sidecar_images_in_chart "helm template $CHART_DIR --set isEKSAddon=true --set sidecars.livenessProbe.image.containerRegistry=$EKS_REGISTRY --set sidecars.nodeDriverRegistrar.image.containerRegistry=$EKS_REGISTRY"
+fi
 
 # Verify headroom pod image (used when experimental.reserveHeadroomForMountpointPods is enabled)
 HEADROOM_IMAGE=$(yq eval '.experimental.headroomPodImage' "${VALUES_FILE}")

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -957,6 +957,30 @@ var _ = Describe("Mountpoint Controller", func() {
 			waitForObjectToDisappear(pod.Pod)
 			waitForObjectToDisappear(s3pa)
 		})
+
+		It("should keep S3 Pod Attachment while workload pod is terminating but still running", func() {
+			vol := createVolume()
+			vol.bind()
+
+			gracePeriod := int64(300)
+			pod := createPod(withPVC(vol.pvc), func(p *corev1.Pod) {
+				p.Spec.TerminationGracePeriodSeconds = &gracePeriod
+			})
+			pod.schedule(testNode)
+
+			// Pod gets a Mountpoint Pod and transitions to Running
+			s3pa, _ := waitAndVerifyS3PodAttachmentAndMountpointPod(testNode, vol, pod)
+			pod.running()
+
+			// Pod is deleted but ignores SIGTERM — still Running with DeletionTimestamp set
+			pod.terminate()
+
+			// S3PA should persist while the pod is still running during graceful termination
+			Consistently(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(s3pa), s3pa)).To(Succeed())
+				g.Expect(findMountpointPodNameForWorkload(s3pa, string(pod.UID))).ToNot(BeEmpty())
+			}, defaultWaitTimeout, defaultWaitRetryPeriod).Should(Succeed())
+		})
 	})
 
 	Context("Duplicate S3PodAttachments recovery", func() {

--- a/tests/e2e-kubernetes/go.mod
+++ b/tests/e2e-kubernetes/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
-	github.com/containerd/containerd v1.7.29 // indirect
+	github.com/containerd/containerd v1.7.33 // indirect
 	github.com/containerd/containerd/api v1.8.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -154,7 +154,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -162,7 +162,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/selinux v1.13.0 // indirect
+	github.com/opencontainers/selinux v1.13.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/tests/e2e-kubernetes/go.sum
+++ b/tests/e2e-kubernetes/go.sum
@@ -88,8 +88,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNSjIRk=
 github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
-github.com/containerd/containerd v1.7.29 h1:90fWABQsaN9mJhGkoVnuzEY+o1XDPbg9BTC9QTAHnuE=
-github.com/containerd/containerd v1.7.29/go.mod h1:azUkWcOvHrWvaiUjSQH0fjzuHIwSPg1WL5PshGP4Szs=
+github.com/containerd/containerd v1.7.33 h1:iAkYGC/ifR/V+0eR4iXWHNGYUF0DF2PmGV5iz4Irj5M=
+github.com/containerd/containerd v1.7.33/go.mod h1:gSbSCVjPCdkfJCjyrzz7aRC+xFlqVbatNpfHfVCYGUM=
 github.com/containerd/containerd/api v1.8.0 h1:hVTNJKR8fMc/2Tiw60ZRijntNMd1U+JVMyTRdsD2bS0=
 github.com/containerd/containerd/api v1.8.0/go.mod h1:dFv4lt6S20wTu/hMcP4350RL87qPWLVa/OHOwmmdnYc=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
@@ -290,8 +290,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
 github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
@@ -321,8 +321,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/opencontainers/selinux v1.13.0 h1:Zza88GWezyT7RLql12URvoxsbLfjFx988+LGaWfbL84=
-github.com/opencontainers/selinux v1.13.0/go.mod h1:XxWTed+A/s5NNq4GmYScVy+9jzXhGBVEOAyucdRUY8s=
+github.com/opencontainers/selinux v1.13.1 h1:A8nNeceYngH9Ow++M+VVEwJVpdFmrlxsN22F+ISDCJE=
+github.com/opencontainers/selinux v1.13.1/go.mod h1:S10WXZ/osk2kWOYKy1x2f/eXF5ZHJoUs8UU/2caNRbg=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=

--- a/tests/e2e-kubernetes/testsuites/cache.go
+++ b/tests/e2e-kubernetes/testsuites/cache.go
@@ -110,8 +110,8 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		// Ensure the data still read from the cache - without cache this would fail as its removed from underlying bucket
 		checkReadFromPath(ctx, f, pod, first, testWriteSize, seed)
 
-		e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("mkdir %s && cd %s && echo 'second!' > %s; sync", dir, dir, second))
-		e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("cat %s | grep -q 'second!'", second))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("mkdir %s && cd %s && echo 'second!' > %s; sync", dir, dir, second))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("cat %s | grep -q 'second!'", second))
 		checkListingPathWithEntries(ctx, f, pod, dir, []string{"second"})
 		checkListingPathWithEntries(ctx, f, pod, basePath, []string{"test-dir"})
 		checkDeletingPath(ctx, f, pod, first)
@@ -244,7 +244,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 			})
 
 			pod, _ := createPod(ctx, mountOptions, podModifiers...)
-			e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("cat %s | grep -q 'hello world!'", testFile))
+			checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("cat %s | grep -q 'hello world!'", testFile))
 		})
 
 		// If we're testing multi-level cache, add two more test cases:
@@ -275,7 +275,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 
 				// Now remove the file from S3 and wipe out local cache
 				deleteObjectFromS3(ctx, bucketName, "first")
-				e2epod.VerifyExecInPodSucceed(ctx, f, pod, "rm -rf /cache/*")
+				checkExecInPodSucceed(ctx, f, pod, "rm -rf /cache/*")
 
 				// Reading should still work
 				for range 3 {

--- a/tests/e2e-kubernetes/testsuites/evictionorder.go
+++ b/tests/e2e-kubernetes/testsuites/evictionorder.go
@@ -75,8 +75,7 @@ func (t *s3CSIEvictionOrderTestSuite) DefineTests(driver storageframework.TestDr
 		seed := time.Now().UTC().UnixNano()
 		toWrite := 1024
 		filePath := path.Join(e2epod.VolumeMountPath1, "file.txt")
-		err := checkWriteToPath(ctx, f, workloadPods[0], filePath, toWrite, seed)
-		framework.ExpectNoError(err)
+		checkWriteToPath(ctx, f, workloadPods[0], filePath, toWrite, seed)
 
 		// Find the Mountpoint pods associated with our volume
 		mpPods, err := findMountpointPods(ctx, f.ClientSet, vol.Pv.Name)
@@ -94,8 +93,7 @@ func (t *s3CSIEvictionOrderTestSuite) DefineTests(driver storageframework.TestDr
 
 		// Check we can still use the mount insde the workload
 		for _, pod := range workloadPods {
-			err = checkReadFromPath(ctx, f, pod, filePath, toWrite, seed)
-			framework.ExpectNoError(err)
+			checkReadFromPath(ctx, f, pod, filePath, toWrite, seed)
 		}
 	})
 }

--- a/tests/e2e-kubernetes/testsuites/mountoptions.go
+++ b/tests/e2e-kubernetes/testsuites/mountoptions.go
@@ -148,11 +148,11 @@ func (t *s3CSIMountOptionsTestSuite) DefineTests(driver storageframework.TestDri
 		ginkgo.By("Checking read from a volume")
 		checkReadFromPath(ctx, f, pod, fileInVol, toWrite, seed)
 		ginkgo.By("Checking file group owner")
-		e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '644 %d %d'", fileInVol, defaultNonRootGroup, defaultNonRootUser))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '644 %d %d'", fileInVol, defaultNonRootGroup, defaultNonRootUser))
 		ginkgo.By("Checking dir group owner")
-		e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '755 %d %d'", volPath, defaultNonRootGroup, defaultNonRootUser))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '755 %d %d'", volPath, defaultNonRootGroup, defaultNonRootUser))
 		ginkgo.By("Checking pod identity")
-		e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("id | grep 'uid=%d gid=%d groups=%d'", defaultNonRootUser, defaultNonRootGroup, defaultNonRootGroup))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("id | grep 'uid=%d gid=%d groups=%d'", defaultNonRootUser, defaultNonRootGroup, defaultNonRootGroup))
 	}
 	ginkgo.It("should access volume as a non-root user", func(ctx context.Context) {
 		validateWriteToVolume(ctx)

--- a/tests/e2e-kubernetes/testsuites/pod_sharing.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing.go
@@ -353,7 +353,7 @@ func (t *s3CSIPodSharingTestSuite) DefineTests(driver storageframework.TestDrive
 			s3paNames, mountpointPodNames = verifyPodsShareMountpointPod(ctx, f, pods, defaultExpectedFields(targetNode, resource.Pv))
 			defer deleteWorkloadPodsAndEnsureMountpointResourcesCleaned(ctx, f, pods, s3paNames, mountpointPodNames)
 
-			e2epod.VerifyExecInPodSucceed(ctx, f, pods[0], "cat /mnt/volume1/terminating.txt | grep -q 'terminating'")
+			checkExecInPodSucceed(ctx, f, pods[0], "cat /mnt/volume1/terminating.txt | grep -q 'terminating'")
 		})
 
 		// Regression test for race condition fixed in https://github.com/awslabs/mountpoint-s3-csi-driver/pull/652

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -465,15 +465,22 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 	}
 }
 
-// buildHelmValues creates common Helm values for install/upgrade
-func buildHelmValues() map[string]any {
-	values := map[string]any{
+// buildHelmValuesBase creates Helm values for installation of the previous version,
+// without image overrides so the chart's default image would be used.
+func buildHelmValuesBase() map[string]any {
+	return map[string]any{
 		"node": map[string]any{
 			"podInfoOnMountCompat": map[string]any{
 				"enable": "true",
 			},
 		},
 	}
+}
+
+// buildHelmValuesForUpgrade creates Helm values for install/upgrade of the new version,
+// overriding the image fields to use the CI-built container from the current commit.
+func buildHelmValuesForUpgrade() map[string]any {
+	values := buildHelmValuesBase()
 	if helmChartContainerRepository != "" && helmChartContainerTag != "" {
 		values["image"] = map[string]any{
 			"repository": helmChartContainerRepository,
@@ -608,7 +615,7 @@ func installCSIDriver(cfg *action.Configuration, version string, chartPath strin
 	chart, err := loader.Load(chartPath)
 	framework.ExpectNoError(err)
 
-	release, err := installClient.RunWithContext(context.Background(), chart, buildHelmValues())
+	release, err := installClient.RunWithContext(context.Background(), chart, buildHelmValuesBase())
 	framework.ExpectNoError(err)
 
 	framework.Logf("Helm release %q created", release.Name)
@@ -651,7 +658,7 @@ func upgradeCSIDriver(cfg *action.Configuration, f *framework.Framework, version
 	chart, err := loader.Load(chartPath)
 	framework.ExpectNoError(err)
 
-	release, err := upgradeClient.RunWithContext(context.Background(), helmReleaseName, chart, buildHelmValues())
+	release, err := upgradeClient.RunWithContext(context.Background(), helmReleaseName, chart, buildHelmValuesForUpgrade())
 	framework.ExpectNoError(err)
 
 	framework.Logf("Helm release %q updated to %v (from %q)", release.Name, version, chartPath)

--- a/tests/e2e-kubernetes/testsuites/util.go
+++ b/tests/e2e-kubernetes/testsuites/util.go
@@ -55,33 +55,43 @@ func genBinDataFromSeed(len int, seed int64) []byte {
 	return binData
 }
 
-func checkWriteToPath(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) error {
+func checkExecInPodSucceed(ctx context.Context, f *framework.Framework, pod *v1.Pod, cmd string) {
+	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "exec in pod %s/%s failed for cmd %q: %v", pod.Namespace, pod.Name, cmd, err)
+}
+
+func checkWriteToPath(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
 	data := genBinDataFromSeed(toWrite, seed)
 	encoded := base64.StdEncoding.EncodeToString(data)
-	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("echo %s | base64 -d | dd conv=fsync of=%s bs=%d count=1", encoded, path, toWrite))
-	if err != nil {
-		framework.Logf("written data with sha: %x", sha256.Sum256(data))
-	}
-	return err
+	cmd := fmt.Sprintf("echo %s | base64 -d | dd conv=fsync of=%s bs=%d count=1", encoded, path, toWrite)
+	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "write to path %q in pod %s/%s failed: %v", path, pod.Namespace, pod.Name, err)
 }
 
 func checkWriteToPathFails(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
 	data := genBinDataFromSeed(toWrite, seed)
 	encoded := base64.StdEncoding.EncodeToString(data)
-	e2epod.VerifyExecInPodFail(ctx, f, pod, fmt.Sprintf("echo %s | base64 -d | dd of=%s bs=%d count=1", encoded, path, toWrite), 1)
+	err := e2epod.VerifyExecInPodFail(ctx, f, pod, fmt.Sprintf("echo %s | base64 -d | dd of=%s bs=%d count=1", encoded, path, toWrite), 1)
+	framework.ExpectNoError(err, "write to path %q in pod %s/%s expected to fail with a specific exit code: %v", path, pod.Namespace, pod.Name, err)
 }
 
-func checkReadFromPath(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) error {
+func checkReadFromPath(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
 	sum := sha256.Sum256(genBinDataFromSeed(toWrite, seed))
-	return e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum | grep -Fq %x", path, toWrite, sum))
+	cmd := fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum | grep -Fq %x", path, toWrite, sum)
+	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "read from path %q in pod %s/%s failed (expected sha256 %x, size %d): %v", path, pod.Namespace, pod.Name, sum, toWrite, err)
 }
 
 func checkDeletingPath(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string) {
-	e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("rm %s", path))
+	cmd := fmt.Sprintf("rm %s", path)
+	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "delete path %q in pod %s/%s failed: %v", path, pod.Namespace, pod.Name, err)
 }
 
 func checkListingPath(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string) {
-	e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("ls %s", path))
+	cmd := fmt.Sprintf("ls %s", path)
+	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "list path %q in pod %s/%s failed: %v", path, pod.Namespace, pod.Name, err)
 }
 
 func checkListingPathWithEntries(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, entries []string) {
@@ -232,9 +242,11 @@ func podModifierNonRoot(pod *v1.Pod) {
 
 func copySmallFileToPod(ctx context.Context, f *framework.Framework, pod *v1.Pod, hostPath, podPath string) {
 	data, err := os.ReadFile(hostPath)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "read host file %q failed: %v", hostPath, err)
 	encoded := base64.StdEncoding.EncodeToString(data)
-	e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("echo %s | base64 -d > %s", encoded, podPath))
+	cmd := fmt.Sprintf("echo %s | base64 -d > %s", encoded, podPath)
+	err = e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "copy file to path %q in pod %s/%s failed: %v", podPath, pod.Namespace, pod.Name, err)
 }
 
 // In some cases like changing Secret object, it's useful to trigger recreation of our pods.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Currently tests ignore errors returned from `VerifyExecInPodSucceed/VerifyExecInPodFail`. This might mean missed failures. Fix tests to fail if `VerifyExecInPodSucceed/VerifyExecInPodFail` returned an error.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
