### PR TITLE
Re-enable tests on ROSA for the `feature/daemonset-architecture` branch

### DIFF
--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -22,8 +22,7 @@ jobs:
     secrets: inherit
   e2e-rosa:
     name: E2E ROSA Tests
-    # Temporarily skipping rosa tests for feature/daemonset-architecture branch
-    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id) && github.base_ref != 'feature/daemonset-architecture' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id }}
     uses: ./.github/workflows/e2e-rosa-tests.yaml
     with:
       environment: "rosa-trusted"
@@ -38,9 +37,4 @@ jobs:
       - e2e-rosa
     steps:
       - name: Verify jobs succeeded
-        run: |
-          if [[ "${{ github.base_ref }}" == "feature/daemonset-architecture" ]]; then
-            echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'
-          else
-            echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'
-          fi
+        run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'

--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -31,8 +31,6 @@ jobs:
     secrets: inherit
   e2e-rosa:
     name: E2E ROSA Tests
-    # Temporarily skipping rosa tests for feature/daemonset-architecture branch
-    if: github.ref_name != 'feature/daemonset-architecture' 
     uses: ./.github/workflows/e2e-rosa-tests.yaml
     needs: approval
     with:
@@ -48,9 +46,4 @@ jobs:
       - e2e-rosa
     steps:
       - name: Verify jobs succeeded
-        run: |
-          if [[ "${{ github.base_ref }}" == "feature/daemonset-architecture" ]]; then
-            echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'
-          else
-            echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'
-          fi
+        run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'

--- a/.github/workflows/e2e-test-untrusted.yaml
+++ b/.github/workflows/e2e-test-untrusted.yaml
@@ -32,7 +32,7 @@ jobs:
   e2e-rosa:
     name: E2E ROSA Tests
     # Temporarily skipping rosa tests for feature/daemonset-architecture branch
-    if: ${{ github.event.pull_request.base.ref != 'feature/daemonset-architecture' }}
+    if: github.ref_name != 'feature/daemonset-architecture' 
     uses: ./.github/workflows/e2e-rosa-tests.yaml
     needs: approval
     with:
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Verify jobs succeeded
         run: |
-          if [[ "${{ github.event.pull_request.base.ref }}" == "feature/daemonset-architecture" ]]; then
+          if [[ "${{ github.base_ref }}" == "feature/daemonset-architecture" ]]; then
             echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'
           else
             echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Re-enable tests on ROSA for the `feature/daemonset-architecture` branch. PR https://github.com/awslabs/mountpoint-s3-csi-driver/pull/845 implements missing creds provisioning to run tests on ROSA.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
