### PR TITLE
Add ExpectNoError to ExecInPod calls

### DIFF
--- a/tests/e2e-kubernetes/testsuites/cache.go
+++ b/tests/e2e-kubernetes/testsuites/cache.go
@@ -97,25 +97,25 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		seed := time.Now().UTC().UnixNano()
 		testWriteSize := 1024 // 1KB
 
-		checkWriteToPath(ctx, f, pod, first, testWriteSize, seed)
+		checkWriteToPathSucceed(ctx, f, pod, first, testWriteSize, seed)
 		checkListingPathWithEntries(ctx, f, pod, basePath, []string{"first"})
 		// Test reading multiple times to ensure cached-read works
 		for range 3 {
-			checkReadFromPath(ctx, f, pod, first, testWriteSize, seed)
+			checkReadFromPathSucceed(ctx, f, pod, first, testWriteSize, seed)
 		}
 
 		// Now remove the file from S3
 		deleteObjectFromS3(ctx, bucketName, "first")
 
 		// Ensure the data still read from the cache - without cache this would fail as its removed from underlying bucket
-		checkReadFromPath(ctx, f, pod, first, testWriteSize, seed)
+		checkReadFromPathSucceed(ctx, f, pod, first, testWriteSize, seed)
 
-		e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("mkdir %s && cd %s && echo 'second!' > %s; sync", dir, dir, second))
-		e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("cat %s | grep -q 'second!'", second))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("mkdir %s && cd %s && echo 'second!' > %s; sync", dir, dir, second))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("cat %s | grep -q 'second!'", second))
 		checkListingPathWithEntries(ctx, f, pod, dir, []string{"second"})
 		checkListingPathWithEntries(ctx, f, pod, basePath, []string{"test-dir"})
-		checkDeletingPath(ctx, f, pod, first)
-		checkDeletingPath(ctx, f, pod, second)
+		checkDeletingPathSucceed(ctx, f, pod, first)
+		checkDeletingPathSucceed(ctx, f, pod, second)
 	}
 
 	createPod := func(ctx context.Context, mountOptions []string, podModifiers ...func(*v1.Pod)) (*v1.Pod, string) {
@@ -244,7 +244,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 			})
 
 			pod, _ := createPod(ctx, mountOptions, podModifiers...)
-			e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("cat %s | grep -q 'hello world!'", testFile))
+			checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("cat %s | grep -q 'hello world!'", testFile))
 		})
 
 		// If we're testing multi-level cache, add two more test cases:
@@ -267,19 +267,19 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 
 				first := filepath.Join(e2epod.VolumeMountPath1, "first")
 
-				checkWriteToPath(ctx, f, pod, first, testWriteSize, seed)
+				checkWriteToPathSucceed(ctx, f, pod, first, testWriteSize, seed)
 				// Initial read should work and populate both local and Express cache
 				for range 3 {
-					checkReadFromPath(ctx, f, pod, first, testWriteSize, seed)
+					checkReadFromPathSucceed(ctx, f, pod, first, testWriteSize, seed)
 				}
 
 				// Now remove the file from S3 and wipe out local cache
 				deleteObjectFromS3(ctx, bucketName, "first")
-				e2epod.VerifyExecInPodSucceed(ctx, f, pod, "rm -rf /cache/*")
+				checkExecInPodSucceed(ctx, f, pod, "rm -rf /cache/*")
 
 				// Reading should still work
 				for range 3 {
-					checkReadFromPath(ctx, f, pod, first, testWriteSize, seed)
+					checkReadFromPathSucceed(ctx, f, pod, first, testWriteSize, seed)
 				}
 			})
 
@@ -299,10 +299,10 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 
 				first := filepath.Join(e2epod.VolumeMountPath1, "first")
 
