### PR TITLE
Add MaxVolumesPerNode to enable scheduler volume limit enforcement

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/mounter-daemonset.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/mounter-daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if eq .Values.experimental.mounterMode "daemonset" }}
-{{- if gt (len .Values.daemonsetMounters) 1 }}
-{{- fail "Only one entry in daemonsetMounters is supported currently" }}
+{{- if ne (len .Values.daemonsetMounters) 1 }}
+{{- fail "daemonsetMounters must have exactly one entry" }}
 {{- end }}
 {{- $mounter := index .Values.daemonsetMounters 0 }}
 kind: DaemonSet

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -105,10 +105,16 @@ spec:
             - name: INSTALLATION_TYPE
               value: {{ if .Values.isEKSAddon }}eks-addon{{ else }}helm{{ end }}
             {{- if eq .Values.experimental.mounterMode "daemonset" }}
+            {{- $mounter := index .Values.daemonsetMounters 0 }}
+            {{- if lt (int $mounter.maxVolumesPerNode) 1 }}
+            {{- fail "daemonsetMounters[].maxVolumesPerNode must be >= 1" }}
+            {{- end }}
             - name: MOUNTER_MODE
               value: daemonset
             - name: MOUNTER_NAMESPACE
               value: {{ .Release.Namespace }}
