### PR TITLE
Improve source mount recovery reliability

### DIFF
--- a/cmd/aws-s3-csi-mounter/main.go
+++ b/cmd/aws-s3-csi-mounter/main.go
@@ -23,7 +23,6 @@ import (
 	utillog "github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/log"
 )
 
-var mountSockRecvTimeout = flag.Duration("mount-sock-recv-timeout", 2*time.Minute, "Timeout for receiving mount options from passed Unix socket.")
 var mountpointBinDir = flag.String("mountpoint-bin-dir", os.Getenv("MOUNTPOINT_BIN_DIR"), "Directory of mount-s3 binary.")
 
 var mountSockPath = mppod.PathInsideMountpointPod(mppod.KnownPathMountSock)
@@ -31,6 +30,8 @@ var mountExitPath = mppod.PathInsideMountpointPod(mppod.KnownPathMountExit)
 var mountErrorPath = mppod.PathInsideMountpointPod(mppod.KnownPathMountError)
 
 const mountpointBin = "mount-s3"
+
+const exitFilePollInterval = 5 * time.Second
 
 func main() {
 	utillog.InitKlog()
@@ -70,9 +71,27 @@ func main() {
 }
 
 func recvMountOptions() (mountoptions.Options, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), *mountSockRecvTimeout)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	klog.Infof("Trying to receive mount options from %s", mountSockPath)