-				checkWriteToPath(ctx, f, pod, first, testWriteSize, seed)
+				checkWriteToPathSucceed(ctx, f, pod, first, testWriteSize, seed)
 				// Initial read should work and populate both local and Express cache
 				for range 3 {
-					checkReadFromPath(ctx, f, pod, first, testWriteSize, seed)
+					checkReadFromPathSucceed(ctx, f, pod, first, testWriteSize, seed)
 				}
 
 				// Now remove the file from S3 and wipe out Express cache
@@ -311,7 +311,7 @@ func (t *s3CSICacheTestSuite) DefineTests(driver storageframework.TestDriver, pa
 
 				// Reading should still work
 				for range 3 {
-					checkReadFromPath(ctx, f, pod, first, testWriteSize, seed)
+					checkReadFromPathSucceed(ctx, f, pod, first, testWriteSize, seed)
 				}
 			})
 		}

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -231,18 +231,18 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 	expectWriteToSucceed := func(ctx context.Context, pod *v1.Pod) writtenFile {
 		seed := time.Now().UTC().UnixNano()
 		framework.Logf("checking writing to %s", testFilePath)
-		checkWriteToPath(ctx, f, pod, testFilePath, testWriteSize, seed)
+		checkWriteToPathSucceed(ctx, f, pod, testFilePath, testWriteSize, seed)
 		return writtenFile{testFilePath, seed, testWriteSize}
 	}
 
 	expectReadToSucceed := func(ctx context.Context, pod *v1.Pod, file writtenFile) {
 		framework.Logf("checking reading from %s", file.path)
-		checkReadFromPath(ctx, f, pod, file.path, file.size, file.seed)
+		checkReadFromPathSucceed(ctx, f, pod, file.path, file.size, file.seed)
 	}
 
 	expectDeleteToSucceed := func(ctx context.Context, pod *v1.Pod, file writtenFile) {
 		framework.Logf("checking if deletion of %s succeeds", file.path)
-		checkDeletingPath(ctx, f, pod, file.path)
+		checkDeletingPathSucceed(ctx, f, pod, file.path)
 	}
 
 	expectWriteToFail := func(ctx context.Context, pod *v1.Pod) {
@@ -253,7 +253,7 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 
 	expectListToSucceed := func(ctx context.Context, pod *v1.Pod) {
 		framework.Logf("checking listing %s", testVolumePath)
-		checkListingPath(ctx, f, pod, testVolumePath)
+		checkListingPathSucceed(ctx, f, pod, testVolumePath)
 	}
 
 	expectReadOnly := func(ctx context.Context, pod *v1.Pod) {

--- a/tests/e2e-kubernetes/testsuites/evictionorder.go
+++ b/tests/e2e-kubernetes/testsuites/evictionorder.go
@@ -75,8 +75,7 @@ func (t *s3CSIEvictionOrderTestSuite) DefineTests(driver storageframework.TestDr
 		seed := time.Now().UTC().UnixNano()
 		toWrite := 1024
 		filePath := path.Join(e2epod.VolumeMountPath1, "file.txt")
-		err := checkWriteToPath(ctx, f, workloadPods[0], filePath, toWrite, seed)
-		framework.ExpectNoError(err)
+		checkWriteToPathSucceed(ctx, f, workloadPods[0], filePath, toWrite, seed)
 
 		// Find the Mountpoint pods associated with our volume
 		mpPods, err := findMountpointPods(ctx, f.ClientSet, vol.Pv.Name)
@@ -94,8 +93,7 @@ func (t *s3CSIEvictionOrderTestSuite) DefineTests(driver storageframework.TestDr
 
 		// Check we can still use the mount insde the workload
 		for _, pod := range workloadPods {
-			err = checkReadFromPath(ctx, f, pod, filePath, toWrite, seed)
-			framework.ExpectNoError(err)
+			checkReadFromPathSucceed(ctx, f, pod, filePath, toWrite, seed)
 		}
 	})
 }

--- a/tests/e2e-kubernetes/testsuites/headroom.go
+++ b/tests/e2e-kubernetes/testsuites/headroom.go
@@ -115,10 +115,10 @@ func (t *s3CSIHeadroomTestSuite) DefineTests(driver storageframework.TestDriver,
 		path := filepath.Join(volPath, filename)
 		testWriteSize := 1024 // 1KB
 
-		checkWriteToPath(ctx, f, pod, path, testWriteSize, seed)
-		checkReadFromPath(ctx, f, pod, path, testWriteSize, seed)
+		checkWriteToPathSucceed(ctx, f, pod, path, testWriteSize, seed)
+		checkReadFromPathSucceed(ctx, f, pod, path, testWriteSize, seed)
 		checkListingPathWithEntries(ctx, f, pod, volPath, []string{filename})
-		checkDeletingPath(ctx, f, pod, path)
+		checkDeletingPathSucceed(ctx, f, pod, path)
 		checkListingPathWithEntries(ctx, f, pod, volPath, []string{})
 	}
 

--- a/tests/e2e-kubernetes/testsuites/mountoptions.go
+++ b/tests/e2e-kubernetes/testsuites/mountoptions.go
@@ -152,7 +152,7 @@ func (t *s3CSIMountOptionsTestSuite) DefineTests(driver storageframework.TestDri
 		ginkgo.By("Checking dir group owner")
 		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '755 %d %d'", volPath, defaultNonRootGroup, defaultNonRootUser))
 		ginkgo.By("Checking pod identity")
-		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("id | grep 'uid=%d gid=%d groups=%d'", defaultNonRootUser, defaultNonRootGroup, defaultNonRootGroup))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("id; id | grep 'uid=%d[^ ]* gid=%d[^ ]* groups=%d'", defaultNonRootUser, defaultNonRootGroup, defaultNonRootGroup))
 	}
 	ginkgo.It("should access volume as a non-root user", func(ctx context.Context) {
 		validateWriteToVolume(ctx)

--- a/tests/e2e-kubernetes/testsuites/mountoptions.go
+++ b/tests/e2e-kubernetes/testsuites/mountoptions.go
@@ -144,15 +144,15 @@ func (t *s3CSIMountOptionsTestSuite) DefineTests(driver storageframework.TestDri
 		seed := time.Now().UTC().UnixNano()
 		toWrite := 1024 // 1KB
 		ginkgo.By("Checking write to a volume")
-		checkWriteToPath(ctx, f, pod, fileInVol, toWrite, seed)
+		checkWriteToPathSucceed(ctx, f, pod, fileInVol, toWrite, seed)
 		ginkgo.By("Checking read from a volume")
-		checkReadFromPath(ctx, f, pod, fileInVol, toWrite, seed)
+		checkReadFromPathSucceed(ctx, f, pod, fileInVol, toWrite, seed)
 		ginkgo.By("Checking file group owner")
-		e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '644 %d %d'", fileInVol, defaultNonRootGroup, defaultNonRootUser))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '644 %d %d'", fileInVol, defaultNonRootGroup, defaultNonRootUser))
 		ginkgo.By("Checking dir group owner")
-		e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '755 %d %d'", volPath, defaultNonRootGroup, defaultNonRootUser))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("stat -L -c '%%a %%g %%u' %s | grep '755 %d %d'", volPath, defaultNonRootGroup, defaultNonRootUser))
 		ginkgo.By("Checking pod identity")
-		e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("id | grep 'uid=%d gid=%d groups=%d'", defaultNonRootUser, defaultNonRootGroup, defaultNonRootGroup))
+		checkExecInPodSucceed(ctx, f, pod, fmt.Sprintf("id | grep 'uid=%d gid=%d groups=%d'", defaultNonRootUser, defaultNonRootGroup, defaultNonRootGroup))
 	}
 	ginkgo.It("should access volume as a non-root user", func(ctx context.Context) {
 		validateWriteToVolume(ctx)

--- a/tests/e2e-kubernetes/testsuites/multivolume.go
+++ b/tests/e2e-kubernetes/testsuites/multivolume.go
@@ -107,13 +107,13 @@ func (t *s3CSIMultiVolumeTestSuite) DefineTests(driver storageframework.TestDriv
 
 		pod1WritesTo := filepath.Join(path, "file1.txt")
 		seed := time.Now().UTC().UnixNano()
-		checkWriteToPath(ctx, f, pods[0], pod1WritesTo, toWrite, seed)
-		checkReadFromPath(ctx, f, pods[1], pod1WritesTo, toWrite, seed)
+		checkWriteToPathSucceed(ctx, f, pods[0], pod1WritesTo, toWrite, seed)
+		checkReadFromPathSucceed(ctx, f, pods[1], pod1WritesTo, toWrite, seed)
 
 		pod2WritesTo := filepath.Join(path, "file2.txt")
 		seed = time.Now().UTC().UnixNano()
-		checkWriteToPath(ctx, f, pods[1], pod2WritesTo, toWrite, seed)
-		checkReadFromPath(ctx, f, pods[0], pod2WritesTo, toWrite, seed)
+		checkWriteToPathSucceed(ctx, f, pods[1], pod2WritesTo, toWrite, seed)
+		checkReadFromPathSucceed(ctx, f, pods[0], pod2WritesTo, toWrite, seed)
 	}
 
 	testOnePodTwoVolumes := func(ctx context.Context, pvcs []*v1.PersistentVolumeClaim, seed int64, doWrite bool) {
@@ -129,10 +129,10 @@ func (t *s3CSIMultiVolumeTestSuite) DefineTests(driver storageframework.TestDriv
 			volSeed := seed + int64(i)
 			if doWrite {
 				ginkgo.By(fmt.Sprintf("Checking write to volume #%d", i))
-				checkWriteToPath(ctx, f, pod, fileInVol, toWrite, volSeed)
+				checkWriteToPathSucceed(ctx, f, pod, fileInVol, toWrite, volSeed)
 			}
 			ginkgo.By(fmt.Sprintf("Checking read from volume #%d", i))
-			checkReadFromPath(ctx, f, pod, fileInVol, toWrite, volSeed)
+			checkReadFromPathSucceed(ctx, f, pod, fileInVol, toWrite, volSeed)
 		}
 	}
 

--- a/tests/e2e-kubernetes/testsuites/pod_sharing.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing.go
@@ -262,10 +262,10 @@ func (t *s3CSIPodSharingTestSuite) DefineTests(driver storageframework.TestDrive
 			secondFile := "/mnt/volume1/file2.txt"
 			seed := time.Now().UTC().UnixNano()
 			// pods[0] should get a read-write mount
-			checkWriteToPath(ctx, f, pods[0], firstFile, toWrite, seed)
+			checkWriteToPathSucceed(ctx, f, pods[0], firstFile, toWrite, seed)
 
 			// pods[1] should get a read-only mount
-			checkReadFromPath(ctx, f, pods[1], firstFile, toWrite, seed)
+			checkReadFromPathSucceed(ctx, f, pods[1], firstFile, toWrite, seed)
 			checkWriteToPathFails(ctx, f, pods[1], secondFile, toWrite, seed)
 		})
 
@@ -289,10 +289,10 @@ func (t *s3CSIPodSharingTestSuite) DefineTests(driver storageframework.TestDrive
 			secondFile := "/mnt/volume1/file2.txt"
 			seed := time.Now().UTC().UnixNano()
 			// pods[0] should get a read-write mount
-			checkWriteToPath(ctx, f, pods[0], firstFile, toWrite, seed)
+			checkWriteToPathSucceed(ctx, f, pods[0], firstFile, toWrite, seed)
 
 			// pods[1] should get a read-only mount
-			checkReadFromPath(ctx, f, pods[1], firstFile, toWrite, seed)
+			checkReadFromPathSucceed(ctx, f, pods[1], firstFile, toWrite, seed)
 			checkWriteToPathFails(ctx, f, pods[1], secondFile, toWrite, seed)
 		})
 