+            - name: MAX_VOLUMES_PER_NODE
+              value: "{{ $mounter.maxVolumesPerNode }}"
             {{- end }}
             {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -105,9 +105,12 @@ spec:
             - name: INSTALLATION_TYPE
               value: {{ if .Values.isEKSAddon }}eks-addon{{ else }}helm{{ end }}
             {{- if eq .Values.experimental.mounterMode "daemonset" }}
+            {{- if ne (len .Values.daemonsetMounters) 1 }}
+            {{- fail "daemonsetMounters must have exactly one entry" }}
+            {{- end }}
             {{- $mounter := index .Values.daemonsetMounters 0 }}
-            {{- if lt (int $mounter.maxVolumesPerNode) 1 }}
-            {{- fail "daemonsetMounters[].maxVolumesPerNode must be >= 1" }}
+            {{- if lt (int $mounter.maxVolumesPerNode) 0 }}
+            {{- fail "daemonsetMounters[].maxVolumesPerNode must be >= 0" }}
             {{- end }}
             - name: MOUNTER_MODE
               value: daemonset

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -156,12 +156,17 @@ daemonsetMounters:
     # Advertised to the Kubernetes scheduler via MaxVolumesPerNode.
     # Shared volumes (same PV used by multiple pods) are counted once.
   - maxVolumesPerNode: 10
-    # Resource requests and limits for the mounter DaemonSet pod.
-    # requests.memory should be sized to maxMountsPerNode × per-mount memory
-    # (e.g., 10 mounts × 2Gi = 20Gi).
+    # Total resource requests and limits for the mounter DaemonSet pod.
+    # requests.memory should be sized to maxVolumesPerNode × per-mount memory
+    # (e.g., 4 mounts × 512Mi = 2Gi, or 10 mounts × 4Gi = 40Gi).
+    # Please refer to Mountpoint documentation for recommended resource configurations.
+    # TODO: Add link for Mountpoint documentation
+    # requests.cpu should also be sized to maxVolumesPerNode × per-mount CPU
+    # (e.g.  4 mounts × 500Mi = 2000m, or 10 mounts × 500m = 5000m).
+    # TODO: update guidances with memory limiter integration
     resources:
       requests:
-        memory: "1Gi"
+        memory: "2Gi"
         cpu: "500m"
     logLevel: 4
     podLabels: {}

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -154,16 +154,14 @@ experimental:
 daemonsetMounters:
     # Maximum number of distinct S3 volumes (Mountpoint processes) per node.
     # Advertised to the Kubernetes scheduler via MaxVolumesPerNode.
-    # Shared volumes (same PV used by multiple pods) are counted once.
-  - maxVolumesPerNode: 10
+    # Set to 0 to disable the limit (unbounded); this risks resource exhaustion
+    # (memory OOM, or disk exhaustion with cache) on the mounter DaemonSet pod.
+    # IMPORTANT: volumeHandle must be unique per PV as the scheduler uses it to 
+    # track volume usage.
+  - maxVolumesPerNode: 4
     # Total resource requests and limits for the mounter DaemonSet pod.
     # requests.memory should be sized to maxVolumesPerNode × per-mount memory
     # (e.g., 4 mounts × 512Mi = 2Gi, or 10 mounts × 4Gi = 40Gi).
-    # Please refer to Mountpoint documentation for recommended resource configurations.
-    # TODO: Add link for Mountpoint documentation
-    # requests.cpu should also be sized to maxVolumesPerNode × per-mount CPU
-    # (e.g.  4 mounts × 500Mi = 2000m, or 10 mounts × 500m = 5000m).
-    # TODO: update guidances with memory limiter integration
     resources:
       requests:
         memory: "2Gi"

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -152,10 +152,17 @@ experimental:
 # Configuration for the secondary mounter daemonset(s).
 # Only used when experimental.mounterMode is "daemonset".
 daemonsetMounters:
-  - resources:
+    # Maximum number of distinct S3 volumes (Mountpoint processes) per node.
+    # Advertised to the Kubernetes scheduler via MaxVolumesPerNode.
+    # Shared volumes (same PV used by multiple pods) are counted once.
+  - maxVolumesPerNode: 10
+    # Resource requests and limits for the mounter DaemonSet pod.
+    # requests.memory should be sized to maxMountsPerNode × per-mount memory
+    # (e.g., 10 mounts × 2Gi = 20Gi).
+    resources:
       requests:
-        cpu: 100m
-        memory: 256Mi
+        memory: "1Gi"
+        cpu: "500m"
     logLevel: 4
     podLabels: {}
     nodeSelector: {}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -50,6 +50,7 @@ import (
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/version"
 	mpmounter "github.com/awslabs/mountpoint-s3-csi-driver/pkg/mountpoint/mounter"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/podmounter/mppod/watcher"
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util"
 )
 
 const (
@@ -61,11 +62,12 @@ const (
 )
 
 var (
-	mountpointPodNamespace = os.Getenv("MOUNTPOINT_NAMESPACE")
-	mounterMode            = os.Getenv("MOUNTER_MODE")
-	mounterModeDaemonset   = "daemonset"
-	podWatcherResyncPeriod = time.Minute
-	scheme                 = runtime.NewScheme()
+	mountpointPodNamespace   = os.Getenv("MOUNTPOINT_NAMESPACE")
+	mounterMode              = os.Getenv("MOUNTER_MODE")
+	mounterModeDaemonset     = "daemonset"
+	maxVolumesPerNodeEnvName = "MAX_VOLUMES_PER_NODE"
+	podWatcherResyncPeriod   = time.Minute
+	scheme                   = runtime.NewScheme()
 )
 
 func init() {
@@ -119,7 +121,7 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 
 	stopCh := make(chan struct{})
 
-	var nodeMounter mounter.Mounter
+	var nodeServer *node.S3NodeServer
 
 	if mounterMode == mounterModeDaemonset {
 		klog.Info("Using daemonset mounter mode")
@@ -139,7 +141,15 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 		}
 		go dm.StartCommDirWatch(stopCh)
 
-		nodeMounter = dm
+		maxVolumesPerNode, err := util.GetEnvAsIntOrFallback(maxVolumesPerNodeEnvName, 0)
+		if err != nil {
+			return nil, err
+		}
+		if maxVolumesPerNode < 1 {
+			return nil, fmt.Errorf("%s must be >= 1, got %d", maxVolumesPerNodeEnvName, maxVolumesPerNode)
+		}
+
+		nodeServer = node.NewS3NodeServer(nodeID, dm, int64(maxVolumesPerNode))
 	} else {
 		mpMounter := mpmounter.New()
 		podWatcher := watcher.New(clientset, mountpointPodNamespace, nodeID, podWatcherResyncPeriod)
@@ -161,10 +171,8 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 		if err != nil {
 			klog.Fatalln(err)
 		}
-		nodeMounter = podMounter
+		nodeServer = node.NewS3NodeServer(nodeID, podMounter, 0) // maxVolumesPerNode = 0 means no limit
 	}
-
-	nodeServer := node.NewS3NodeServer(nodeID, nodeMounter)
 
 	return &Driver{
 		Endpoint:   endpoint,

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -141,7 +141,7 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 		}
 		go dm.StartCommDirWatch(stopCh)
 
-		maxVolumesPerNode, err := util.GetEnvAsIntOrFallback(maxVolumesPerNodeEnvName, 0)
+		maxVolumesPerNode, err := util.GetEnvAsInt(maxVolumesPerNodeEnvName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -145,8 +145,14 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 		if err != nil {
 			return nil, err
 		}
-		if maxVolumesPerNode < 1 {
-			return nil, fmt.Errorf("%s must be >= 1, got %d", maxVolumesPerNodeEnvName, maxVolumesPerNode)
+		if maxVolumesPerNode < 0 {
+			return nil, fmt.Errorf("%s must be >= 0, got %d", maxVolumesPerNodeEnvName, maxVolumesPerNode)
+		}
+		if maxVolumesPerNode == 0 {
+			klog.Warningf("%s is 0: volume limit is disabled (unbounded). The scheduler will not "+
+				"limit the number of S3 volumes per node, which may lead to resource exhaustion "+
+				"(memory OOM, or disk exhaustion when cache is enabled) on s3-csi-daemonset-mounter.",
+				maxVolumesPerNodeEnvName)
 		}
 
 		nodeServer = node.NewS3NodeServer(nodeID, dm, int64(maxVolumesPerNode))

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -63,12 +63,13 @@ const (
 
 // S3NodeServer is the implementation of the csi.NodeServer interface
 type S3NodeServer struct {
-	NodeID  string
-	Mounter mounter.Mounter
+	NodeID            string
+	Mounter           mounter.Mounter
+	MaxVolumesPerNode int64
 }
 
-func NewS3NodeServer(nodeID string, mounter mounter.Mounter) *S3NodeServer {
-	return &S3NodeServer{NodeID: nodeID, Mounter: mounter}
+func NewS3NodeServer(nodeID string, mounter mounter.Mounter, maxVolumesPerNode int64) *S3NodeServer {
+	return &S3NodeServer{NodeID: nodeID, Mounter: mounter, MaxVolumesPerNode: maxVolumesPerNode}
 }
 
 func (ns *S3NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
@@ -292,7 +293,8 @@ func (ns *S3NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReq
 	klog.V(4).Infof("NodeGetInfo: called with args %+v", req)
 
 	return &csi.NodeGetInfoResponse{
-		NodeId: ns.NodeID,
+		NodeId:            ns.NodeID,
+		MaxVolumesPerNode: ns.MaxVolumesPerNode,
 	}, nil
 }
 

--- a/pkg/driver/node/node_test.go
+++ b/pkg/driver/node/node_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
 )
 
+const testNodeID = "test-nodeID"
+
 type nodeServerTestEnv struct {
 	mockCtl     *gomock.Controller
 	mockMounter *mock_driver.MockMounter
@@ -30,7 +32,7 @@ type nodeServerTestEnv struct {
 func initNodeServerTestEnv(t *testing.T) *nodeServerTestEnv {
 	mockCtl := gomock.NewController(t)
 	mockMounter := mock_driver.NewMockMounter(mockCtl)
-	server := node.NewS3NodeServer("test-nodeID", mockMounter)
+	server := node.NewS3NodeServer(testNodeID, mockMounter, 0)
 	return &nodeServerTestEnv{
 		mockCtl:     mockCtl,
 		mockMounter: mockMounter,
@@ -1020,6 +1022,52 @@ func TestNodeGetCapabilitiesForPodMounter(t *testing.T) {
 	}, resp.GetCapabilities())
 
 	nodeTestEnv.mockCtl.Finish()
+}
+
+func TestNodeGetInfo(t *testing.T) {
+	testCases := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{
+			name: "returns MaxVolumesPerNode when configured",
+			testFunc: func(t *testing.T) {
+				var maxVolumesPerNode int64 = 50
+				nodeTestEnv := initNodeServerTestEnv(t)
+				nodeTestEnv.server.MaxVolumesPerNode = maxVolumesPerNode
+
+				ctx := context.Background()
+				req := &csi.NodeGetInfoRequest{}
+
+				resp, err := nodeTestEnv.server.NodeGetInfo(ctx, req)
+				if err != nil {
+					t.Fatalf("NodeGetInfo failed: %v", err)
+				}
+				assert.Equals(t, testNodeID, resp.NodeId)
+				assert.Equals(t, maxVolumesPerNode, resp.MaxVolumesPerNode)
+			},
+		},
+		{
+			name: "returns zero when MaxVolumesPerNode not set (unbounded, for pod mode)",
+			testFunc: func(t *testing.T) {
+				nodeTestEnv := initNodeServerTestEnv(t)
+
+				ctx := context.Background()
+				req := &csi.NodeGetInfoRequest{}
+
+				resp, err := nodeTestEnv.server.NodeGetInfo(ctx, req)
+				if err != nil {
+					t.Fatalf("NodeGetInfo failed: %v", err)
+				}
+				assert.Equals(t, testNodeID, resp.NodeId)
+				assert.Equals(t, int64(0), resp.MaxVolumesPerNode)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.testFunc)
+	}
 }
 
 var _ mounter.Mounter = &dummyMounter{}

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -1,7 +1,24 @@
 package util
 
-import "os"
+import (
+	"os"
+	"strconv"
+)
 
 func SupportLegacySystemdMounts() bool {
 	return os.Getenv("SUPPORT_LEGACY_SYSTEMD_MOUNTS") == "true"
+}
+
+// GetEnvAsIntOrFallback returns the env variable (parsed as integer) for
+// the given key and falls back to the given defaultValue if not set.
+// Copied from https://github.com/kubernetes/kubernetes/blob/release-1.36/pkg/util/env/env.go
+func GetEnvAsIntOrFallback(key string, defaultValue int) (int, error) {
+	if v := os.Getenv(key); v != "" {
+		value, err := strconv.Atoi(v)
+		if err != nil {
+			return defaultValue, err
+		}
+		return value, nil
+	}
+	return defaultValue, nil
 }

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 )
@@ -9,16 +10,16 @@ func SupportLegacySystemdMounts() bool {
 	return os.Getenv("SUPPORT_LEGACY_SYSTEMD_MOUNTS") == "true"
 }
 
-// GetEnvAsIntOrFallback returns the env variable (parsed as integer) for
-// the given key and falls back to the given defaultValue if not set.
-// Copied from https://github.com/kubernetes/kubernetes/blob/release-1.36/pkg/util/env/env.go
-func GetEnvAsIntOrFallback(key string, defaultValue int) (int, error) {
-	if v := os.Getenv(key); v != "" {
-		value, err := strconv.Atoi(v)
-		if err != nil {
-			return defaultValue, err
-		}
-		return value, nil
+// GetEnvAsInt returns the env variable parsed as an integer.
+// Returns an error if the variable is not set or not a valid integer.
+func GetEnvAsInt(key string) (int, error) {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return 0, fmt.Errorf("%s environment variable is required", key)
 	}
-	return defaultValue, nil
+	value, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a valid integer, got %q: %w", key, val, err)
+	}
+	return value, nil
 }

--- a/pkg/util/env_test.go
+++ b/pkg/util/env_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Adapted from https://github.com/kubernetes/kubernetes/blob/v1.36.2/pkg/util/env/env_test.go
+
+package util
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestGetEnvAsIntOrFallback(t *testing.T) {
+	const expected = 1
+
+	// Valid int: returns parsed value, no error
+	key := "FLOCKER_SET_VAR"
+	t.Setenv(key, strconv.Itoa(expected))
+	returnVal, err := GetEnvAsIntOrFallback(key, 1)
+	assert.NoError(t, err)
+	assert.Equals(t, expected, returnVal)
+
+	// Unset: returns fallback, no error
+	key = "FLOCKER_UNSET_VAR"
+	returnVal, err = GetEnvAsIntOrFallback(key, expected)
+	assert.NoError(t, err)
+	assert.Equals(t, expected, returnVal)
+
+	// Invalid string: returns fallback + error
+	key = "FLOCKER_SET_VAR"
+	t.Setenv(key, "not-an-int")
+	returnVal, err = GetEnvAsIntOrFallback(key, 1)
+	assert.Equals(t, expected, returnVal)
+	if err == nil {
+		t.Error("expected error")
+	}
+}

--- a/pkg/util/env_test.go
+++ b/pkg/util/env_test.go
@@ -1,20 +1,4 @@
-/*
-Copyright 2015 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-// Adapted from https://github.com/kubernetes/kubernetes/blob/v1.36.2/pkg/util/env/env_test.go
+// References https://github.com/kubernetes/kubernetes/blob/v1.36.2/pkg/util/env/env_test.go
 
 package util
 
@@ -25,28 +9,30 @@ import (
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
 )
 
-func TestGetEnvAsIntOrFallback(t *testing.T) {
+func TestGetEnvAsInt(t *testing.T) {
 	const expected = 1
 
 	// Valid int: returns parsed value, no error
-	key := "FLOCKER_SET_VAR"
+	key := "TEST_INT_VAR"
 	t.Setenv(key, strconv.Itoa(expected))
-	returnVal, err := GetEnvAsIntOrFallback(key, 1)
+	returnVal, err := GetEnvAsInt(key)
 	assert.NoError(t, err)
 	assert.Equals(t, expected, returnVal)
 
-	// Unset: returns fallback, no error
-	key = "FLOCKER_UNSET_VAR"
-	returnVal, err = GetEnvAsIntOrFallback(key, expected)
-	assert.NoError(t, err)
-	assert.Equals(t, expected, returnVal)
-
-	// Invalid string: returns fallback + error
-	key = "FLOCKER_SET_VAR"
-	t.Setenv(key, "not-an-int")
-	returnVal, err = GetEnvAsIntOrFallback(key, 1)
-	assert.Equals(t, expected, returnVal)
+	// Unset: returns error
+	key = "TEST_UNSET_VAR"
+	_, err = GetEnvAsInt(key)
 	if err == nil {
-		t.Error("expected error")
+		t.Error("expected error for unset variable")
 	}
+	t.Logf("%s", err)
+
+	// Invalid string: returns error
+	key = "TEST_INVALID_VAR"
+	t.Setenv(key, "not-an-int")
+	_, err = GetEnvAsInt(key)
+	if err == nil {
+		t.Error("expected error for invalid string")
+	}
+	t.Logf("%s", err)
 }

--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -104,7 +104,7 @@ var CSITestSuites = []func() framework.TestSuite{
 	// testsuites.InitMultiVolumeTestSuite,
 	// testsuites.InitVolumeExpandTestSuite,
 	// testsuites.InitDisruptiveTestSuite,
-	// testsuites.InitVolumeLimitsTestSuite,
+	// testsuites.InitVolumeLimitsTestSuite, // custom_testsuites.InitS3CSIVolumeLimitsTestSuite adapts this
 	// testsuites.InitTopologyTestSuite,
 	// testsuites.InitVolumeStressTestSuite,
 	// testsuites.InitFsGroupChangePolicyTestSuite,
@@ -117,6 +117,7 @@ var CSITestSuites = []func() framework.TestSuite{
 	custom_testsuites.InitS3MountOptionsTestSuite,
 	custom_testsuites.InitS3CSICredentialsTestSuite,
 	custom_testsuites.InitS3CSIPodSharingDaemonsetTestSuite,
+	custom_testsuites.InitS3CSIVolumeLimitsTestSuite,
 	// TODO: reenable or rewrite when credentials / cache / pod sharing are implemented for daemonset mode
 	// custom_testsuites.InitS3CSICacheTestSuite,
 	// custom_testsuites.InitS3CSIPodSharingTestSuite,

--- a/tests/e2e-kubernetes/testdriver.go
+++ b/tests/e2e-kubernetes/testdriver.go
@@ -50,7 +50,8 @@ func initS3Driver() *s3Driver {
 				"", // Default fsType
 			),
 			Capabilities: map[framework.Capability]bool{
-				framework.CapPersistence: true,
+				framework.CapPersistence:  true,
+				framework.CapVolumeLimits: true,
 			},
 			RequiredAccessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadWriteMany,

--- a/tests/e2e-kubernetes/testsuites/volumelimits.go
+++ b/tests/e2e-kubernetes/testsuites/volumelimits.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Adapted from https://github.com/kubernetes/kubernetes/blob/v1.36.2/test/e2e/storage/testsuites/volumelimits.go.
+// The upstream test requires dynamic provisioning; we use static provisioning with pre-created S3 buckets.
+
+package custom_testsuites
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+type s3CSIVolumeLimitsTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+const (
+	// The test uses generic pod startup / PV deletion timeouts. As it creates
+	// much more volumes at once, these timeouts are multiplied by this number.
+	// Using real nr. of volumes (e.g. 128 on GCE) would be really too much.
+	// Upstream uses 10; we use 2 since our default maxVolumesPerNode is 10 (not 128).
+	testSlowMultiplier = 2
+
+	// How long to wait until CSINode gets attach limit from installed CSI driver.
+	csiNodeInfoTimeout = 2 * time.Minute
+)
+
+var _ storageframework.TestSuite = &s3CSIVolumeLimitsTestSuite{}
+
+// InitS3CSIVolumeLimitsTestSuite returns s3CSIVolumeLimitsTestSuite that implements TestSuite interface
+// using custom test patterns
+func InitS3CSIVolumeLimitsTestSuite() storageframework.TestSuite {
+	return &s3CSIVolumeLimitsTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "volumelimits",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+func (t *s3CSIVolumeLimitsTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *s3CSIVolumeLimitsTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, _ storageframework.TestPattern) {
+	dInfo := driver.GetDriverInfo()
+	if !dInfo.Capabilities[storageframework.CapVolumeLimits] {
+		e2eskipper.Skipf("Driver %s does not support volume limits", dInfo.Name)
+	}
+}
+
+func (t *s3CSIVolumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	type local struct {
+		resources []*storageframework.VolumeResource
+		config    *storageframework.PerTestConfig
+	}
+	var l local
+
+	f := framework.NewFrameworkWithCustomTimeouts(NamespacePrefix+"volumelimits", storageframework.GetDriverTimeouts(driver))
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	cleanup := func(ctx context.Context) {
+		var errs []error
+		for _, resource := range l.resources {
+			errs = append(errs, resource.CleanupResource(ctx))
+		}
+		framework.ExpectNoError(errors.NewAggregate(errs), "while cleanup resource")
+	}
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		ginkgo.DeferCleanup(cleanup)
+	})
+
+	// This checks that CSIMaxVolumeLimitChecker works as expected.
+	// A randomly chosen node should be able to handle as many CSI volumes as
+	// it claims to handle in CSINode.Spec.Drivers[x].Allocatable.
+	// The test uses one single pod with a lot of volumes to work around any
+	// max pod limit on a node.
+	// And one extra pod with a CSI volume should get Pending with a condition
+	// that says it's unschedulable because of volume limit.
+	// BEWARE: the test may create lot of volumes and it's really slow.
+	f.It("should support volume limits", f.WithSerial(), func(ctx context.Context) {
+		driverInfo := driver.GetDriverInfo()
+
+		ginkgo.By("Picking a node")
+		// Some CSI drivers are deployed to a single node (e.g csi-hostpath),
+		// so we use that node instead of picking a random one.
+		nodeName := l.config.ClientNodeSelection.Name
+		if nodeName == "" {
+			node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
+			framework.ExpectNoError(err)
+			nodeName = node.Name
+		}
+		framework.Logf("Selected node %s", nodeName)
+
+		ginkgo.By("Checking node limits")
+		limit, err := getCSINodeLimits(ctx, f, nodeName, driverInfo.Name)
+		framework.ExpectNoError(err)
+		framework.Logf("Node %s can handle %d volumes of driver %s", nodeName, limit, driverInfo.Name)
+
+		// Create <limit> PVCs for one gigantic pod.
+		var pvcs []*v1.PersistentVolumeClaim
+		ginkgo.By(fmt.Sprintf("Creating %d volume(s)", limit))
+		for range limit {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+			pvcs = append(pvcs, resource.Pvc)
+		}
+
+		ginkgo.By("Creating pod to use all PVC(s)")
+		// pod.Spec.NodeName should not be set directly because it will bypass the scheduler. Use SetNodeSelection instead for these 2 occurences.
+		// https://github.com/kubernetes/kubernetes/blob/24e2b02af5543d7910c2bb074c7264df5a8f0467/test/e2e/framework/pod/node_selection.go#L96-L101
+		selection := e2epod.NodeSelection{Name: nodeName}
+		pod := e2epod.MakePod(f.Namespace.Name, nil, pvcs, admissionapi.LevelBaseline, "")
+		e2epod.SetNodeSelection(&pod.Spec, selection)
+		pod, err = createPodWithoutWaiting(ctx, f.ClientSet, f.Namespace.Name, pod)
+		framework.ExpectNoError(err)
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+		}()
+
+		ginkgo.By("Waiting for the pod running")
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, testSlowMultiplier*f.Timeouts.PodStart)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Creating an extra pod with one volume to exceed the limit")
+		extraResource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+		l.resources = append(l.resources, extraResource)
+
+		extraPod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{extraResource.Pvc}, admissionapi.LevelBaseline, "")
+		e2epod.SetNodeSelection(&extraPod.Spec, selection)
+		extraPod, err = createPodWithoutWaiting(ctx, f.ClientSet, f.Namespace.Name, extraPod)
+		framework.ExpectNoError(err, "creating extra pod beyond limit")
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, extraPod))
+		}()
+
+		ginkgo.By("Waiting for the pod to get unschedulable with the right message")
+		err = e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, extraPod.Name, "Unschedulable", f.Timeouts.PodStart, func(pod *v1.Pod) (bool, error) {
+			if pod.Status.Phase == v1.PodPending {
+				// Matches Message " 0/1 nodes are available: 1 node(s) exceed max volume count."
+				reg, err := regexp.Compile(`max.+volume.+count`)
+				if err != nil {
+					return false, err
+				}
+				for _, cond := range pod.Status.Conditions {
+					matched := reg.MatchString(cond.Message)
+					if cond.Type == v1.PodScheduled && cond.Status == v1.ConditionFalse && cond.Reason == "Unschedulable" && matched {
+						return true, nil
+					}
+				}
+			}
+			if pod.Status.Phase != v1.PodPending {
+				return true, fmt.Errorf("expected pod to be in phase Pending, but got phase: %v", pod.Status.Phase)
+			}
+			return false, nil
+		})
+		framework.ExpectNoError(err)
+	})
+
+	// TODO: Uncomment when pod sharing is implemented. Alternatively just add to test above
+	// Verifies that the scheduler's volumeHandle dedup works correctly:
+	// a workload reusing an already-mounted PV should be admitted without counting
+	// against the volume limit (same PV = same Mountpoint process = counted once).
+	// f.It("should admit a pod reusing an already-mounted PV without counting it twice", f.WithSerial(), func(ctx context.Context) {
+	// 	driverInfo := driver.GetDriverInfo()
+
+	// 	ginkgo.By("Picking a node")
+	// 	nodeName := l.config.ClientNodeSelection.Name
+	// 	if nodeName == "" {
+	// 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
+	// 		framework.ExpectNoError(err)
+	// 		nodeName = node.Name
+	// 	}
+
+	// 	ginkgo.By("Checking node limits")
+	// 	limit, err := getCSINodeLimits(ctx, f, nodeName, driverInfo.Name)
+	// 	framework.ExpectNoError(err)
+	// 	framework.Logf("Node %s can handle %d volumes of driver %s", nodeName, limit, driverInfo.Name)
+
+	// 	// Create <limit> PVCs for one gigantic pod.
+	// 	var pvcs []*v1.PersistentVolumeClaim
+	// 	ginkgo.By(fmt.Sprintf("Creating %d volume(s)", limit))
+	// 	for range limit {
+	// 		resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+	// 		l.resources = append(l.resources, resource)
+	// 		pvcs = append(pvcs, resource.Pvc)
+	// 	}
+
+	// 	ginkgo.By("Creating pod to use all PVC(s)")
+	// 	// pod.Spec.NodeName should not be set directly because it will bypass the scheduler. Use SetNodeSelection instead for these 2 occurences.
+	// 	// https://github.com/kubernetes/kubernetes/blob/24e2b02af5543d7910c2bb074c7264df5a8f0467/test/e2e/framework/pod/node_selection.go#L96-L101
+	// 	selection := e2epod.NodeSelection{Name: nodeName}
+	// 	pod := e2epod.MakePod(f.Namespace.Name, nil, pvcs, admissionapi.LevelBaseline, "")
+	// 	e2epod.SetNodeSelection(&pod.Spec, selection)
+	// 	pod, err = createPodWithoutWaiting(ctx, f.ClientSet, f.Namespace.Name, pod)
+	// 	framework.ExpectNoError(err)
+	// 	defer func() {
+	// 		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+	// 	}()
+
+	// 	err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, testSlowMultiplier*f.Timeouts.PodStart)
+	// 	framework.ExpectNoError(err)
+
+	// 	// Create a new pod referencing an EXISTING PVC (mounted by the first pod).
+	// 	// The scheduler should admit it because the same volumeHandle is not counted twice.
+	// 	ginkgo.By("Creating a pod reusing an already-mounted PV (should not be stuck in pending)")
+	// 	sharedPod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvcs[0]}, admissionapi.LevelBaseline, "")
+	// 	e2epod.SetNodeSelection(&sharedPod.Spec, selection)
+	// 	sharedPod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, sharedPod)
+	// 	framework.ExpectNoError(err, "pod reusing an already-mounted PV should be admitted (not counted against volume limit)")
+	// 	defer func() {
+	// 		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, sharedPod))
+	// 	}()
+	// })
+
+	ginkgo.It("should verify that all csinodes have volume limits", func(ctx context.Context) {
+		driverInfo := driver.GetDriverInfo()
+		if !driverInfo.Capabilities[storageframework.CapVolumeLimits] {
+			ginkgo.Skip(fmt.Sprintf("driver %s does not support volume limits", driverInfo.Name))
+		}
+
+		nodeNames := []string{}
+		if l.config.ClientNodeSelection.Name != "" {
+			// Some CSI drivers are deployed to a single node (e.g csi-hostpath),
+			// so we check that node instead of checking all of them
+			nodeNames = append(nodeNames, l.config.ClientNodeSelection.Name)
+		} else {
+			nodeList, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
+			framework.ExpectNoError(err)
+			for _, node := range nodeList.Items {
+				nodeNames = append(nodeNames, node.Name)
+			}
+		}
+
+		for _, nodeName := range nodeNames {
+			ginkgo.By("Checking csinode limits")
+			_, err := getCSINodeLimits(ctx, f, nodeName, driverInfo.Name)
+			if err != nil {
+				framework.Failf("Expected volume limits to be set, error: %v", err)
+			}
+		}
+	})
+}
+
+// getCSINodeLimits reads the volume limit for the given driver from the CSINode object.
+func getCSINodeLimits(ctx context.Context, f *framework.Framework, nodeName, driverName string) (int, error) {
+	// Retry with a timeout, the driver might just have been installed and kubelet takes a while to publish everything.
+	var limit int
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, csiNodeInfoTimeout, true, func(ctx context.Context) (bool, error) {
+		csiNode, err := f.ClientSet.StorageV1().CSINodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("%s", err)
+			return false, nil
+		}
+		var csiDriver *storagev1.CSINodeDriver
+		for i, c := range csiNode.Spec.Drivers {
+			if c.Name == driverName {
+				csiDriver = &csiNode.Spec.Drivers[i]
+				break
+			}
+		}
+		if csiDriver == nil {
+			framework.Logf("CSINodeInfo does not have driver %s yet", driverName)
+			return false, nil
+		}
+		if csiDriver.Allocatable == nil {
+			return false, fmt.Errorf("CSINodeInfo does not have Allocatable for driver %s", driverName)
+		}
+		if csiDriver.Allocatable.Count == nil {
+			return false, fmt.Errorf("CSINodeInfo does not have Allocatable.Count for driver %s", driverName)
+		}
+		limit = int(*csiDriver.Allocatable.Count)
+		return true, nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("could not get CSINode limit for driver %s: %w", driverName, err)
+	}
+	return limit, nil
+}

--- a/tests/e2e-kubernetes/testsuites/volumelimits.go
+++ b/tests/e2e-kubernetes/testsuites/volumelimits.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,7 +111,6 @@ func (t *s3CSIVolumeLimitsTestSuite) DefineTests(driver storageframework.TestDri
 	// max pod limit on a node.
 	// And one extra pod with a CSI volume should get Pending with a condition
 	// that says it's unschedulable because of volume limit.
-	// BEWARE: the test may create lot of volumes and it's really slow.
 	f.It("should support volume limits", f.WithSerial(), func(ctx context.Context) {
 		driverInfo := driver.GetDriverInfo()
 
@@ -129,6 +129,12 @@ func (t *s3CSIVolumeLimitsTestSuite) DefineTests(driver storageframework.TestDri
 		limit, err := getCSINodeLimits(ctx, f, nodeName, driverInfo.Name)
 		framework.ExpectNoError(err)
 		framework.Logf("Node %s can handle %d volumes of driver %s", nodeName, limit, driverInfo.Name)
+
+		ginkgo.By("Verifying node has no pre-existing S3 volumes")
+		existing, err := countS3VolumesOnNode(ctx, f, nodeName, driverInfo.Name)
+		framework.ExpectNoError(err)
+		gomega.Expect(existing).To(gomega.Equal(0),
+			"node %s already has %d %s volume(s); test requires no pre-existing S3 volumes", nodeName, existing, driverInfo.Name)
 
 		// Create <limit> PVCs for one gigantic pod.
 		var pvcs []*v1.PersistentVolumeClaim
@@ -154,6 +160,12 @@ func (t *s3CSIVolumeLimitsTestSuite) DefineTests(driver storageframework.TestDri
 		ginkgo.By("Waiting for the pod running")
 		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, testSlowMultiplier*f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
+
+		ginkgo.By("Verifying node is now at the volume limit")
+		inUse, err := countS3VolumesOnNode(ctx, f, nodeName, driverInfo.Name)
+		framework.ExpectNoError(err)
+		gomega.Expect(inUse).To(gomega.Equal(limit),
+			"expected node %s to have %d (volume limit) volumes in use, got %d", nodeName, limit, inUse)
 
 		ginkgo.By("Creating an extra pod with one volume to exceed the limit")
 		extraResource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
@@ -189,62 +201,6 @@ func (t *s3CSIVolumeLimitsTestSuite) DefineTests(driver storageframework.TestDri
 		})
 		framework.ExpectNoError(err)
 	})
-
-	// TODO: Uncomment when pod sharing is implemented. Alternatively just add to test above
-	// Verifies that the scheduler's volumeHandle dedup works correctly:
-	// a workload reusing an already-mounted PV should be admitted without counting
-	// against the volume limit (same PV = same Mountpoint process = counted once).
-	// f.It("should admit a pod reusing an already-mounted PV without counting it twice", f.WithSerial(), func(ctx context.Context) {
-	// 	driverInfo := driver.GetDriverInfo()
-
-	// 	ginkgo.By("Picking a node")
-	// 	nodeName := l.config.ClientNodeSelection.Name
-	// 	if nodeName == "" {
-	// 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-	// 		framework.ExpectNoError(err)
-	// 		nodeName = node.Name
-	// 	}
-
-	// 	ginkgo.By("Checking node limits")
-	// 	limit, err := getCSINodeLimits(ctx, f, nodeName, driverInfo.Name)
-	// 	framework.ExpectNoError(err)
-	// 	framework.Logf("Node %s can handle %d volumes of driver %s", nodeName, limit, driverInfo.Name)
-
-	// 	// Create <limit> PVCs for one gigantic pod.
-	// 	var pvcs []*v1.PersistentVolumeClaim
-	// 	ginkgo.By(fmt.Sprintf("Creating %d volume(s)", limit))
-	// 	for range limit {
-	// 		resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
-	// 		l.resources = append(l.resources, resource)
-	// 		pvcs = append(pvcs, resource.Pvc)
-	// 	}
-
-	// 	ginkgo.By("Creating pod to use all PVC(s)")
-	// 	// pod.Spec.NodeName should not be set directly because it will bypass the scheduler. Use SetNodeSelection instead for these 2 occurences.
-	// 	// https://github.com/kubernetes/kubernetes/blob/24e2b02af5543d7910c2bb074c7264df5a8f0467/test/e2e/framework/pod/node_selection.go#L96-L101
-	// 	selection := e2epod.NodeSelection{Name: nodeName}
-	// 	pod := e2epod.MakePod(f.Namespace.Name, nil, pvcs, admissionapi.LevelBaseline, "")
-	// 	e2epod.SetNodeSelection(&pod.Spec, selection)
-	// 	pod, err = createPodWithoutWaiting(ctx, f.ClientSet, f.Namespace.Name, pod)
-	// 	framework.ExpectNoError(err)
-	// 	defer func() {
-	// 		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
-	// 	}()
-
-	// 	err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, testSlowMultiplier*f.Timeouts.PodStart)
-	// 	framework.ExpectNoError(err)
-
-	// 	// Create a new pod referencing an EXISTING PVC (mounted by the first pod).
-	// 	// The scheduler should admit it because the same volumeHandle is not counted twice.
-	// 	ginkgo.By("Creating a pod reusing an already-mounted PV (should not be stuck in pending)")
-	// 	sharedPod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvcs[0]}, admissionapi.LevelBaseline, "")
-	// 	e2epod.SetNodeSelection(&sharedPod.Spec, selection)
-	// 	sharedPod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, sharedPod)
-	// 	framework.ExpectNoError(err, "pod reusing an already-mounted PV should be admitted (not counted against volume limit)")
-	// 	defer func() {
-	// 		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, sharedPod))
-	// 	}()
-	// })
 
 	ginkgo.It("should verify that all csinodes have volume limits", func(ctx context.Context) {
 		driverInfo := driver.GetDriverInfo()
@@ -309,4 +265,39 @@ func getCSINodeLimits(ctx context.Context, f *framework.Framework, nodeName, dri
 		return 0, fmt.Errorf("could not get CSINode limit for driver %s: %w", driverName, err)
 	}
 	return limit, nil
+}
+
+// countS3VolumesOnNode counts distinct volumes (by volumeHandle) for the given CSI driver that are
+// in use by pods scheduled on nodeName. Dedup is similar to scheduler which dedups via driverName/volumeHandle.
+// See https://github.com/kubernetes/kubernetes/blob/v1.36.2/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go#L451
+func countS3VolumesOnNode(ctx context.Context, f *framework.Framework, nodeName, driverName string) (int, error) {
+	pods, err := f.ClientSet.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("listing pods on node %s: %w", nodeName, err)
+	}
+
+	handles := map[string]struct{}{}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		for _, vol := range pod.Spec.Volumes {
+			// Skip volumes without PVC.
+			if vol.PersistentVolumeClaim == nil {
+				continue
+			}
+			// Skip if the PVC can't be read / isn't bound to a PV.
+			pvc, err := f.ClientSet.CoreV1().PersistentVolumeClaims(pod.Namespace).Get(ctx, vol.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+			if err != nil || pvc.Spec.VolumeName == "" {
+				continue
+			}
+			// Skip if the PV can't be read / isn't a volume of our CSI driver.
+			pv, err := f.ClientSet.CoreV1().PersistentVolumes().Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{})
+			if err != nil || pv.Spec.CSI == nil || pv.Spec.CSI.Driver != driverName {
+				continue
+			}
+			handles[pv.Spec.CSI.VolumeHandle] = struct{}{}
+		}
+	}
+	return len(handles), nil
 }

--- a/tests/e2e-kubernetes/testsuites/volumelimits.go
+++ b/tests/e2e-kubernetes/testsuites/volumelimits.go
@@ -53,6 +53,10 @@ const (
 
 	// How long to wait until CSINode gets attach limit from installed CSI driver.
 	csiNodeInfoTimeout = 2 * time.Minute
+
+	// How long to wait for a node to drain pre-existing S3 volumes left by prior
+	// tests.
+	nodeVolumeDrainTimeout = 5 * time.Minute
 )
 
 var _ storageframework.TestSuite = &s3CSIVolumeLimitsTestSuite{}
@@ -130,11 +134,8 @@ func (t *s3CSIVolumeLimitsTestSuite) DefineTests(driver storageframework.TestDri
 		framework.ExpectNoError(err)
 		framework.Logf("Node %s can handle %d volumes of driver %s", nodeName, limit, driverInfo.Name)
 
-		ginkgo.By("Verifying node has no pre-existing S3 volumes")
-		existing, err := countS3VolumesOnNode(ctx, f, nodeName, driverInfo.Name)
-		framework.ExpectNoError(err)
-		gomega.Expect(existing).To(gomega.Equal(0),
-			"node %s already has %d %s volume(s); test requires no pre-existing S3 volumes", nodeName, existing, driverInfo.Name)
+		ginkgo.By("Waiting for node to have no pre-existing S3 volumes")
+		waitForNoS3VolumesOnNode(ctx, f, nodeName, driverInfo.Name)
 
 		// Create <limit> PVCs for one gigantic pod.
 		var pvcs []*v1.PersistentVolumeClaim
@@ -202,6 +203,78 @@ func (t *s3CSIVolumeLimitsTestSuite) DefineTests(driver storageframework.TestDri
 		framework.ExpectNoError(err)
 	})
 
+	// Verifies that the scheduler's volumeHandle dedup works correctly:
+	// a workload reusing an already-mounted PV should be admitted without counting
+	// against the volume limit (same PV = same Mountpoint process = counted once).
+	f.It("should admit a pod reusing an already-mounted PV without counting it twice", f.WithSerial(), func(ctx context.Context) {
+		driverInfo := driver.GetDriverInfo()
+
+		ginkgo.By("Picking a node")
+		nodeName := l.config.ClientNodeSelection.Name
+		if nodeName == "" {
+			node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
+			framework.ExpectNoError(err)
+			nodeName = node.Name
+		}
+
+		ginkgo.By("Checking node limits")
+		limit, err := getCSINodeLimits(ctx, f, nodeName, driverInfo.Name)
+		framework.ExpectNoError(err)
+		framework.Logf("Node %s can handle %d volumes of driver %s", nodeName, limit, driverInfo.Name)
+
+		ginkgo.By("Waiting for node to have no pre-existing S3 volumes")
+		waitForNoS3VolumesOnNode(ctx, f, nodeName, driverInfo.Name)
+
+		// Create <limit> PVCs for one gigantic pod.
+		var pvcs []*v1.PersistentVolumeClaim
+		ginkgo.By(fmt.Sprintf("Creating %d volume(s)", limit))
+		for range limit {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+			pvcs = append(pvcs, resource.Pvc)
+		}
+
+		ginkgo.By("Creating pod to use all PVC(s)")
+		// pod.Spec.NodeName should not be set directly because it will bypass the scheduler. Use SetNodeSelection instead for these 2 occurences.
+		// https://github.com/kubernetes/kubernetes/blob/24e2b02af5543d7910c2bb074c7264df5a8f0467/test/e2e/framework/pod/node_selection.go#L96-L101
+		selection := e2epod.NodeSelection{Name: nodeName}
+		pod := e2epod.MakePod(f.Namespace.Name, nil, pvcs, admissionapi.LevelBaseline, "")
+		e2epod.SetNodeSelection(&pod.Spec, selection)
+		pod, err = createPodWithoutWaiting(ctx, f.ClientSet, f.Namespace.Name, pod)
+		framework.ExpectNoError(err)
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+		}()
+
+		ginkgo.By("Waiting for the pod running")
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, testSlowMultiplier*f.Timeouts.PodStart)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Verifying node is now at the volume limit")
+		inUse, err := countS3VolumesOnNode(ctx, f, nodeName, driverInfo.Name)
+		framework.ExpectNoError(err)
+		gomega.Expect(inUse).To(gomega.Equal(limit),
+			"expected node %s to have %d (volume limit) volumes in use, got %d", nodeName, limit, inUse)
+
+		// Create a new pod referencing an EXISTING PVC (mounted by the first pod).
+		// The scheduler should admit it because the same volumeHandle is not counted twice.
+		ginkgo.By("Creating a pod reusing an already-mounted PV (should not be stuck in pending)")
+		sharedPod := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{pvcs[0]}, admissionapi.LevelBaseline, "")
+		e2epod.SetNodeSelection(&sharedPod.Spec, selection)
+		sharedPod, err = createPod(ctx, f.ClientSet, f.Namespace.Name, sharedPod)
+		framework.ExpectNoError(err, "pod reusing an already-mounted PV should be admitted (not counted against volume limit)")
+		defer func() {
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, sharedPod))
+		}()
+
+		ginkgo.By("Verifying node is still at the volume limit (sanity check)")
+		inUse, err = countS3VolumesOnNode(ctx, f, nodeName, driverInfo.Name)
+		framework.ExpectNoError(err)
+		gomega.Expect(inUse).To(gomega.Equal(limit),
+			"expected node %s to have %d (volume limit) volumes in use, got %d", nodeName, limit, inUse)
+
+	})
+
 	ginkgo.It("should verify that all csinodes have volume limits", func(ctx context.Context) {
 		driverInfo := driver.GetDriverInfo()
 		if !driverInfo.Capabilities[storageframework.CapVolumeLimits] {
@@ -265,6 +338,15 @@ func getCSINodeLimits(ctx context.Context, f *framework.Framework, nodeName, dri
 		return 0, fmt.Errorf("could not get CSINode limit for driver %s: %w", driverName, err)
 	}
 	return limit, nil
+}
+
+// waitForNoS3VolumesOnNode polls until nodeName reports zero S3 volumes for the
+// given driver, failing the test if it never drains within nodeVolumeDrainTimeout.
+func waitForNoS3VolumesOnNode(ctx context.Context, f *framework.Framework, nodeName, driverName string) {
+	gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
+		return countS3VolumesOnNode(ctx, f, nodeName, driverName)
+	}).WithTimeout(nodeVolumeDrainTimeout).WithPolling(5*time.Second).Should(gomega.Equal(0),
+		"node %s still has pre-existing %s volume(s); test requires a node with no pre-existing S3 volumes", nodeName, driverName)
 }
 
 // countS3VolumesOnNode counts distinct volumes (by volumeHandle) for the given CSI driver that are

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -73,6 +73,7 @@ var _ = BeforeSuite(func() {
 		NodeServer: node.NewS3NodeServer(
 			"fake_id",
 			&mounter.FakeMounter{},
+			0,
 		),
 	}
 	go func() {


### PR DESCRIPTION
### Description

This PR advertises `MaxVolumesPerNode` ([KEP 554](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/554-maximum-volume-count)) via `NodeGetInfo` in daemonset mode, and the scheduler's existing [NodeVolumeLimit plugin](https://github.com/kubernetes/kubernetes/blob/eb51fbf7c6de0e361504729feabdadd178cd2b7b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go#L257) reads this and rejects workload pods when the node's volume capacity is full, which allows autoscaler scale-ups. 


#### Changes

Implementation:
- values.yaml: maxVolumesPerNode field and sizing guidance
- node.yaml: Emit env var + Helm validation (fail if < 0), 
  - Allow 0 for unbounded volume limits, with warning in node logs / values.yaml comment. Note kubelet [doesn't write allocatable value if 0](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go#L634-L643)
- driver.go: Parse MAX_VOLUMES_PER_NODE env var via util.GetEnvAsInt (referenced from k8s [here](https://github.com/kubernetes/kubernetes/blob/release-1.36/pkg/util/env/env.go))
- node.go: Add MaxVolumesPerNode field to S3NodeServer, returns in NodeGetInfo

Tests:
- Unit test: Very basic passthrough verification and parsing logic test adapted from k8s [env_test.go](https://github.com/kubernetes/kubernetes/blob/v1.36.2/pkg/util/env/env_test.go)
- E2E test: Adapted from [upstream volumelimits.go](https://github.com/kubernetes/kubernetes/blob/v1.36.2/test/e2e/storage/testsuites/volumelimits.go) for our existing static provisioning pattern
  - "should support volume limits" - fill node to capacity, extra pod should be rejected
  - "should admit a pod reusing an already-mounted PV without counting it twice" - fills node to capacity, node that uses existing PV should be accepted. (volume sharing case)
  - "should verify that all csinodes have volume limits" - deployment health check

#### Important follow-up PR after this PR merges
- Prevent / Warn users when they have non-unique volumeHandles (map based on PV name in pod sharing PR doesn't encapsulate volumeHandles, but we can reference some of the restart guarantees in the PR to write similar map including volumeHandles to repopulate on restart)

#### Important Notes
- For Karpenter integration - this startup taint might be needed for race condition where pods are scheduled into node before the driver starts advertising the maxVolumesPerNode volume limit.
```yaml
      startupTaints:
        - key: s3.csi.aws.com/agent-not-ready
          effect: NoSchedule
```
- Upgrade note: switching an existing node from pod mode to daemonset mode updates the advertised limit correctly - [kubelet overwrites CSINode.allocatable.count](https://github.com/kubernetes/kubernetes/blob/bbedc834eb4e2509cb913a5e0dcf5236fab6fac9/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go#L619) on driver re-registration, when performing helm upgrade. Verified in this test:
  - Deployed in pod mode, and added 10 s3 workloads
  - helm upgrade to daemonset mode (volume limit 4), and added 1 s3 workload
  - All pod mode workload pods stay working, and the new s3 workload in daemonset mode Pending state with reason "FailedScheduling".


---

### Additional Context

#### Motivation

In current pod mode, per-mount resources are per-PV volumeAttributes (`mountpointContainerResourcesRequestsMemory`, `cacheEphemeralStorageResourceRequest`) and the scheduler sees each Mountpoint pod individually. In daemonset architecture, all Mountpoint processes share a daemonset pod with fixed resource budget. Without a volume limit (per node), the scheduler, with no visibility into per-mount resource usage, would keep placing workloads until the mount resources are exhausted (e.g. OOM when out of RAM, or fills disk with emptyDir cache). We decided to use `MaxVolumesPerNode` to mitigate this problem.

Alternatives considered:
- Driver computes via memory per mount - but it forces all mounts to use identical resources, and is in conflict with PV --memory-target for example.
- [DRA consumable capacity](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#consumable-capacity) - but `ResourceClaims` are pod-scoped so pod-sharing mounts are double-counted, and requires mutating webhook.
- Upstream KEP for multi-dimensional volume limits - extend `CSINode.Allocatable` from a flat count to resource budgets, and add per-PV cost to `PersistentVolumeSpec` so scheduler sums costs instead of counting. Significant upstream changes required (CSI spec, k8s API, scheduler changes) and is something we could still consider if configuring `MaxVolumesPerNode` is a big pain point for customers.

#### `maxVolumesPerNode` flow

Data path of maxVolumesPerNode flow (with AI help finding the path)
- Helm value (`maxVolumesPerNode: 10`)
- -> [node.yaml template](./charts/aws-mountpoint-s3-csi-driver/templates/node.yaml) (env `MAX_VOLUMES_PER_NODE=10`)
- -> [driver.go](./pkg/driver/driver.go) parses `maxVolumesPerNode`
- -> [node.go NodeGetInfo](./pkg/driver/node/node.go) ([docs](https://github.com/container-storage-interface/spec/blob/master/spec.md#nodegetinfo)) returns `MaxVolumesPerNode: ns.MaxVolumesPerNode`
- -> [kubelet calls NodeGetInfo](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/volume/csi/csi_plugin.go#L149) and gets `maxVolumePerNode`
- -> [kubelet writes `CSINode.allocatable.count`](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/volume/csi/csi_plugin.go#L157): through [`InstallCSIDriver`](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go#L112), [`updateCSINode`](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go#L360), [`tryUpdateCSINode`](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go#L385), [`installDriverToCSINode`](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go#L591), and writes allocatable count in [`driverSpec.Allocatable = &storagev1.VolumeNodeResources{Count: &m}`](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go#L639-L640)
- -> [scheduler reads `allocatable.count`](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go#L204)
- -> [scheduler rejects](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go#L348) pods when volume count is over the limit
- Autoscalers' responses
  - -> [Karpenter gets the volume limit in populateVolumeLimits](https://github.com/kubernetes-sigs/karpenter/blob/43964dc54782bc68f15b7da6414c50931dadd07b/pkg/controllers/state/cluster.go#L845-L857), and [Karpenter actions based on `ExceedsLimits`](https://github.com/kubernetes-sigs/karpenter/blob/43964dc54782bc68f15b7da6414c50931dadd07b/pkg/scheduling/volumeusage.go#L201-L208)
  - -> [KEP-5030: Integrate Volume Attach limit into cluster autoscaler](https://github.com/kubernetes/enhancements/tree/master/keps/sig-autoscaling/5030-attach-limit-autoscaler) allows Cluster Autoscaler to be aware of volume limits.

#### Unique volumeHandles needed

For this feature to work, volumeHandles must be unique. This is because for static provisioning, k8s count PVs with their volumeHandles in [nodevolumelimits/csi.go](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go#L499), and uses `fmt.Sprintf("%s/%s", driverName, volumeHandle)
` in [getVolumeUniqueName](https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go#L688).

### Misc Notes

- Node pod limit can be queried if we want via instance metadata: [source of formula](https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/internal/kubelet/eni_max_pods.go): instanceInfo.DefaultMaxENIs*(instanceInfo.Ipv4AddressesPerInterface-1) + 2

#### Note for Reviewer(s)

Some follow-ups / TODOs:
- Prevent / Warn users when they have non-unique volumeHandles (map based on PV name in pod sharing PR doesn't encapsulate volumeHandles, but we can reference some of the restart guarantees in the PR to write similar map including volumeHandles to repopulate on restart)
- Warn if maxMountsPerNode * --max-memory-target exceeds the pod resources.requests.memory - TODO as a follow up task after memory limit is integrated with daemonset architecture
- Add documentation for volume limits (we might want to do this as part of follow up too since we need to clarify user experience on it)

For Reviewer: Things to consider when reviewing:
- Unit test doesn't test much - do we need driver_test.go?
- Copies from k8s package - I tried to follow existing test suites (e.g. multivolumes.go) porting from k8s testsuite to our static provisioning integration tests, but perhaps we can further simplify the test file. My thinking was to reduce the changes from the original in case we later support dynamic provisioning which would mean we can use the original testsuites adding our new (e.g. pod sharing) tests for volume limits.
  - 1 pod N PVs in integration test, or 10 pod each with 1 PV? (chosen 1 pod N PVs for simplicity / match k8s volumelimits.go testsuite)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