+
+	// Poll for exit file in the background — if the CSI node signals us to stop
+	// (e.g., workload was removed), cancel the context so we don't wait forever.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(exitFilePollInterval):
+				if csimounter.ShouldExitWithSuccessCode(mountExitPath) {
+					klog.Info("Detected `mount.exit` file while waiting for mount options, canceling")
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+
+	klog.Infof("Trying to receive mount options from %s (no timeout, waiting for options or exit file)", mountSockPath)
 	options, err := mountoptions.Recv(ctx, mountSockPath)
 	if err != nil {
 		return mountoptions.Options{}, err

--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -4,6 +4,7 @@ package mounter
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"k8s.io/klog/v2"
 	mountutils "k8s.io/mount-utils"
@@ -85,10 +86,23 @@ func (m *Mounter) Unmount(target Target) error {
 // This is achieved by calling the `mountutils.List()` method to enumerate all mount points.
 func (m *Mounter) CheckMountpoint(target Target) (bool, error) {
 	if err := statx(target); err != nil {
+		klog.Warningf("CheckMountpoint: statx(%q) failed: %v", target, err)
 		return false, err
 	}
+	klog.V(5).Infof("CheckMountpoint: statx(%q) succeeded", target)
+
+	// statx succeeds on dead FUSE mounts (cached inode), but open() triggers
+	// the FUSE opendir path and returns ENOTCONN if the daemon is gone.
+	f, openErr := os.Open(target)
+	if openErr != nil {
+		klog.Warningf("CheckMountpoint: mount %q appears stale (open failed: %v), treating as corrupted", target, openErr)
+		return false, openErr
+	}
+	f.Close()
+	klog.V(5).Infof("CheckMountpoint: Open(%q) succeeded", target)
 
 	isMountPoint, err := m.mount.IsMountPoint(target)
+	klog.V(5).Infof("CheckMountpoint: IsMountPoint(%q) = %v, err=%v", target, isMountPoint, err)
 	if err != nil {
 		return false, err
 	}
@@ -103,14 +117,16 @@ func (m *Mounter) CheckMountpoint(target Target) (bool, error) {
 
 	for _, mp := range mountPoints {
 		if mp.Path == target {
+			klog.V(5).Infof("CheckMountpoint: found mount entry for %q: device=%q", target, mp.Device)
 			if mp.Device != fsName {
-				klog.Infof("mounter: %q is a %q mount, but %q is expected, ignoring", target, mp.Device, fsName)
+				klog.V(5).Infof("mounter: %q is a %q mount, but %q is expected, ignoring", target, mp.Device, fsName)
 				continue
 			}
 			return true, nil
 		}
 	}
 
+	klog.V(5).Infof("CheckMountpoint: %q is a mount point but no matching entry found in mount list", target)
 	return false, nil
 }
 

--- a/pkg/mountpoint/mountoptions/mount_options.go
+++ b/pkg/mountpoint/mountoptions/mount_options.go
@@ -115,19 +115,27 @@ func Recv(ctx context.Context, sockPath string) (Options, error) {
 	if err != nil {
 		return Options{}, fmt.Errorf("failed to listen unix socket %s: %w", sockPath, err)
 	}
-	defer l.Close()
 
-	// `l.Accept` does not respect `ctx`'s deadline, we need to call `ul.SetDeadline` to ensure `l.Accept` has a deadline.
-	if deadline, ok := ctx.Deadline(); ok {
-		ul := l.(*net.UnixListener)
-		err := ul.SetDeadline(deadline)
-		if err != nil {
-			return Options{}, fmt.Errorf("failed to set deadline on unix socket %s: %w", sockPath, err)
+	// Close the listener when ctx is canceled to unblock Accept,
+	// or when Recv completes normally. Ensures exactly one Close call
+	// and no goroutine leak.
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			l.Close()
+		case <-done:
+			l.Close()
 		}
-	}
+	}()
 
 	conn, err := l.Accept()
 	if err != nil {
+		if ctx.Err() != nil {
+			return Options{}, ctx.Err()
+		}
 		return Options{}, fmt.Errorf("failed to accept connection from unix socket %s: %w", sockPath, err)
 	}
 

--- a/pkg/mountpoint/mountoptions/mount_options_test.go
+++ b/pkg/mountpoint/mountoptions/mount_options_test.go
@@ -199,6 +199,35 @@ func mustMarshal(t *testing.T, v any) []byte {
 	return data
 }
 
+func TestRecvExitsOnContextCancel(t *testing.T) {
+	basePath := t.TempDir()
+	t.Chdir(basePath)
+	mountSock := filepath.Join(basePath, "m")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := mountoptions.Recv(ctx, mountSock)
+		errCh <- err
+	}()
+
+	// Give Recv time to start listening.
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel the context — Recv should return promptly.
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Recv did not return after context cancellation")
+	}
+}
+
 const defaultTimeout = 10 * time.Second
 
 func defaultContext(t *testing.T) context.Context {

--- a/tests/e2e-kubernetes/testsuites/pod_sharing.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing.go
@@ -356,6 +356,57 @@ func (t *s3CSIPodSharingTestSuite) DefineTests(driver storageframework.TestDrive
 			checkExecInPodSucceed(ctx, f, pods[0], "cat /mnt/volume1/terminating.txt | grep -q 'terminating'")
 		})
 
+		ginkgo.It("should recover mount for new workload after Mountpoint process crash", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			ginkgo.By("Creating first workload pod with continuous mount access")
+			pod1 := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			// Continuously access the mount to keep kernel FUSE dentry cache warm.
+			// This reproduces the scenario where lstat on the source mount
+			// succeeds (served from cache) even though the FUSE daemon is dead.
+			pod1.Spec.Containers[0].Command = []string{"/bin/sh"}
+			pod1.Spec.Containers[0].Args = []string{"-c", "while true; do cat /mnt/volume1/file.txt 2>/dev/null || true; sleep 1; done"}
+			pod1, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod1)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(e2epod.DeletePodWithWait, f.ClientSet, pod1)
+			targetNode := pod1.Spec.NodeName
+
+			ginkgo.By("Verifying first pod has a healthy mount")
+			checkWriteToPathSucceed(ctx, f, pod1, "/mnt/volume1/file.txt", 1024, time.Now().UTC().UnixNano())
+
+			ginkgo.By("Crashing the Mountpoint process")
+			crashMountpointForVolume(ctx, f, resource.Pv.Name)
+
+			ginkgo.By("Verifying first pod's mount is broken")
+			framework.Gomega().Eventually(ctx, func() error {
+				return e2epod.VerifyExecInPodSucceed(ctx, f, pod1, "ls /mnt/volume1")
+			}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).ShouldNot(gomega.Succeed())
+
+			ginkgo.By("Waiting for Mountpoint Pod to restart and be Running")
+			mpPods, err := findMountpointPods(ctx, f.ClientSet, resource.Pv.Name)
+			framework.ExpectNoError(err)
+			gomega.Expect(mpPods).ToNot(gomega.BeEmpty())
+			framework.Gomega().Eventually(ctx, func() bool {
+				mpPod, err := f.ClientSet.CoreV1().Pods(mountpointNamespace).Get(ctx, mpPods[0].Name, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				return mpPod.Status.Phase == v1.PodRunning
+			}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(gomega.BeTrue())
+
+			ginkgo.By("Creating second workload pod on the same node")
+			pod2 := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			pod2, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod2)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(e2epod.DeletePodWithWait, f.ClientSet, pod2)
+
+			ginkgo.By("Verifying second pod has a healthy mount")
+			seed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pod2, "/mnt/volume1/after-crash.txt", 1024, seed)
+			checkReadFromPathSucceed(ctx, f, pod2, "/mnt/volume1/after-crash.txt", 1024, seed)
+		})
+
 		// Regression test for race condition fixed in https://github.com/awslabs/mountpoint-s3-csi-driver/pull/652
 		// This test was previously failing intermittently before the fix.
 		//