@@ -314,8 +314,8 @@ func (t *s3CSIPodSharingTestSuite) DefineTests(driver storageframework.TestDrive
 			toWrite := 1024 // 1KB
 			path := "/mnt/volume1/new-file-after-pod1-terminated.txt"
 			seed := time.Now().UTC().UnixNano()
-			checkWriteToPath(ctx, f, pods[1], path, toWrite, seed)
-			checkReadFromPath(ctx, f, pods[1], path, toWrite, seed)
+			checkWriteToPathSucceed(ctx, f, pods[1], path, toWrite, seed)
+			checkReadFromPathSucceed(ctx, f, pods[1], path, toWrite, seed)
 		})
 
 		ginkgo.It("should keep Mountpoint Pod running during graceful termination period", func(ctx context.Context) {
@@ -353,7 +353,7 @@ func (t *s3CSIPodSharingTestSuite) DefineTests(driver storageframework.TestDrive
 			s3paNames, mountpointPodNames = verifyPodsShareMountpointPod(ctx, f, pods, defaultExpectedFields(targetNode, resource.Pv))
 			defer deleteWorkloadPodsAndEnsureMountpointResourcesCleaned(ctx, f, pods, s3paNames, mountpointPodNames)
 
-			e2epod.VerifyExecInPodSucceed(ctx, f, pods[0], "cat /mnt/volume1/terminating.txt | grep -q 'terminating'")
+			checkExecInPodSucceed(ctx, f, pods[0], "cat /mnt/volume1/terminating.txt | grep -q 'terminating'")
 		})
 
 		// Regression test for race condition fixed in https://github.com/awslabs/mountpoint-s3-csi-driver/pull/652
@@ -632,8 +632,8 @@ func checkPodWriteAndOtherPodRead(ctx context.Context, f *framework.Framework, w
 	filePath := filepath.Join(basePath, filename)
 	seed := time.Now().UTC().UnixNano()
 
-	checkWriteToPath(ctx, f, writerPod, filePath, size, seed)
-	checkReadFromPath(ctx, f, readerPod, filePath, size, seed)
+	checkWriteToPathSucceed(ctx, f, writerPod, filePath, size, seed)
+	checkReadFromPathSucceed(ctx, f, readerPod, filePath, size, seed)
 }
 
 type podLevelIdentityConfig struct {

--- a/tests/e2e-kubernetes/testsuites/proxy.go
+++ b/tests/e2e-kubernetes/testsuites/proxy.go
@@ -114,6 +114,9 @@ func (t *s3CSIProxyTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		})
 
 		resource := createVolumeResource(proxy, l.config, pattern, v1.ReadWriteMany, []string{
+			fmt.Sprintf("uid=%d", defaultNonRootUser),
+			fmt.Sprintf("gid=%d", defaultNonRootGroup),
+			"allow-other",
 			"debug",
 			"debug-crt",
 		})

--- a/tests/e2e-kubernetes/testsuites/proxy.go
+++ b/tests/e2e-kubernetes/testsuites/proxy.go
@@ -179,7 +179,7 @@ func (t *s3CSIProxyTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		seed := time.Now().UTC().UnixNano()
 		toWrite := 1024 // 1KB
 		ginkgo.By("Checking write to a volume")
-		checkWriteToPath(ctx, f, pod, fileInVol, toWrite, seed)
+		checkWriteToPathSucceed(ctx, f, pod, fileInVol, toWrite, seed)
 
 		ginkgo.By("Checking mountpoint actually operate behind proxy")
 		// Find the Mountpoint pods associated with our volume

--- a/tests/e2e-kubernetes/testsuites/taint_removal.go
+++ b/tests/e2e-kubernetes/testsuites/taint_removal.go
@@ -85,10 +85,10 @@ func (t *s3CSITaintRemovalTestSuite) DefineTests(driver storageframework.TestDri
 		path := filepath.Join(volPath, filename)
 		testWriteSize := 1024 // 1KB
 
-		checkWriteToPath(ctx, f, pod, path, testWriteSize, seed)
-		checkReadFromPath(ctx, f, pod, path, testWriteSize, seed)
+		checkWriteToPathSucceed(ctx, f, pod, path, testWriteSize, seed)
+		checkReadFromPathSucceed(ctx, f, pod, path, testWriteSize, seed)
 		checkListingPathWithEntries(ctx, f, pod, volPath, []string{filename})
-		checkDeletingPath(ctx, f, pod, path)
+		checkDeletingPathSucceed(ctx, f, pod, path)
 		checkListingPathWithEntries(ctx, f, pod, volPath, []string{})
 	}
 

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -210,10 +210,10 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 		path := filepath.Join(e2epod.VolumeMountPath1, filename)
 		testWriteSize := 1024 // 1KB
 
-		checkWriteToPath(ctx, f, pod, path, testWriteSize, seed)
-		checkReadFromPath(ctx, f, pod, path, testWriteSize, seed)
+		checkWriteToPathSucceed(ctx, f, pod, path, testWriteSize, seed)
+		checkReadFromPathSucceed(ctx, f, pod, path, testWriteSize, seed)
 		checkListingPathWithEntries(ctx, f, pod, e2epod.VolumeMountPath1, []string{filename, "test.txt"})
-		checkDeletingPath(ctx, f, pod, path)
+		checkDeletingPathSucceed(ctx, f, pod, path)
 		checkListingPathWithEntries(ctx, f, pod, e2epod.VolumeMountPath1, []string{"test.txt"})
 	}
 
@@ -267,8 +267,8 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 		testWriteSize = 1024
 		testFile = filepath.Join(e2epod.VolumeMountPath1, "test.txt")
 		for _, pod := range pods {
-			checkWriteToPath(ctx, f, pod, testFile, testWriteSize, seed)
-			checkReadFromPath(ctx, f, pod, testFile, testWriteSize, seed)
+			checkWriteToPathSucceed(ctx, f, pod, testFile, testWriteSize, seed)
+			checkReadFromPathSucceed(ctx, f, pod, testFile, testWriteSize, seed)
 		}
 		return
 	}
@@ -276,7 +276,7 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 	// verifyReadOnlyAccess verifies pods can list but not write
 	verifyReadOnlyAccess := func(ctx context.Context, pods []*v1.Pod, testFile string, testWriteSize int, seed int64) {
 		for _, pod := range pods {
-			checkListingPath(ctx, f, pod, e2epod.VolumeMountPath1)
+			checkListingPathSucceed(ctx, f, pod, e2epod.VolumeMountPath1)
 			checkWriteToPathFails(ctx, f, pod, testFile, testWriteSize, seed)
 		}
 	}
@@ -295,11 +295,11 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 	// verifyWorkloadHealth checks if pods can perform expected operations
 	verifyWorkloadHealth := func(ctx context.Context, fullAccessPods, readOnlyPods []*v1.Pod, testFile string, testWriteSize int, seed int64) {
 		for _, pod := range fullAccessPods {
-			checkReadFromPath(ctx, f, pod, testFile, testWriteSize, seed)
+			checkReadFromPathSucceed(ctx, f, pod, testFile, testWriteSize, seed)
 			checkBasicFileOperations(ctx, pod)
 		}
 		for _, pod := range readOnlyPods {
-			checkListingPath(ctx, f, pod, e2epod.VolumeMountPath1)
+			checkListingPathSucceed(ctx, f, pod, e2epod.VolumeMountPath1)
 			checkWriteToPathFails(ctx, f, pod, testFile, testWriteSize, seed)
 		}
 	}