@@ -615,6 +666,40 @@ func defaultExpectedFields(nodeName string, pv *v1.PersistentVolume) map[string]
 		"AuthenticationSource": "driver",
 		"WorkloadFSGroup":      "",
 	}
+}
+
+// crashMountpointForVolume kills the mount-s3 process inside the Mountpoint Pod serving the given volume.
+func crashMountpointForVolume(ctx context.Context, f *framework.Framework, volumeName string) {
+	mpPods, err := findMountpointPods(ctx, f.ClientSet, volumeName)
+	framework.ExpectNoError(err)
+	gomega.Expect(mpPods).ToNot(gomega.BeEmpty(), "no Mountpoint pods found for volume %s", volumeName)
+
+	mpPod := mpPods[0]
+	framework.Logf("Killing mount-s3 process in Mountpoint Pod %s/%s", mpPod.Namespace, mpPod.Name)
+
+	// Find and kill the mount-s3 child process (not PID 1 which is aws-s3-csi-mounter).
+	// We iterate /proc to find the mount-s3 process by its cmdline.
+	killCmd := `for pid in $(ls /proc/ | grep -E '^[0-9]+$'); do
+		if [ "$pid" != "1" ] && cat /proc/$pid/cmdline 2>/dev/null | tr '\0' ' ' | grep -q mount-s3; then
+			kill -9 $pid
+			echo "killed $pid"
+			exit 0
+		fi
+	done
+	echo "mount-s3 process not found"
+	exit 1`
+
+	stdout, stderr, err := e2epod.ExecWithOptions(f, e2epod.ExecOptions{
+		Command:            []string{"/bin/sh", "-c", killCmd},
+		Namespace:          mpPod.Namespace,
+		PodName:            mpPod.Name,
+		ContainerName:      "mountpoint",
+		CaptureStdout:      true,
+		CaptureStderr:      true,
+		PreserveWhitespace: false,
+	})
+	framework.Logf("Kill result: stdout=%q stderr=%q err=%v", stdout, stderr, err)
+	framework.ExpectNoError(err, "failed to kill mount-s3 process in pod %s", mpPod.Name)
 }
 
 func checkCrossReadWrite(ctx context.Context, f *framework.Framework, pod1, pod2 *v1.Pod) {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

1. Add a test for mount recovery. Note that the workload continuously accesses (`cat /mnt/volume1/file.txt`) the dead mount, which might be a rare scenario. 
2. Update `CheckMountpoint` to detect dead mount when the `stat(target)` is cached in kernel
3. Update behaviour of `aws-s3-csi-mounter` when waiting for mount options: instead of exiting and restarting (which might result in failed mount attempts, when backoff becomes large), it continues running until an `.exit` file was placed by `csi-node` 
 
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