--- a/tests/e2e-kubernetes/testsuites/util.go
+++ b/tests/e2e-kubernetes/testsuites/util.go
@@ -55,33 +55,43 @@ func genBinDataFromSeed(len int, seed int64) []byte {
 	return binData
 }
 
-func checkWriteToPath(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) error {
+func checkExecInPodSucceed(ctx context.Context, f *framework.Framework, pod *v1.Pod, cmd string) {
+	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "exec in pod %s/%s failed for cmd %q: %v", pod.Namespace, pod.Name, cmd, err)
+}
+
+func checkWriteToPathSucceed(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
 	data := genBinDataFromSeed(toWrite, seed)
 	encoded := base64.StdEncoding.EncodeToString(data)
-	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("echo %s | base64 -d | dd conv=fsync of=%s bs=%d count=1", encoded, path, toWrite))
-	if err != nil {
-		framework.Logf("written data with sha: %x", sha256.Sum256(data))
-	}
-	return err
+	cmd := fmt.Sprintf("echo %s | base64 -d | dd conv=fsync of=%s bs=%d count=1", encoded, path, toWrite)
+	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "write to path %q in pod %s/%s failed: %v", path, pod.Namespace, pod.Name, err)
 }
 
 func checkWriteToPathFails(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
 	data := genBinDataFromSeed(toWrite, seed)
 	encoded := base64.StdEncoding.EncodeToString(data)
-	e2epod.VerifyExecInPodFail(ctx, f, pod, fmt.Sprintf("echo %s | base64 -d | dd of=%s bs=%d count=1", encoded, path, toWrite), 1)
+	err := e2epod.VerifyExecInPodFail(ctx, f, pod, fmt.Sprintf("echo %s | base64 -d | dd of=%s bs=%d count=1", encoded, path, toWrite), 1)
+	framework.ExpectNoError(err, "write to path %q in pod %s/%s expected to fail with a specific exit code: %v", path, pod.Namespace, pod.Name, err)
 }
 
-func checkReadFromPath(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) error {
+func checkReadFromPathSucceed(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
 	sum := sha256.Sum256(genBinDataFromSeed(toWrite, seed))
-	return e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum | grep -Fq %x", path, toWrite, sum))
+	cmd := fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum | grep -Fq %x", path, toWrite, sum)
+	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "read from path %q in pod %s/%s failed (expected sha256 %x, size %d): %v", path, pod.Namespace, pod.Name, sum, toWrite, err)
 }
 
-func checkDeletingPath(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string) {
-	e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("rm %s", path))
+func checkDeletingPathSucceed(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string) {
+	cmd := fmt.Sprintf("rm %s", path)
+	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "delete path %q in pod %s/%s failed: %v", path, pod.Namespace, pod.Name, err)
 }
 
-func checkListingPath(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string) {
-	e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("ls %s", path))
+func checkListingPathSucceed(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string) {
+	cmd := fmt.Sprintf("ls %s", path)
+	err := e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "list path %q in pod %s/%s failed: %v", path, pod.Namespace, pod.Name, err)
 }
 
 func checkListingPathWithEntries(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, entries []string) {
@@ -232,9 +242,11 @@ func podModifierNonRoot(pod *v1.Pod) {
 
 func copySmallFileToPod(ctx context.Context, f *framework.Framework, pod *v1.Pod, hostPath, podPath string) {
 	data, err := os.ReadFile(hostPath)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "read host file %q failed: %v", hostPath, err)
 	encoded := base64.StdEncoding.EncodeToString(data)
-	e2epod.VerifyExecInPodSucceed(ctx, f, pod, fmt.Sprintf("echo %s | base64 -d > %s", encoded, podPath))
+	cmd := fmt.Sprintf("echo %s | base64 -d > %s", encoded, podPath)
+	err = e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	framework.ExpectNoError(err, "copy file to path %q in pod %s/%s failed: %v", podPath, pod.Namespace, pod.Name, err)
 }
 
 // In some cases like changing Secret object, it's useful to trigger recreation of our pods.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Currently tests ignore errors returned from
`VerifyExecInPodSucceed/VerifyExecInPodFail`. This might mean missed failures. Fix tests to fail if `VerifyExecInPodSucceed/VerifyExecInPodFail` returned an error.

Fix 2 tests which started failing:
- `should be able to operate behind proxy` (accessing FS as non-root requires `uid,gid,allow-other` flags)
- `should access volume as a non-root user` (unexpected `id` tool output format) 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.