### PR TITLE
Sharing mountpoint processes changes

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -125,7 +125,15 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 		klog.Info("Using daemonset mounter mode")
 		klog.Info("Note: s3-csi-daemonset-mounter uses OnDelete update strategy - helm upgrade will not restart/upgrade mounter pods automatically")
 
-		dm := mounter.NewDaemonsetMounter(clientset, nodeID, mpmounter.New(), credProvider, nil)
+		dm := mounter.NewDaemonsetMounter(clientset, nodeID, mpmounter.New(), credProvider, nil, nil, nil)
+
+		// Rebuild mount map from persisted .meta.json files + kernel mount table.
+		// Fatal on failure: operating with an empty map while FUSE mounts exist
+		// would cause duplicate mounts or incorrect unmounts.
+		if err := dm.RebuildMountMap(); err != nil {
+			klog.Fatalf("Failed to rebuild mount map from disk: %v", err)
+		}
+
 		if err := dm.DiscoverCommDir(context.Background()); err != nil {
 			klog.Fatalf("Failed to discover mounter pod: %v", err)
 		}

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -28,6 +28,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -36,8 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-
-	k8sstrings "k8s.io/utils/strings"
 
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
@@ -79,6 +78,12 @@ var (
 // mountSyscallFunc performs the FUSE mount and returns the fd. Injectable for testing.
 type mountSyscallFunc func(target string, opts mpmounter.MountOptions) (int, error)
 
+// bindMountSyscallFunc performs a bind mount. Injectable for testing.
+type bindMountSyscallFunc func(source, target string) error
+
+// mountInfoProviderFunc reads the kernel mount table. Injectable for testing.
+type mountInfoProviderFunc func() ([]mountInfoEntry, error)
+
 // DaemonsetMounter is a [Mounter] that delegates Mountpoint process management
 // to a secondary daemonset running on the same node. It communicates via the
 // secondary pod's emptyDir volume, accessed through the kubelet pod directory.
@@ -95,183 +100,244 @@ type DaemonsetMounter struct {
 	rediscoverCh chan struct{}
 
 	// Injectable for testing. nil = use default.
-	mountSyscall mountSyscallFunc
+	mountSyscall      mountSyscallFunc
+	bindMountSyscall  bindMountSyscallFunc
+	mountInfoProvider mountInfoProviderFunc
+
+	// mountMap tracks shared source mounts for pod-sharing.
+	// Mount/Unmount use reference-counted sharing via this map.
+	mountMap *MountMap
 }
 
 // NewDaemonsetMounter creates a new [DaemonsetMounter].
-// mountSyscall may be nil, in which case the default FUSE mount implementation is used.
+// mountSyscall, bindMountSyscall, and mountInfoProvider may be nil,
+// in which case the default implementations are used.
 func NewDaemonsetMounter(clientset kubernetes.Interface, nodeID string, mount *mpmounter.Mounter,
-	credProvider credentialprovider.ProviderInterface, mountSyscall mountSyscallFunc) *DaemonsetMounter {
+	credProvider credentialprovider.ProviderInterface, mountSyscall mountSyscallFunc, bindMountSyscall bindMountSyscallFunc, mountInfoProvider mountInfoProviderFunc) *DaemonsetMounter {
 	return &DaemonsetMounter{
-		clientset:    clientset,
-		nodeID:       nodeID,
-		kubeletPath:  util.ContainerKubeletPath(),
-		mount:        mount,
-		credProvider: credProvider,
-		rediscoverCh: make(chan struct{}, 1),
-		mountSyscall: mountSyscall,
+		clientset:         clientset,
+		nodeID:            nodeID,
+		kubeletPath:       util.ContainerKubeletPath(),
+		mount:             mount,
+		credProvider:      credProvider,
+		rediscoverCh:      make(chan struct{}, 1),
+		mountSyscall:      mountSyscall,
+		bindMountSyscall:  bindMountSyscall,
+		mountInfoProvider: mountInfoProvider,
+		mountMap:          NewMountMap(),
 	}
 }
 
-// Mount mounts the given S3 bucket at the target path.
+// Mount mounts the given S3 bucket at the target path with pod-sharing support.
 //
-// It performs the following steps:
-//  1. Provides credentials for the mount
-//  2. Opens /dev/fuse and performs the kernel FUSE mount on target
-//  3. Sends mount options (including FUSE FD) to the secondary daemonset via UDS
-//  4. Waits for Mountpoint to start serving (or an error)
+// Flow:
+//  1. If target is already mounted (republish): refresh credentials without locking, return early
+//  2. Acquire per-volume lock via MountMap (serializes concurrent NodePublishVolume for same PV)
+//  3. Provision credentials (under lock to avoid race with cleanup on failure)
+//  4. If an existing healthy source mount exists for this volumeID → bind mount to target
+//  5. If no source exists (or dead) → FUSE mount at source path, send FD to mounter, wait for readiness
+//  6. Bind mount source → target
+//  7. Track the target in MountMap for refcounting
+//
+// On initial mount failure (fuseMount or bindMount), credentials are cleaned up immediately
+// under the lock. On unmount of last consumer, the FUSE source is unmounted (causing mount-s3
+// to exit via kernel FUSE teardown) and credentials are removed.
 func (dm *DaemonsetMounter) Mount(ctx context.Context, bucketName string, target string,
 	credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string, userEnv envprovider.Environment) error {
-	mountId, err := GetMountId(target)
-	if err != nil {
-		return err
-	}
-	volumeId := credentialCtx.VolumeID
-	mountSuccess := false
 
-	commDir, err := dm.GetCommDir()
+	// Extract PV name from target path to use as the volume identifier for sharing and filesystem paths.
+	// PV names are Kubernetes resource names — guaranteed DNS-safe (no '/', no '..', alphanumeric + '-' + '.').
+	// Target path format: /var/lib/kubelet/pods/<podUID>/volumes/kubernetes.io~csi/<pv-name>/mount
+	parsedTarget, err := targetpath.Parse(target)
 	if err != nil {
-		return fmt.Errorf("failed to find s3-csi-daemonset-mounter pod: %w. %s", err, helpMessageForCheckingMounterPodStatus())
+		return fmt.Errorf("failed to parse target path %q: %w", target, err)
 	}
+	volumeID := parsedTarget.VolumeID // This is the PV name
 
-	alreadyMounted, err := dm.IsMountPoint(target)
+	// Idempotency: if target is already a healthy Mountpoint mount, refresh creds and return.
+	// Kubelet may call NodePublishVolume repeatedly (requiresRepublish, retries).
+	isMounted, err := dm.IsMountPoint(target)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("failed to check if target %q is a mount point (mount target is possibly"+
 			" corrupted, manual pod re-creation %s might be required for mount recovery): %w",
 			target, credentialCtx.WorkloadPodID, err)
 	}
-
-	// Cleanup provisioned credentials only if this is a new mount (not a republish) and mount failed
-	defer func() {
-		if alreadyMounted || mountSuccess {
-			return
+	if isMounted {
+		// Republish: refresh credentials for the existing mount (token rotation).
+		commDir, err := dm.GetCommDir()
+		if err == nil {
+			if _, err := dm.provideCredentials(ctx, commDir, volumeID, &credentialCtx); err != nil {
+				klog.Errorf("DaemonsetMounter: failed to refresh credentials on republish for %s: %v", target, err)
+			}
 		}
-		if err := dm.cleanupCredentials(commDir, mountId, credentialCtx.ToCleanupCtx()); err != nil {
-			klog.Errorf("DaemonsetMounter: failed to clean up credential directory for mount %s: %v", mountId, err)
-		}
-	}()
-
-	// Provision credentials before the alreadyMounted early return so republish refreshes them
-	credsEnv, err := dm.provideCredentials(ctx, commDir, mountId, &credentialCtx)
-	if err != nil {
-		return err
-	}
-
-	// Idempotency: if target is already a healthy Mountpoint mount, return early
-	if alreadyMounted {
 		klog.V(4).Infof("DaemonsetMounter: target %s is already mounted, credentials refreshed", target)
-		mountSuccess = true
 		return nil
 	}
 
-	// Ensure target directory exists (kubelet may not have created it yet)
-	if err := os.MkdirAll(target, targetDirPerm); err != nil {
-		return fmt.Errorf("failed to create target directory %q: %w", target, err)
-	}
-
-	defer func() {
-		if mountSuccess {
-			return
-		}
-		// TODO(vlaad): might leak a mount, implement periodic stale mount cleanup
-		if umErr := dm.mount.Unmount(target); umErr != nil {
-			klog.Errorf("Failed to unmount %q during cleanup: %v", target, umErr)
-		}
-	}()
-
-	// Perform FUSE mount and send options to secondary daemonset
-	if err := dm.mountS3AtTarget(ctx, target, bucketName, args, mountId, volumeId, commDir, userEnv, credsEnv); err != nil {
-		return err
-	}
-
-	mountSuccess = true
-	klog.V(4).Infof("DaemonsetMounter: volume %s (mount %s) mounted at %s", volumeId, mountId, target)
-	return nil
+	// Pod-sharing: use MountMap to share a single Mountpoint process per volume.
+	// Credential provisioning happens inside mountOrShareSource under the per-volume lock
+	// to avoid races between concurrent NodePublishVolume calls for the same PV.
+	return dm.mountOrShareSource(ctx, bucketName, target, volumeID, credentialCtx, args, fsGroup, userEnv)
 }
 
-// Unmount unmounts the FUSE filesystem at target.
-// This causes the Mountpoint process in the secondary daemonset to exit.
-func (dm *DaemonsetMounter) Unmount(ctx context.Context, target string, cleanupCtx credentialprovider.CleanupContext) error {
-	// cleanup the error file and credentials
+// mountOrShareSource implements the pod-sharing Mount flow using MountMap.
+func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName string, target string,
+	volumeID string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string, userEnv envprovider.Environment) error {
+
+	// Get or create the per-volume entry, then lock it.
+	// Retry loop ensures we hold the canonical entry — not one orphaned by a concurrent unmount/delete.
+	var entry *MountEntry
+	for {
+		entry, _ = dm.mountMap.GetOrCreate(volumeID)
+		entry.mu.Lock()
+		if dm.mountMap.Get(volumeID) == entry {
+			break // we hold the canonical entry
+		}
+		entry.mu.Unlock() // orphaned entry (deleted by concurrent unmount), retry
+	}
+	defer entry.mu.Unlock()
+
+	// Provision credentials under the lock to avoid races between concurrent
+	// NodePublishVolume calls for the same PV (all share one credential file).
 	commDir, err := dm.GetCommDir()
 	if err != nil {
-		return fmt.Errorf("failed to find s3-csi-daemonset-mounter pod: %w. %s", err, helpMessageForCheckingMounterPodStatus())
+		return fmt.Errorf("connection to s3-csi-daemonset-mounter not yet established, allowing kubelet to retry NodePublishVolume: %w. %s", err, helpMessageForCheckingMounterPodStatus())
 	}
-	mountId, err := GetMountId(target)
+	credsEnv, err := dm.provideCredentials(ctx, commDir, volumeID, &credentialCtx)
 	if err != nil {
 		return err
 	}
 
-	if err = removeIfExists(filepath.Join(commDir, GetErrorFileName(mountId))); err != nil {
-		return fmt.Errorf("failed to remove the error file: %w", err)
+	// Build mount params for this request — used for validation and stored on first mount.
+	incomingParams := MountParams{
+		MountOptions:             args.SortedList(),
+		AuthenticationSource:     credentialCtx.AuthenticationSource,
+		ServiceAccountName:       credentialCtx.ServiceAccountName,
+		ServiceAccountEKSRoleARN: credentialCtx.ServiceAccountEKSRoleARN,
+		PodNamespace:             credentialCtx.PodNamespace,
+		FSGroup:                  fsGroup,
 	}
 
-	err = dm.cleanupCredentials(commDir, mountId, cleanupCtx)
-	if err != nil {
-		return fmt.Errorf("failed to cleanup credentials: %w", err)
+	sourcePath := SourceMountPath(dm.kubeletPath, volumeID)
+
+	if entry.initialized {
+		// Existing source — validate compatibility before sharing.
+		if err := entry.Params.ValidateCompatibility(&incomingParams); err != nil {
+			return fmt.Errorf("cannot share mount for volume %s: %w", volumeID, err)
+		}
+
+		// Check health before sharing.
+		if dm.IsSourceHealthy(entry.SourcePath) {
+			// Healthy source: bind mount to new target.
+			if err := dm.BindMount(entry.SourcePath, target); err != nil {
+				return err
+			}
+			entry.RefCount++
+			entry.Targets = append(entry.Targets, target)
+			klog.V(4).Infof("DaemonsetMounter: shared existing mount for volume %s → %s (refcount=%d)",
+				volumeID, target, entry.RefCount)
+			return nil
+		}
+		// Dead source: clean up and fall through to new mount.
+		klog.V(2).Infof("DaemonsetMounter: source %s is dead for volume %s, recovering", entry.SourcePath, volumeID)
+		if err := dm.mount.Unmount(entry.SourcePath); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to unmount dead source %q for volume %s, will retry: %w", entry.SourcePath, volumeID, err)
+			}
+		}
+		os.Remove(entry.SourcePath)
+		entry.initialized = false
 	}
 
-	// finally unmount (this order ensures retrying cleanup)
-	err = dm.mount.Unmount(target)
-	if err != nil {
-		return fmt.Errorf("failed to unmount %q: %w", target, err)
+	// New mount: FUSE mount at source, then bind to target.
+	mountId := volumeID // In sharing mode, one mount per volume
+	if err := dm.fuseMount(ctx, bucketName, sourcePath, mountId, args, userEnv, credsEnv); err != nil {
+		dm.cleanupCredentials(commDir, volumeID, credentialCtx.ToCleanupCtx())
+		return err
 	}
 
-	klog.V(4).Infof("DaemonsetMounter: volume %s unmounted from %s", cleanupCtx.VolumeID, target)
+	// Bind mount source → target.
+	if err := dm.BindMount(sourcePath, target); err != nil {
+		// Cleanup source and credentials on bind failure.
+		dm.mount.Unmount(sourcePath)
+		os.Remove(sourcePath)
+		dm.cleanupCredentials(commDir, volumeID, credentialCtx.ToCleanupCtx())
+		return err
+	}
+
+	// Populate the entry.
+	entry.SourcePath = sourcePath
+	entry.MountID = mountId
+	entry.Params = incomingParams
+	entry.RefCount = 1
+	entry.Targets = []string{target}
+	entry.initialized = true
+
+	// Persist meta to disk for recovery after driver restart.
+	if err := WriteMeta(dm.kubeletPath, entry); err != nil {
+		klog.Errorf("DaemonsetMounter: failed to write meta for volume %s: %v (non-fatal)", volumeID, err)
+	}
+
+	klog.V(4).Infof("DaemonsetMounter: new shared mount for volume %s at source %s → %s", volumeID, sourcePath, target)
 	return nil
 }
 
-// IsMountPoint returns whether the given target is a Mountpoint mount.
-func (dm *DaemonsetMounter) IsMountPoint(target string) (bool, error) {
-	return dm.mount.CheckMountpoint(target)
-}
+// fuseMount performs the FUSE mount + FD send + wait cycle at the given path.
+// Credentials are already provisioned by the caller (Mount).
+func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mountPath string,
+	mountId string, args mountpoint.Args, userEnv envprovider.Environment, credsEnv envprovider.Environment) error {
 
-// mountS3AtTarget performs the kernel FUSE mount at target and sends mount options
-// (including the FUSE fd) to the secondary daemonset. On success the mount remains
-// at target; on failure any partial mount is cleaned up.
-func (dm *DaemonsetMounter) mountS3AtTarget(ctx context.Context, target string, bucketName string,
-	args mountpoint.Args, mountId string, volumeId string, commDir string,
-	userEnv envprovider.Environment, credsEnv envprovider.Environment) error {
-	// Remove old error file if exists
-	errFilePath := filepath.Join(commDir, GetErrorFileName(mountId))
-	if err := removeIfExists(errFilePath); err != nil {
-		return fmt.Errorf("failed to remove stale error file %q: %w", errFilePath, err)
+	commDir, err := dm.GetCommDir()
+	if err != nil {
+		return fmt.Errorf("connection to s3-csi-daemonset-mounter not yet established, allowing kubelet to retry NodePublishVolume: %w. %s", err, helpMessageForCheckingMounterPodStatus())
+	}
+
+	if err := os.MkdirAll(mountPath, targetDirPerm); err != nil {
+		return fmt.Errorf("failed to create mount directory %q: %w", mountPath, err)
 	}
 
 	mountOpts := mpmounter.MountOptions{
 		ReadOnly:   args.Has(mountpoint.ArgReadOnly),
 		AllowOther: args.Has(mountpoint.ArgAllowOther) || args.Has(mountpoint.ArgAllowRoot),
 	}
-	fd, err := dm.mountSyscallWithDefault(target, mountOpts)
+	fd, err := dm.mountSyscallWithDefault(mountPath, mountOpts)
 	if err != nil {
-		return fmt.Errorf("failed to mount FUSE at %q: %w", target, err)
+		return fmt.Errorf("failed to mount FUSE at %q: %w", mountPath, err)
 	}
+
+	fdClosed := false
+	unmount := true
 	defer func() {
-		if err := mpmounter.CloseFD(fd); err != nil {
-			klog.Errorf("DaemonsetMounter: failed to close /dev/fuse fd %d: %v", fd, err)
+		if !fdClosed {
+			dm.closeFUSEDevFD(fd)
+		}
+		if unmount {
+			if umErr := dm.mount.Unmount(mountPath); umErr != nil {
+				klog.Errorf("Failed to unmount %q during cleanup: %v", mountPath, umErr)
+			}
 		}
 	}()
 
-	// TODO: add --user-agent-prefix for S3 request telemetry
+	args.Remove(mountpoint.ArgReadOnly)
 
-	// Build environment
 	env := envprovider.Environment{}
 	env.Merge(userEnv)
 	env.Merge(envprovider.Default())
 	env.Merge(credsEnv)
 
-	// Move --aws-max-attempts to env if provided
 	if maxAttempts, ok := args.Remove(mountpoint.ArgAWSMaxAttempts); ok {
 		env.Set(envprovider.EnvMaxAttempts, maxAttempts)
 	}
-	// Remove read-only from args since we already passed MS_RDONLY in mount syscall
-	args.Remove(mountpoint.ArgReadOnly)
 
-	// Send mount options to secondary daemonset
 	sockPath := filepath.Join(commDir, MountSockName)
-	klog.V(4).Infof("DaemonsetMounter: sending mount options for volume %s (mount %s) to %s", volumeId, mountId, sockPath)
+	errFilePath := filepath.Join(commDir, GetErrorFileName(mountId))
+	os.Remove(errFilePath)
+
+	klog.V(4).Infof("DaemonsetMounter: sending mount options (mount %s) to %s", mountId, sockPath)
+
 	sendCtx, sendCancel := context.WithTimeout(ctx, sendOptionsTimeout)
 	defer sendCancel()
+
 	err = mountoptions.Send(sendCtx, sockPath, mountoptions.Options{
 		Fd:         fd,
 		BucketName: bucketName,
@@ -280,8 +346,6 @@ func (dm *DaemonsetMounter) mountS3AtTarget(ctx context.Context, target string, 
 		VolumeId:   mountId,
 	})
 	if err != nil {
-		// If send failed due to stale path, signal re-discovery and let Kubelet retry NodePublishVolume.
-		// Send -> dialWithRetry retries ENOENT/ECONNREFUSED, so we only check these errors
 		if errors.Is(err, fs.ErrNotExist) || os.IsPermission(err) || errors.Is(err, context.DeadlineExceeded) {
 			klog.V(4).Infof("DaemonsetMounter: comm dir may be stale, signaling re-discovery")
 			dm.commDir.Store(nil)
@@ -290,52 +354,147 @@ func (dm *DaemonsetMounter) mountS3AtTarget(ctx context.Context, target string, 
 			default:
 			}
 		}
-		return fmt.Errorf("failed to send mount options for volume %s (mount %s): %w. %s", volumeId, mountId, err, helpMessageForGettingMounterLogs())
+		return fmt.Errorf("failed to send mount options (mount %s): %w. %s", mountId, err, helpMessageForGettingMounterLogs())
 	}
 
-	// Wait for mount readiness or error
-	err = dm.waitForMount(ctx, target, mountId, errFilePath)
+	dm.closeFUSEDevFD(fd)
+	fdClosed = true
+
+	err = dm.waitForMount(ctx, mountPath, mountId, errFilePath)
 	if err != nil {
 		return err
 	}
 
+	unmount = false
 	return nil
 }
 
-// waitForMount waits until Mountpoint is serving at target or an error occurs.
-func (dm *DaemonsetMounter) waitForMount(parentCtx context.Context, target, mountId, errFilePath string) error {
-	ctx, cancel := context.WithTimeout(parentCtx, mountReadyTimeout)
-	defer cancel()
+// Unmount unmounts the target path with pod-sharing awareness.
+//
+// Flow:
+//   - Unmounts the bind mount at target
+//   - Decrements refcount in MountMap
+//   - If refcount reaches 0, unmounts the FUSE source and removes the entry
+func (dm *DaemonsetMounter) Unmount(ctx context.Context, target string, credentialCtx credentialprovider.CleanupContext) error {
+	parsedTarget, err := targetpath.Parse(target)
+	if err != nil {
+		return fmt.Errorf("failed to parse target path %q: %w", target, err)
+	}
+	volumeID := parsedTarget.VolumeID // This is the PV name
+	return dm.releaseTarget(target, volumeID)
+}
 
-	mountResultCh := make(chan error, 2)
+// releaseTarget handles the Unmount flow with MountMap refcounting.
+func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string) error {
+	entry := dm.mountMap.Get(volumeID)
+	if entry == nil {
+		// No entry means we never mounted this volume. Return success (idempotency).
+		klog.V(4).Infof("DaemonsetMounter: no mount map entry for volume %s, unmount of %s is a no-op", volumeID, target)
+		return nil
+	}
 
-	// Poll for error file
-	go func() {
-		wait.PollUntilContextCancel(ctx, mountReadyPollInterval, true, func(ctx context.Context) (bool, error) {
-			content, err := os.ReadFile(errFilePath)
-			if err != nil {
-				return false, nil
-			}
-			os.Remove(errFilePath)
-			mountResultCh <- fmt.Errorf("Mountpoint for mount %s failed: %s", mountId, string(content))
-			return true, nil
-		})
-	}()
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
 
-	// Poll for mount readiness
-	go func() {
-		err := wait.PollUntilContextCancel(ctx, mountReadyPollInterval, true, func(ctx context.Context) (bool, error) {
-			isMounted, _ := dm.mount.CheckMountpoint(target)
-			return isMounted, nil
-		})
-		if err != nil {
-			mountResultCh <- fmt.Errorf("timed out waiting for Mountpoint to serve mount %s at %s. %s", mountId, target, helpMessageForGettingMounterLogs())
-		} else {
-			mountResultCh <- nil
+	// Unmount the bind mount at target.
+	if err := dm.mount.Unmount(target); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to unmount bind mount at %q: %w", target, err)
 		}
-	}()
+	}
 
-	return <-mountResultCh
+	// Remove target from entry.
+	for i, t := range entry.Targets {
+		if t == target {
+			entry.Targets = append(entry.Targets[:i], entry.Targets[i+1:]...)
+			entry.RefCount--
+			break
+		}
+	}
+
+	if entry.RefCount == 0 {
+		// Last consumer: clean up credentials first, then unmount the FUSE source.
+		klog.V(4).Infof("DaemonsetMounter: last consumer for volume %s, unmounting source %s", volumeID, entry.SourcePath)
+
+		// Clean up error file and credentials before unmount (ensures retrying cleanup on failure).
+		if dir := dm.commDir.Load(); dir != nil {
+			os.Remove(filepath.Join(*dir, GetErrorFileName(entry.MountID)))
+			if err := dm.cleanupCredentials(*dir, entry.MountID, credentialprovider.CleanupContext{
+				VolumeID:  volumeID,
+				MountKind: credentialprovider.MountKindDaemonset,
+			}); err != nil {
+				klog.Errorf("DaemonsetMounter: failed to cleanup credentials for volume %s: %v", volumeID, err)
+			}
+		}
+
+		// Unmount FUSE source — causes mount-s3 to exit via kernel FUSE teardown.
+		if err := dm.mount.Unmount(entry.SourcePath); err != nil {
+			klog.Errorf("DaemonsetMounter: failed to unmount source %q: %v (best-effort cleanup)", entry.SourcePath, err)
+		}
+		os.Remove(entry.SourcePath)
+
+		// Delete entry from the map — the retry loop in Mount handles the race.
+		dm.mountMap.Delete(volumeID)
+
+		// Remove persisted meta file.
+		RemoveMeta(dm.kubeletPath, volumeID)
+	}
+
+	klog.V(4).Infof("DaemonsetMounter: volume %s unmounted from %s", volumeID, target)
+	return nil
+}
+
+// GetErrorFileName returns the error file name for a given mount ID.
+func GetErrorFileName(mountId string) string {
+	return mountId + MountErrorSuffix
+}
+
+// helpMessageForGettingMounterLogs returns a help message with a command to get mounter logs.
+func helpMessageForGettingMounterLogs() string {
+	return fmt.Sprintf("You can see mounter logs by running: `kubectl logs -n %s -l app=s3-csi-daemonset-mounter`", mounterNamespace)
+}
+
+// helpMessageForCheckingMounterPodStatus returns a help message with a command to check mounter pod status.
+func helpMessageForCheckingMounterPodStatus() string {
+	return fmt.Sprintf("You can check mounter pod status by running: `kubectl get pods -n %s -l app=s3-csi-daemonset-mounter`", mounterNamespace)
+}
+
+// IsMountPoint returns whether the given target is a Mountpoint mount.
+func (dm *DaemonsetMounter) IsMountPoint(target string) (bool, error) {
+	return dm.mount.CheckMountpoint(target)
+}
+
+// IsSourceHealthy checks if the FUSE mount at sourcePath is alive and serving.
+
+func (dm *DaemonsetMounter) IsSourceHealthy(sourcePath string) bool {
+	return dm.mount.IsHealthyMountpoint(sourcePath)
+}
+
+// BindMount performs a bind mount from source to target, creating the target directory if needed.
+func (dm *DaemonsetMounter) BindMount(source, target string) error {
+	if err := os.MkdirAll(target, targetDirPerm); err != nil {
+		return fmt.Errorf("failed to create bind mount target directory %q: %w", target, err)
+	}
+	if err := dm.bindMountSyscallWithDefault(source, target); err != nil {
+		return fmt.Errorf("failed to bind mount %q → %q: %w", source, target, err)
+	}
+	klog.V(4).Infof("DaemonsetMounter: bind mounted %s → %s", source, target)
+	return nil
+}
+
+// bindMountSyscallWithDefault delegates to bindMountSyscall if set, or falls back to dm.mount.BindMount.
+func (dm *DaemonsetMounter) bindMountSyscallWithDefault(source, target string) error {
+	if dm.bindMountSyscall != nil {
+		return dm.bindMountSyscall(source, target)
+	}
+	return dm.mount.BindMount(source, target)
+}
+
+// TODO: refactor closeFUSEDevFD into a shared helper (duplicated in pod_mounter.go)
+func (dm *DaemonsetMounter) closeFUSEDevFD(fd int) {
+	if err := mpmounter.CloseFD(fd); err != nil {
+		klog.V(4).Infof("DaemonsetMounter: failed to close /dev/fuse fd %d: %v", fd, err)
+	}
 }
 
 // mountSyscallWithDefault delegates to mountSyscall if set, or falls back to dm.mount.Mount.
@@ -375,43 +534,6 @@ func (dm *DaemonsetMounter) cleanupCredentials(commDir, mountId string, cleanupC
 		return err
 	}
 	return nil
-}
-
-// GetMountId returns a filesystem-safe mount ID derived from the target path.
-// It uses the pod UID and PV name from the kubelet target path structure:
-//
-//	.../pods/<pod-uid>/volumes/kubernetes.io~csi/<pv-name>/mount
-//
-// Both components are escaped as defense in depth against unexpected characters.
-func GetMountId(target string) (string, error) {
-	tp, err := targetpath.Parse(target)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse target path %q: %w", target, err)
-	}
-	return k8sstrings.EscapeQualifiedName(tp.PodID) + "-" + k8sstrings.EscapeQualifiedName(tp.VolumeID), nil
-}
-
-// GetErrorFileName returns the error file name for a given mount ID.
-func GetErrorFileName(mountId string) string {
-	return mountId + MountErrorSuffix
-}
-
-// removeIfExists removes a file, ignoring "not exist" errors.
-func removeIfExists(path string) error {
-	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-	return nil
-}
-
-// helpMessageForGettingMounterLogs returns a help message with a command to get mounter logs.
-func helpMessageForGettingMounterLogs() string {
-	return fmt.Sprintf("You can see mounter logs by running: `kubectl logs -n %s -l app=s3-csi-daemonset-mounter`", mounterNamespace)
-}
-
-// helpMessageForCheckingMounterPodStatus returns a help message with a command to check mounter pod status.
-func helpMessageForCheckingMounterPodStatus() string {
-	return fmt.Sprintf("You can check mounter pod status by running: `kubectl get pods -n %s -l app=s3-csi-daemonset-mounter`", mounterNamespace)
 }
 
 // DiscoverCommDir discovers the comm dir path synchronously with retries.
@@ -502,6 +624,100 @@ func (dm *DaemonsetMounter) GetCommDir() (string, error) {
 	return *dir, nil
 }
 
+// KubeletPath returns the kubelet path used by this mounter.
+func (dm *DaemonsetMounter) KubeletPath() string {
+	return dm.kubeletPath
+}
+
+// mountInfoProviderWithDefault delegates to mountInfoProvider if set, or falls back to parseMountInfoFromProc.
+func (dm *DaemonsetMounter) mountInfoProviderWithDefault() ([]mountInfoEntry, error) {
+	if dm.mountInfoProvider != nil {
+		return dm.mountInfoProvider()
+	}
+	return parseMountInfoFromProc()
+}
+
+// RebuildMountMap reconstructs the MountMap from disk on driver startup.
+// It scans the meta directory for .meta.json files, verifies each source mount
+// is still alive via /proc/self/mountinfo, and counts bind mounts (targets) by
+// matching device IDs.
+//
+// Algorithm:
+//  1. List all .meta.json files in the plugins/s3.csi.aws.com/mnt/ directory
+//  2. For each meta file, parse the JSON to get MountMeta
+//  3. Scan /proc/self/mountinfo to find the source mount and its device ID
+//  4. Count bind mounts sharing that device ID (these are the targets)
+//  5. Populate MountMap entries with refcount = number of bind mounts
+//
+// Entries with dead source mounts are skipped (meta file cleaned up).
+func (dm *DaemonsetMounter) RebuildMountMap() error {
+	metaDir := filepath.Join(dm.kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
+	entries, err := os.ReadDir(metaDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			klog.V(4).Info("MountMap: no meta directory found, starting fresh")
+			return nil
+		}
+		return fmt.Errorf("failed to read meta directory %s: %w", metaDir, err)
+	}
+
+	// Parse mount table once
+	mountInfos, err := dm.mountInfoProviderWithDefault()
+	if err != nil {
+		return fmt.Errorf("failed to parse /proc/self/mountinfo: %w", err)
+	}
+
+	for _, dirEntry := range entries {
+		if !strings.HasSuffix(dirEntry.Name(), ".meta.json") {
+			continue
+		}
+
+		metaPath := filepath.Join(metaDir, dirEntry.Name())
+		meta, err := readMeta(metaPath)
+		if err != nil {
+			klog.Warningf("MountMap: failed to read meta file %s, skipping: %v", metaPath, err)
+			continue
+		}
+
+		// Derive SourcePath and MountID from VolumeID (they are not persisted)
+		sourcePath := SourceMountPath(dm.kubeletPath, meta.VolumeID)
+		mountID := meta.VolumeID // MountID == VolumeID in sharing mode
+
+		// Find the source mount in mountinfo
+		sourceMI := findMountByPath(mountInfos, sourcePath)
+		if sourceMI == nil {
+			// Source mount is gone — clean up the meta file
+			klog.V(2).Infof("MountMap: source mount %s for volume %s not found in mount table, cleaning up", sourcePath, meta.VolumeID)
+			os.Remove(metaPath)
+			continue
+		}
+
+		// Count bind mounts sharing the same device ID (major:minor)
+		targets := findBindMountTargets(mountInfos, sourceMI.DeviceID, sourcePath)
+
+		entry, _ := dm.mountMap.GetOrCreate(meta.VolumeID)
+		entry.mu.Lock()
+		entry.SourcePath = sourcePath
+		entry.MountID = mountID
+		entry.Params = MountParams{
+			MountOptions:             meta.MountOptions,
+			AuthenticationSource:     meta.AuthenticationSource,
+			ServiceAccountName:       meta.ServiceAccountName,
+			ServiceAccountEKSRoleARN: meta.ServiceAccountEKSRoleARN,
+			PodNamespace:             meta.PodNamespace,
+			FSGroup:                  meta.FSGroup,
+		}
+		entry.RefCount = len(targets)
+		entry.Targets = targets
+		entry.initialized = true
+		entry.mu.Unlock()
+
+		klog.V(2).Infof("MountMap: recovered volume %s with %d targets from mount table", meta.VolumeID, len(targets))
+	}
+
+	return nil
+}
+
 // tryDiscoverCommDir performs a single attempt to find the secondary mounter pod on
 // this node and returns the path to its emptyDir comm volume as seen from the
 // primary daemonset (via kubelet pod dir).
@@ -532,4 +748,40 @@ func (dm *DaemonsetMounter) tryDiscoverCommDir(ctx context.Context) (string, err
 	commDir := filepath.Join(dm.kubeletPath, "pods", podUID, "volumes", "kubernetes.io~empty-dir", CommVolumeName)
 	klog.V(4).Infof("DaemonsetMounter: discovered mounter pod %s (uid=%s), comm dir: %s", running[0].Name, podUID, commDir)
 	return commDir, nil
+}
+
+// waitForMount waits until Mountpoint is serving at target or an error occurs.
+func (dm *DaemonsetMounter) waitForMount(parentCtx context.Context, target, mountId, errFilePath string) error {
+	ctx, cancel := context.WithTimeout(parentCtx, mountReadyTimeout)
+	defer cancel()
+
+	mountResultCh := make(chan error, 2)
+
+	// Poll for error file
+	go func() {
+		wait.PollUntilContextCancel(ctx, mountReadyPollInterval, true, func(ctx context.Context) (bool, error) {
+			content, err := os.ReadFile(errFilePath)
+			if err != nil {
+				return false, nil
+			}
+			os.Remove(errFilePath)
+			mountResultCh <- fmt.Errorf("Mountpoint for mount %s failed: %s", mountId, string(content))
+			return true, nil
+		})
+	}()
+
+	// Poll for mount readiness
+	go func() {
+		err := wait.PollUntilContextCancel(ctx, mountReadyPollInterval, true, func(ctx context.Context) (bool, error) {
+			isMounted, _ := dm.mount.CheckMountpoint(target)
+			return isMounted, nil
+		})
+		if err != nil {
+			mountResultCh <- fmt.Errorf("timed out waiting for Mountpoint to serve mount %s at %s. %s", mountId, target, helpMessageForGettingMounterLogs())
+		} else {
+			mountResultCh <- nil
+		}
+	}()
+
+	return <-mountResultCh
 }

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -250,7 +250,6 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	}
 
 	// New mount: FUSE mount at source, then bind to target.
-	mountId := volumeID // In sharing mode, one mount per volume
 
 	// Persist meta to disk BEFORE mounting so that RebuildMountMap can find this volume
 	// if the driver crashes between fuseMount and the end of this function. If the mount
@@ -262,7 +261,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 		klog.Errorf("DaemonsetMounter: failed to write meta for volume %s: %v (non-fatal)", volumeID, err)
 	}
 
-	if err := dm.fuseMount(ctx, bucketName, sourcePath, mountId, args, userEnv, credsEnv); err != nil {
+	if err := dm.fuseMount(ctx, bucketName, sourcePath, volumeID, args, userEnv, credsEnv); err != nil {
 		dm.cleanupCredentials(commDir, volumeID, credentialCtx.ToCleanupCtx())
 		dm.mountMap.Delete(volumeID)
 		RemoveMeta(dm.kubeletPath, volumeID)
@@ -282,7 +281,6 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 
 	// Populate the entry.
 	entry.SourcePath = sourcePath
-	entry.MountID = mountId
 	entry.RefCount = 1
 	entry.Targets = []string{target}
 	entry.initialized = true
@@ -294,7 +292,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 // fuseMount performs the FUSE mount + FD send + wait cycle at the given path.
 // Credentials are already provisioned by the caller (Mount).
 func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mountPath string,
-	mountId string, args mountpoint.Args, userEnv envprovider.Environment, credsEnv envprovider.Environment) error {
+	volumeID string, args mountpoint.Args, userEnv envprovider.Environment, credsEnv envprovider.Environment) error {
 
 	commDir, err := dm.GetCommDir()
 	if err != nil {
@@ -339,10 +337,10 @@ func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mo
 	}
 
 	sockPath := filepath.Join(commDir, MountSockName)
-	errFilePath := filepath.Join(commDir, GetErrorFileName(mountId))
+	errFilePath := filepath.Join(commDir, GetErrorFileName(volumeID))
 	os.Remove(errFilePath)
 
-	klog.V(4).Infof("DaemonsetMounter: sending mount options (mount %s) to %s", mountId, sockPath)
+	klog.V(4).Infof("DaemonsetMounter: sending mount options (mount %s) to %s", volumeID, sockPath)
 
 	sendCtx, sendCancel := context.WithTimeout(ctx, sendOptionsTimeout)
 	defer sendCancel()
@@ -352,7 +350,7 @@ func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mo
 		BucketName: bucketName,
 		Args:       args.SortedList(),
 		Env:        env.List(),
-		VolumeId:   mountId,
+		VolumeId:   volumeID,
 	})
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) || os.IsPermission(err) || errors.Is(err, context.DeadlineExceeded) {
@@ -363,13 +361,13 @@ func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mo
 			default:
 			}
 		}
-		return fmt.Errorf("failed to send mount options (mount %s): %w. %s", mountId, err, helpMessageForGettingMounterLogs())
+		return fmt.Errorf("failed to send mount options (mount %s): %w. %s", volumeID, err, helpMessageForGettingMounterLogs())
 	}
 
 	dm.closeFUSEDevFD(fd)
 	fdClosed = true
 
-	err = dm.waitForMount(ctx, mountPath, mountId, errFilePath)
+	err = dm.waitForMount(ctx, mountPath, volumeID, errFilePath)
 	if err != nil {
 		return err
 	}
@@ -427,8 +425,8 @@ func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string) error 
 
 		// Clean up error file and credentials before unmount (ensures retrying cleanup on failure).
 		if dir := dm.commDir.Load(); dir != nil {
-			os.Remove(filepath.Join(*dir, GetErrorFileName(entry.MountID)))
-			if err := dm.cleanupCredentials(*dir, entry.MountID, credentialprovider.CleanupContext{
+			os.Remove(filepath.Join(*dir, GetErrorFileName(entry.VolumeID)))
+			if err := dm.cleanupCredentials(*dir, entry.VolumeID, credentialprovider.CleanupContext{
 				VolumeID:  volumeID,
 				MountKind: credentialprovider.MountKindDaemonset,
 			}); err != nil {
@@ -453,9 +451,9 @@ func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string) error 
 	return nil
 }
 
-// GetErrorFileName returns the error file name for a given mount ID.
-func GetErrorFileName(mountId string) string {
-	return mountId + MountErrorSuffix
+// GetErrorFileName returns the error file name for a given volume ID.
+func GetErrorFileName(volumeID string) string {
+	return volumeID + MountErrorSuffix
 }
 
 // helpMessageForGettingMounterLogs returns a help message with a command to get mounter logs.
@@ -515,25 +513,25 @@ func (dm *DaemonsetMounter) mountSyscallWithDefault(target string, opts mpmounte
 }
 
 // provideCredentials creates a per-mount credential directory and provisions credentials into it.
-func (dm *DaemonsetMounter) provideCredentials(ctx context.Context, commDir, mountId string, credentialCtx *credentialprovider.ProvideContext) (envprovider.Environment, error) {
-	mountCredDir := filepath.Join(commDir, mountId)
+func (dm *DaemonsetMounter) provideCredentials(ctx context.Context, commDir, volumeID string, credentialCtx *credentialprovider.ProvideContext) (envprovider.Environment, error) {
+	mountCredDir := filepath.Join(commDir, volumeID)
 	if err := os.MkdirAll(mountCredDir, credentialprovider.CredentialDirPerm); err != nil {
 		return nil, fmt.Errorf("failed to create credential directory %q: %w", mountCredDir, err)
 	}
 	credentialCtx.WritePath = mountCredDir
-	credentialCtx.EnvPath = filepath.Join("/comm", mountId)
+	credentialCtx.EnvPath = filepath.Join("/comm", volumeID)
 	credentialCtx.MountKind = credentialprovider.MountKindDaemonset
 
 	env, _, err := dm.credProvider.Provide(ctx, *credentialCtx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to provide credentials for mount %s: %w", mountId, err)
+		return nil, fmt.Errorf("failed to provide credentials for mount %s: %w", volumeID, err)
 	}
 	return env, nil
 }
 
 // cleanupCredentials removes the per-mount credential directory.
-func (dm *DaemonsetMounter) cleanupCredentials(commDir, mountId string, cleanupCtx credentialprovider.CleanupContext) error {
-	mountCredDir := filepath.Join(commDir, mountId)
+func (dm *DaemonsetMounter) cleanupCredentials(commDir, volumeID string, cleanupCtx credentialprovider.CleanupContext) error {
+	mountCredDir := filepath.Join(commDir, volumeID)
 	cleanupCtx.WritePath = mountCredDir
 	cleanupCtx.MountKind = credentialprovider.MountKindDaemonset
 	if err := dm.credProvider.Cleanup(cleanupCtx); err != nil {
@@ -688,9 +686,8 @@ func (dm *DaemonsetMounter) RebuildMountMap() error {
 			continue
 		}
 
-		// Derive SourcePath and MountID from VolumeID (they are not persisted)
+		// Derive SourcePath from VolumeID (not persisted, always computable)
 		sourcePath := SourceMountPath(dm.kubeletPath, meta.VolumeID)
-		mountID := meta.VolumeID // MountID == VolumeID in sharing mode
 
 		// Find the source mount in mountinfo
 		sourceMI := findMountByPath(mountInfos, sourcePath)
@@ -707,7 +704,6 @@ func (dm *DaemonsetMounter) RebuildMountMap() error {
 		entry, _ := dm.mountMap.GetOrCreate(meta.VolumeID)
 		entry.mu.Lock()
 		entry.SourcePath = sourcePath
-		entry.MountID = mountID
 		entry.Params = MountParams{
 			MountOptions:             meta.MountOptions,
 			AuthenticationSource:     meta.AuthenticationSource,
@@ -760,7 +756,7 @@ func (dm *DaemonsetMounter) tryDiscoverCommDir(ctx context.Context) (string, err
 }
 
 // waitForMount waits until Mountpoint is serving at target or an error occurs.
-func (dm *DaemonsetMounter) waitForMount(parentCtx context.Context, target, mountId, errFilePath string) error {
+func (dm *DaemonsetMounter) waitForMount(parentCtx context.Context, target, volumeID, errFilePath string) error {
 	ctx, cancel := context.WithTimeout(parentCtx, mountReadyTimeout)
 	defer cancel()
 
@@ -774,7 +770,7 @@ func (dm *DaemonsetMounter) waitForMount(parentCtx context.Context, target, moun
 				return false, nil
 			}
 			os.Remove(errFilePath)
-			mountResultCh <- fmt.Errorf("Mountpoint for mount %s failed: %s", mountId, string(content))
+			mountResultCh <- fmt.Errorf("Mountpoint for mount %s failed: %s", volumeID, string(content))
 			return true, nil
 		})
 	}()
@@ -786,7 +782,7 @@ func (dm *DaemonsetMounter) waitForMount(parentCtx context.Context, target, moun
 			return isMounted, nil
 		})
 		if err != nil {
-			mountResultCh <- fmt.Errorf("timed out waiting for Mountpoint to serve mount %s at %s. %s", mountId, target, helpMessageForGettingMounterLogs())
+			mountResultCh <- fmt.Errorf("timed out waiting for Mountpoint to serve mount %s at %s. %s", volumeID, target, helpMessageForGettingMounterLogs())
 		} else {
 			mountResultCh <- nil
 		}

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -251,32 +251,41 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 
 	// New mount: FUSE mount at source, then bind to target.
 	mountId := volumeID // In sharing mode, one mount per volume
+
+	// Persist meta to disk BEFORE mounting so that RebuildMountMap can find this volume
+	// if the driver crashes between fuseMount and the end of this function. If the mount
+	// fails, we clean up the meta file. An orphan meta file (crash after meta-write but
+	// before fuseMount) is harmless — RebuildMountMap detects no matching mount in
+	// /proc/self/mountinfo and deletes the stale meta file.
+	entry.Params = incomingParams
+	if err := WriteMeta(dm.kubeletPath, entry); err != nil {
+		klog.Errorf("DaemonsetMounter: failed to write meta for volume %s: %v (non-fatal)", volumeID, err)
+	}
+
 	if err := dm.fuseMount(ctx, bucketName, sourcePath, mountId, args, userEnv, credsEnv); err != nil {
 		dm.cleanupCredentials(commDir, volumeID, credentialCtx.ToCleanupCtx())
+		dm.mountMap.Delete(volumeID)
+		RemoveMeta(dm.kubeletPath, volumeID)
 		return err
 	}
 
 	// Bind mount source → target.
 	if err := dm.BindMount(sourcePath, target); err != nil {
-		// Cleanup source and credentials on bind failure.
+		// Cleanup source, credentials, map entry, and meta on bind failure.
 		dm.mount.Unmount(sourcePath)
 		os.Remove(sourcePath)
 		dm.cleanupCredentials(commDir, volumeID, credentialCtx.ToCleanupCtx())
+		dm.mountMap.Delete(volumeID)
+		RemoveMeta(dm.kubeletPath, volumeID)
 		return err
 	}
 
 	// Populate the entry.
 	entry.SourcePath = sourcePath
 	entry.MountID = mountId
-	entry.Params = incomingParams
 	entry.RefCount = 1
 	entry.Targets = []string{target}
 	entry.initialized = true
-
-	// Persist meta to disk for recovery after driver restart.
-	if err := WriteMeta(dm.kubeletPath, entry); err != nil {
-		klog.Errorf("DaemonsetMounter: failed to write meta for volume %s: %v (non-fatal)", volumeID, err)
-	}
 
 	klog.V(4).Infof("DaemonsetMounter: new shared mount for volume %s at source %s → %s", volumeID, sourcePath, target)
 	return nil

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -133,15 +133,15 @@ func NewDaemonsetMounter(clientset kubernetes.Interface, nodeID string, mount *m
 //
 // Flow:
 //  1. Acquire per-volume lock via MountMap (serializes concurrent NodePublishVolume for same PV)
-//  2. If entry is initialized, check source health:
+//  2. If source is mounted, check source health:
 //     - Dead source → tear down and reset entry to allow fresh mount
 //     - Healthy source → validate compatibility (reject incompatible params before any cred writes)
-//  3. If not initialized (fresh or recovered from dead): write meta, set SourcePath/CommDir
+//  3. If source not mounted (fresh or recovered from dead): write meta, set SourcePath/CommDir
 //  4. Provision credentials (under lock to avoid race with cleanup on failure)
 //  5. If target is already mounted (republish/retry): creds refreshed above, return early
-//  6. If entry is initialized (healthy source) → bind mount to new target, bump refcount
-//  7. If not initialized → FUSE mount at source, send FD to mounter, wait for readiness,
-//     bind mount source → target, mark entry initialized
+//  6. If source is mounted (healthy source) → bind mount to new target, bump refcount
+//  7. If source not mounted → FUSE mount at source, send FD to mounter, wait for readiness,
+//     bind mount source → target, mark source as mounted
 //
 // On initial mount failure (fuseMount or bindMount), credentials are cleaned up immediately
 // under the lock. On unmount of last consumer, the FUSE source is unmounted (causing mount-s3
@@ -199,15 +199,15 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 		FSGroup:                  fsGroup,
 	}
 
-	// If entry is initialized, check health first. Dead source = tear down and treat as fresh.
+	// If source is mounted, check health first. Dead source = tear down and treat as fresh.
 	// Only enforce compatibility on a healthy (living) source.
-	if entry.initialized {
+	if entry.sourceMounted {
 		if !dm.IsSourceHealthy(entry.SourcePath) {
 			// Dead source — tear down and allow fresh mount with any params.
 			klog.V(2).Infof("DaemonsetMounter: source %s is dead for volume %s, resetting entry for fresh mount", entry.SourcePath, volumeID)
 			dm.mount.Unmount(entry.SourcePath)
 			os.Remove(entry.SourcePath)
-			entry.initialized = false
+			entry.sourceMounted = false
 		} else {
 			// Healthy source — enforce compatibility before any credential writes.
 			if err := entry.Params.ValidateCompatibility(&incomingParams); err != nil {
@@ -216,7 +216,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 		}
 	}
 
-	if !entry.initialized {
+	if !entry.sourceMounted {
 		// New mount (or recovered from dead source): write meta BEFORE credentials.
 		entry.Params = incomingParams
 		entry.SourcePath = SourceMountPath(dm.kubeletPath, volumeID)
@@ -227,8 +227,8 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	}
 
 	// Provision credentials under the lock. We use the fresh commDir (from GetCommDir at the
-	// top of Mount) for all publish operations. When entry is initialized (source healthy),
-	// commDir == entry.CommDir because the mounter pod hasn't restarted. When not initialized
+	// top of Mount) for all publish operations. When source is mounted (source healthy),
+	// commDir == entry.CommDir because the mounter pod hasn't restarted. When source not mounted
 	// (fresh mount or dead-source recovery), entry.CommDir is empty/stale, so the fresh
 	// commDir is the only valid path. Cleanup (releaseTarget) uses entry.CommDir to clean
 	// resources in the same location where they were originally created.
@@ -249,7 +249,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 		return nil
 	}
 
-	if entry.initialized {
+	if entry.sourceMounted {
 		// Source was confirmed healthy above. Bind mount to new target.
 		if err := dm.BindMount(entry.SourcePath, target); err != nil {
 			return err
@@ -285,7 +285,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	// Populate entry — SourcePath and CommDir already set above.
 	entry.RefCount = 1
 	entry.Targets = []string{target}
-	entry.initialized = true
+	entry.sourceMounted = true
 
 	klog.V(4).Infof("DaemonsetMounter: new shared mount for volume %s at source %s → %s", volumeID, entry.SourcePath, target)
 	return nil
@@ -743,7 +743,7 @@ func (dm *DaemonsetMounter) RebuildMountMap() error {
 		}
 		entry.RefCount = len(targets)
 		entry.Targets = targets
-		entry.initialized = true
+		entry.sourceMounted = true
 		entry.mu.Unlock()
 
 		klog.V(2).Infof("MountMap: recovered volume %s with %d targets from mount table", meta.VolumeID, len(targets))

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -134,18 +134,22 @@ func NewDaemonsetMounter(clientset kubernetes.Interface, nodeID string, mount *m
 // Flow:
 //  1. Acquire per-volume lock via MountMap (serializes concurrent NodePublishVolume for same PV)
 //  2. If source is mounted, check source health:
-//     - Dead source → tear down and reset entry to allow fresh mount
+//     - Dead source → mark sourceMounted=false (fall through to step 3)
 //     - Healthy source → validate compatibility (reject incompatible params before any cred writes)
-//  3. If source not mounted (fresh or recovered from dead): write meta, set SourcePath/CommDir
+//  3. If source not mounted (fresh, dead-source recovery, or prior failed attempt):
+//     - Clean up any stale resources via cleanupMount (idempotent); fail mount if cleanup fails
+//     - Write meta file, set SourcePath/CommDir on the entry
 //  4. Provision credentials (under lock to avoid race with cleanup on failure)
 //  5. If target is already mounted (republish/retry): creds refreshed above, return early
-//  6. If source is mounted (healthy source) → bind mount to new target, bump refcount
-//  7. If source not mounted → FUSE mount at source, send FD to mounter, wait for readiness,
-//     bind mount source → target, mark source as mounted
+//  6. If source is mounted (healthy) → bind mount to new target, bump refcount
+//  7. If source not mounted → FUSE mount at source, bind mount source → target,
+//     set sourceMounted=true and refcount=1
 //
-// On initial mount failure (fuseMount or bindMount), credentials are cleaned up immediately
-// under the lock. On unmount of last consumer, the FUSE source is unmounted (causing mount-s3
-// to exit via kernel FUSE teardown) and credentials are removed.
+// Error handling:
+//   - If fuseMount or bindMount fails, cleanupMount is called. If cleanup succeeds,
+//     the map entry and meta file are removed (clean slate for next retry). If cleanup
+//     fails, the entry and meta are preserved so the next retry enters step 3 and
+//     retries cleanup before proceeding.
 func (dm *DaemonsetMounter) Mount(ctx context.Context, bucketName string, target string,
 	credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string, userEnv envprovider.Environment) error {
 

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -199,14 +199,11 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 		FSGroup:                  fsGroup,
 	}
 
-	// If source is mounted, check health first. Dead source = tear down and treat as fresh.
-	// Only enforce compatibility on a healthy (living) source.
+	// If source is mounted, check health first. Dead source = mark not mounted so we go
+	// through the fresh-mount path below. Only enforce compatibility on a healthy (living) source.
 	if entry.sourceMounted {
 		if !dm.IsSourceHealthy(entry.SourcePath) {
-			// Dead source — tear down and allow fresh mount with any params.
-			klog.V(2).Infof("DaemonsetMounter: source %s is dead for volume %s, resetting entry for fresh mount", entry.SourcePath, volumeID)
-			dm.mount.Unmount(entry.SourcePath)
-			os.Remove(entry.SourcePath)
+			klog.V(2).Infof("DaemonsetMounter: source %s is dead for volume %s, will clean up and re-mount", entry.SourcePath, volumeID)
 			entry.sourceMounted = false
 		} else {
 			// Healthy source — enforce compatibility before any credential writes.
@@ -217,7 +214,13 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	}
 
 	if !entry.sourceMounted {
-		// New mount (or recovered from dead source): write meta BEFORE credentials.
+		// Fresh mount: ensure no associated resources (credentials, error file, FUSE mount,
+		// source directory) are left behind from a previous attempt or dead source before
+		// creating new ones. cleanupMount is idempotent — safe when resources don't exist.
+		if cleanErr := dm.cleanupMount(entry, credentialCtx.ToCleanupCtx()); cleanErr != nil {
+			return fmt.Errorf("failed to clean up stale resources for volume %s, cannot proceed with fresh mount: %w", volumeID, cleanErr)
+		}
+
 		entry.Params = incomingParams
 		entry.SourcePath = SourceMountPath(dm.kubeletPath, volumeID)
 		entry.CommDir = commDir
@@ -266,6 +269,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	if err := dm.fuseMount(ctx, bucketName, entry.SourcePath, volumeID, commDir, args, userEnv, credsEnv); err != nil {
 		if cleanErr := dm.cleanupMount(entry, credentialCtx.ToCleanupCtx()); cleanErr != nil {
 			klog.Errorf("DaemonsetMounter: cleanup after fuseMount failure for volume %s: %v", volumeID, cleanErr)
+			return err
 		}
 		dm.mountMap.Delete(volumeID)
 		RemoveMeta(dm.kubeletPath, volumeID)
@@ -276,6 +280,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	if err := dm.BindMount(entry.SourcePath, target); err != nil {
 		if cleanErr := dm.cleanupMount(entry, credentialCtx.ToCleanupCtx()); cleanErr != nil {
 			klog.Errorf("DaemonsetMounter: cleanup after BindMount failure for volume %s: %v", volumeID, cleanErr)
+			return err
 		}
 		dm.mountMap.Delete(volumeID)
 		RemoveMeta(dm.kubeletPath, volumeID)
@@ -476,8 +481,8 @@ func (dm *DaemonsetMounter) cleanupMount(entry *MountEntry, credentialCtx creden
 		}
 	}
 
-	//[future] Clean cache dir
-	// [future] Verify no MP process running
+	//[TODO] Clean cache dir
+	//[TODO] Verify no MP process running
 
 	if len(errs) > 0 {
 		return fmt.Errorf("incomplete cleanup for volume %s (%d errors)", entry.VolumeID, len(errs))

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -206,7 +206,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	// If source is mounted, check health first. Dead source = mark not mounted so we go
 	// through the fresh-mount path below. Only enforce compatibility on a healthy (living) source.
 	if entry.sourceMounted {
-		if !dm.IsSourceHealthy(entry.SourcePath) {
+		if !dm.IsSourceHealthy(ctx, entry.SourcePath) {
 			klog.V(2).Infof("DaemonsetMounter: source %s is dead for volume %s, will clean up and re-mount", entry.SourcePath, volumeID)
 			entry.sourceMounted = false
 		} else {
@@ -233,13 +233,10 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 		}
 	}
 
-	// Provision credentials under the lock. We use the fresh commDir (from GetCommDir at the
-	// top of Mount) for all publish operations. When source is mounted (source healthy),
-	// commDir == entry.CommDir because the mounter pod hasn't restarted. When source not mounted
-	// (fresh mount or dead-source recovery), entry.CommDir is empty/stale, so the fresh
-	// commDir is the only valid path. Cleanup (releaseTarget) uses entry.CommDir to clean
-	// resources in the same location where they were originally created.
-	credsEnv, err := dm.provideCredentials(ctx, commDir, volumeID, &credentialCtx)
+	// Provision credentials under the lock. We always use entry.CommDir which is set above
+	// (either from an existing healthy entry, or freshly assigned from commDir on new mount).
+	// This ensures credentials are written to the same location that cleanup will look at.
+	credsEnv, err := dm.provideCredentials(ctx, entry.CommDir, volumeID, &credentialCtx)
 	if err != nil {
 		return err
 	}
@@ -399,7 +396,7 @@ func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string, creden
 		// successful RebuildMountMap recovery). Best-effort unmount the target in case a
 		// stale bind mount still exists in the kernel mount table.
 		klog.V(4).Infof("DaemonsetMounter: no mount map entry for volume %s, best-effort unmount of %s", volumeID, target)
-		if err := dm.mount.Unmount(target); err != nil && !os.IsNotExist(err) {
+		if err := dm.unmountIfMounted(target); err != nil {
 			klog.Errorf("DaemonsetMounter: best-effort unmount of untracked target %s failed: %v", target, err)
 		}
 		return nil
@@ -409,10 +406,8 @@ func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string, creden
 	defer entry.mu.Unlock()
 
 	// Unmount the bind mount at target.
-	if err := dm.mount.Unmount(target); err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to unmount bind mount at %q: %w", target, err)
-		}
+	if err := dm.unmountIfMounted(target); err != nil {
+		return fmt.Errorf("failed to unmount bind mount at %q: %w", target, err)
 	}
 
 	// Remove target from entry.
@@ -468,7 +463,7 @@ func (dm *DaemonsetMounter) cleanupMount(entry *MountEntry, credentialCtx creden
 
 	// Unmount FUSE source (causes mount-s3 to exit via kernel FUSE teardown)
 	if entry.SourcePath != "" {
-		if err := dm.mount.Unmount(entry.SourcePath); err != nil && !os.IsNotExist(err) {
+		if err := dm.unmountIfMounted(entry.SourcePath); err != nil {
 			klog.Errorf("DaemonsetMounter: unmount source %s: %v", entry.SourcePath, err)
 			errs = append(errs, err)
 		}
@@ -503,8 +498,18 @@ func (dm *DaemonsetMounter) IsMountPoint(target string) (bool, error) {
 }
 
 // IsSourceHealthy checks if the FUSE mount at sourcePath is alive and serving.
-func (dm *DaemonsetMounter) IsSourceHealthy(sourcePath string) bool {
-	return dm.mount.IsHealthyMountpoint(sourcePath)
+// Runs the check in a goroutine bounded by ctx to avoid blocking forever if
+// the FUSE daemon is alive but not reading from the fd (frozen).
+func (dm *DaemonsetMounter) IsSourceHealthy(ctx context.Context, sourcePath string) bool {
+	ch := make(chan bool, 1)
+	go func() { ch <- dm.mount.IsHealthyMountpoint(sourcePath) }()
+	select {
+	case healthy := <-ch:
+		return healthy
+	case <-ctx.Done():
+		klog.V(2).Infof("DaemonsetMounter: IsSourceHealthy timed out for %s, treating as dead", sourcePath)
+		return false
+	}
 }
 
 // BindMount performs a bind mount from source to target, creating the target directory if needed.
@@ -538,6 +543,24 @@ func (dm *DaemonsetMounter) mountSyscallWithDefault(target string, opts mpmounte
 		return dm.mountSyscall(target, opts)
 	}
 	return dm.mount.Mount(target, opts)
+}
+
+// unmountIfMounted checks whether the given path is a mountpoint and only issues an unmount
+// if it is currently mounted. This avoids errors from old util-linux versions that return
+// EINVAL when unmounting a path that is not a mount point.
+// Returns nil if the path is not mounted (intent already satisfied).
+func (dm *DaemonsetMounter) unmountIfMounted(target string) error {
+	isMounted, err := dm.mount.IsMountPoint(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // path doesn't exist — nothing to unmount
+		}
+		// IsMountPoint can return corrupted mount errors; attempt unmount anyway.
+		klog.V(4).Infof("DaemonsetMounter: mount check for %s returned error, attempting unmount: %v", target, err)
+	} else if !isMounted {
+		return nil // not in mount table — intent already satisfied
+	}
+	return dm.mount.Unmount(target)
 }
 
 // provideCredentials creates a per-mount credential directory and provisions credentials into it.
@@ -659,11 +682,6 @@ func (dm *DaemonsetMounter) GetCommDir() (string, error) {
 	return *dir, nil
 }
 
-// KubeletPath returns the kubelet path used by this mounter.
-func (dm *DaemonsetMounter) KubeletPath() string {
-	return dm.kubeletPath
-}
-
 // mountInfoProviderWithDefault delegates to mountInfoProvider if set, or falls back to parseMountInfoFromProc.
 func (dm *DaemonsetMounter) mountInfoProviderWithDefault() ([]mountutils.MountInfo, error) {
 	if dm.mountInfoProvider != nil {
@@ -672,13 +690,34 @@ func (dm *DaemonsetMounter) mountInfoProviderWithDefault() ([]mountutils.MountIn
 	return parseMountInfoFromProc()
 }
 
+// populateEntryFromMeta creates or retrieves the MountMap entry for the given volume
+// and fills it from persisted metadata and mount state.
+func (dm *DaemonsetMounter) populateEntryFromMeta(meta *MountMeta, sourcePath string, sourceMounted bool, targets []string) {
+	entry, _ := dm.mountMap.GetOrCreate(meta.VolumeID)
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	entry.SourcePath = sourcePath
+	entry.CommDir = meta.CommDir
+	entry.Params = MountParams{
+		MountOptions:             meta.MountOptions,
+		AuthenticationSource:     meta.AuthenticationSource,
+		ServiceAccountName:       meta.ServiceAccountName,
+		ServiceAccountEKSRoleARN: meta.ServiceAccountEKSRoleARN,
+		PodNamespace:             meta.PodNamespace,
+		FSGroup:                  meta.FSGroup,
+	}
+	entry.RefCount = len(targets)
+	entry.Targets = targets
+	entry.sourceMounted = sourceMounted
+}
+
 // RebuildMountMap reconstructs the MountMap from disk on driver startup.
 // It scans the meta directory for .meta.json files, verifies each source mount
 // is still alive via /proc/self/mountinfo, and counts bind mounts (targets) by
 // matching device IDs.
 //
 // Algorithm:
-//  1. List all .meta.json files in the plugins/s3.csi.aws.com/mnt/ directory
+//  1. List all .meta.json files in the plugins/s3.csi.aws.com/meta/ directory
 //  2. For each meta file, parse the JSON to get MountMeta
 //  3. Scan /proc/self/mountinfo to find the source mount and its device ID
 //  4. Count bind mounts sharing that device ID (these are the targets)
@@ -729,7 +768,10 @@ func (dm *DaemonsetMounter) RebuildMountMap() error {
 			}
 			cleanupCtx := credentialprovider.CleanupContext{VolumeID: meta.VolumeID}
 			if cleanErr := dm.cleanupMount(entry, cleanupCtx); cleanErr != nil {
-				klog.Errorf("MountMap: cleanup for dead volume %s failed: %v (keeping meta for retry)", meta.VolumeID, cleanErr)
+				klog.Errorf("MountMap: cleanup for dead volume %s failed: %v (keeping meta and map entry for retry)", meta.VolumeID, cleanErr)
+				// Store entry in the map so future NodePublish or periodic cleanup can
+				// retry cleanup using the original commDir where credentials were written.
+				dm.populateEntryFromMeta(meta, sourcePath, false, nil)
 				continue
 			}
 			os.Remove(metaPath)
@@ -739,22 +781,7 @@ func (dm *DaemonsetMounter) RebuildMountMap() error {
 		// Count bind mounts sharing the same device ID (major:minor)
 		targets := findBindMountTargets(mountInfos, deviceID(sourceMI), sourcePath)
 
-		entry, _ := dm.mountMap.GetOrCreate(meta.VolumeID)
-		entry.mu.Lock()
-		entry.SourcePath = sourcePath
-		entry.CommDir = meta.CommDir
-		entry.Params = MountParams{
-			MountOptions:             meta.MountOptions,
-			AuthenticationSource:     meta.AuthenticationSource,
-			ServiceAccountName:       meta.ServiceAccountName,
-			ServiceAccountEKSRoleARN: meta.ServiceAccountEKSRoleARN,
-			PodNamespace:             meta.PodNamespace,
-			FSGroup:                  meta.FSGroup,
-		}
-		entry.RefCount = len(targets)
-		entry.Targets = targets
-		entry.sourceMounted = true
-		entry.mu.Unlock()
+		dm.populateEntryFromMeta(meta, sourcePath, true, targets)
 
 		klog.V(2).Infof("MountMap: recovered volume %s with %d targets from mount table", meta.VolumeID, len(targets))
 	}

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -375,9 +375,9 @@ func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mo
 // Unmount unmounts the target path with pod-sharing awareness.
 //
 // Flow:
-//   - Unmounts the bind mount at target
-//   - Decrements refcount in MountMap
-//   - If refcount reaches 0, unmounts the FUSE source and removes the entry
+//  1. Unmounts the bind mount at target
+//  2. Decrements refcount in MountMap
+//  3. If refcount reaches 0, unmounts the FUSE source and removes the entry
 func (dm *DaemonsetMounter) Unmount(ctx context.Context, target string, credentialCtx credentialprovider.CleanupContext) error {
 	parsedTarget, err := targetpath.Parse(target)
 	if err != nil {
@@ -685,7 +685,7 @@ func (dm *DaemonsetMounter) mountInfoProviderWithDefault() ([]mountutils.MountIn
 //
 // Entries with dead source mounts are skipped (meta file cleaned up).
 func (dm *DaemonsetMounter) RebuildMountMap() error {
-	metaDir := filepath.Join(dm.kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
+	metaDir := filepath.Join(dm.kubeletPath, "plugins", "s3.csi.aws.com", "meta")
 	entries, err := os.ReadDir(metaDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -719,8 +719,18 @@ func (dm *DaemonsetMounter) RebuildMountMap() error {
 		// Find the source mount in mountinfo
 		sourceMI := findMountByPath(mountInfos, sourcePath)
 		if sourceMI == nil {
-			// Source mount is gone — clean up the meta file
+			// Source mount is gone — full cleanup of all resources before removing meta.
 			klog.V(2).Infof("MountMap: source mount %s for volume %s not found in mount table, cleaning up", sourcePath, meta.VolumeID)
+			entry := &MountEntry{
+				VolumeID:   meta.VolumeID,
+				SourcePath: sourcePath,
+				CommDir:    meta.CommDir,
+			}
+			cleanupCtx := credentialprovider.CleanupContext{VolumeID: meta.VolumeID}
+			if cleanErr := dm.cleanupMount(entry, cleanupCtx); cleanErr != nil {
+				klog.Errorf("MountMap: cleanup for dead volume %s failed: %v (keeping meta for retry)", meta.VolumeID, cleanErr)
+				continue
+			}
 			os.Remove(metaPath)
 			continue
 		}

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -503,7 +503,6 @@ func (dm *DaemonsetMounter) IsMountPoint(target string) (bool, error) {
 }
 
 // IsSourceHealthy checks if the FUSE mount at sourcePath is alive and serving.
-
 func (dm *DaemonsetMounter) IsSourceHealthy(sourcePath string) bool {
 	return dm.mount.IsHealthyMountpoint(sourcePath)
 }
@@ -527,8 +526,6 @@ func (dm *DaemonsetMounter) bindMountSyscallWithDefault(source, target string) e
 	}
 	return dm.mount.BindMount(source, target)
 }
-
-// TODO: refactor closeFUSEDevFD into a shared helper (duplicated in pod_mounter.go)
 func (dm *DaemonsetMounter) closeFUSEDevFD(fd int) {
 	if err := mpmounter.CloseFD(fd); err != nil {
 		klog.V(4).Infof("DaemonsetMounter: failed to close /dev/fuse fd %d: %v", fd, err)

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	mountutils "k8s.io/mount-utils"
 
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
@@ -82,7 +83,7 @@ type mountSyscallFunc func(target string, opts mpmounter.MountOptions) (int, err
 type bindMountSyscallFunc func(source, target string) error
 
 // mountInfoProviderFunc reads the kernel mount table. Injectable for testing.
-type mountInfoProviderFunc func() ([]mountInfoEntry, error)
+type mountInfoProviderFunc func() ([]mountutils.MountInfo, error)
 
 // DaemonsetMounter is a [Mounter] that delegates Mountpoint process management
 // to a secondary daemonset running on the same node. It communicates via the
@@ -154,35 +155,23 @@ func (dm *DaemonsetMounter) Mount(ctx context.Context, bucketName string, target
 	}
 	volumeID := parsedTarget.VolumeID // This is the PV name
 
-	// Idempotency: if target is already a healthy Mountpoint mount, refresh creds and return.
-	// Kubelet may call NodePublishVolume repeatedly (requiresRepublish, retries).
-	isMounted, err := dm.IsMountPoint(target)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("failed to check if target %q is a mount point (mount target is possibly"+
-			" corrupted, manual pod re-creation %s might be required for mount recovery): %w",
-			target, credentialCtx.WorkloadPodID, err)
-	}
-	if isMounted {
-		// Republish: refresh credentials for the existing mount (token rotation).
-		commDir, err := dm.GetCommDir()
-		if err == nil {
-			if _, err := dm.provideCredentials(ctx, commDir, volumeID, &credentialCtx); err != nil {
-				klog.Errorf("DaemonsetMounter: failed to refresh credentials on republish for %s: %v", target, err)
-			}
-		}
-		klog.V(4).Infof("DaemonsetMounter: target %s is already mounted, credentials refreshed", target)
-		return nil
+	// Resolve commDir once per NodePublishVolume to ensure credentials and mount options
+	// are sent to the same mounter instance. Prevents the race where mounter pod restarts
+	// between provideCredentials and fuseMount, causing mount-s3 to start without creds.
+	commDir, err := dm.GetCommDir()
+	if err != nil {
+		return fmt.Errorf("connection to s3-csi-daemonset-mounter not yet established, allowing kubelet to retry NodePublishVolume: %w. %s", err, helpMessageForCheckingMounterPodStatus())
 	}
 
-	// Pod-sharing: use MountMap to share a single Mountpoint process per volume.
-	// Credential provisioning happens inside mountOrShareSource under the per-volume lock
-	// to avoid races between concurrent NodePublishVolume calls for the same PV.
-	return dm.mountOrShareSource(ctx, bucketName, target, volumeID, credentialCtx, args, fsGroup, userEnv)
+	// All paths (republish, share, new mount) go through mountOrShareSource
+	// which holds the per-volume lock and validates compatibility before any
+	// credential writes.
+	return dm.mountOrShareSource(ctx, bucketName, target, volumeID, commDir, credentialCtx, args, fsGroup, userEnv)
 }
 
 // mountOrShareSource implements the pod-sharing Mount flow using MountMap.
 func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName string, target string,
-	volumeID string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string, userEnv envprovider.Environment) error {
+	volumeID string, commDir string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string, userEnv envprovider.Environment) error {
 
 	// Get or create the per-volume entry, then lock it.
 	// Retry loop ensures we hold the canonical entry — not one orphaned by a concurrent unmount/delete.
@@ -197,17 +186,6 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	}
 	defer entry.mu.Unlock()
 
-	// Provision credentials under the lock to avoid races between concurrent
-	// NodePublishVolume calls for the same PV (all share one credential file).
-	commDir, err := dm.GetCommDir()
-	if err != nil {
-		return fmt.Errorf("connection to s3-csi-daemonset-mounter not yet established, allowing kubelet to retry NodePublishVolume: %w. %s", err, helpMessageForCheckingMounterPodStatus())
-	}
-	credsEnv, err := dm.provideCredentials(ctx, commDir, volumeID, &credentialCtx)
-	if err != nil {
-		return err
-	}
-
 	// Build mount params for this request — used for validation and stored on first mount.
 	incomingParams := MountParams{
 		MountOptions:             args.SortedList(),
@@ -218,86 +196,103 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 		FSGroup:                  fsGroup,
 	}
 
-	sourcePath := SourceMountPath(dm.kubeletPath, volumeID)
+	// If entry is initialized, check health first. Dead source = tear down and treat as fresh.
+	// Only enforce compatibility on a healthy (living) source.
+	if entry.initialized {
+		if !dm.IsSourceHealthy(entry.SourcePath) {
+			// Dead source — tear down and allow fresh mount with any params.
+			klog.V(2).Infof("DaemonsetMounter: source %s is dead for volume %s, resetting entry for fresh mount", entry.SourcePath, volumeID)
+			dm.mount.Unmount(entry.SourcePath)
+			os.Remove(entry.SourcePath)
+			entry.initialized = false
+		} else {
+			// Healthy source — enforce compatibility before any credential writes.
+			if err := entry.Params.ValidateCompatibility(&incomingParams); err != nil {
+				return fmt.Errorf("cannot share mount for volume %s: %w", volumeID, err)
+			}
+		}
+	}
+
+	if !entry.initialized {
+		// New mount (or recovered from dead source): write meta BEFORE credentials.
+		entry.Params = incomingParams
+		entry.SourcePath = SourceMountPath(dm.kubeletPath, volumeID)
+		entry.CommDir = commDir
+		if err := WriteMeta(dm.kubeletPath, entry); err != nil {
+			return fmt.Errorf("failed to write meta for volume %s, cannot proceed with mount: %w", volumeID, err)
+		}
+	}
+
+	// Provision credentials under the lock. We use the fresh commDir (from GetCommDir at the
+	// top of Mount) for all publish operations. When entry is initialized (source healthy),
+	// commDir == entry.CommDir because the mounter pod hasn't restarted. When not initialized
+	// (fresh mount or dead-source recovery), entry.CommDir is empty/stale, so the fresh
+	// commDir is the only valid path. Cleanup (releaseTarget) uses entry.CommDir to clean
+	// resources in the same location where they were originally created.
+	credsEnv, err := dm.provideCredentials(ctx, commDir, volumeID, &credentialCtx)
+	if err != nil {
+		return err
+	}
+
+	// Idempotency: if target is already mounted (republish/retry), creds are refreshed above, done.
+	isMounted, err := dm.IsMountPoint(target)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to check if target %q is a mount point (mount target is possibly"+
+			" corrupted, manual pod re-creation %s might be required for mount recovery): %w",
+			target, credentialCtx.WorkloadPodID, err)
+	}
+	if isMounted {
+		klog.V(4).Infof("DaemonsetMounter: target %s is already mounted, credentials refreshed", target)
+		return nil
+	}
 
 	if entry.initialized {
-		// Existing source — validate compatibility before sharing.
-		if err := entry.Params.ValidateCompatibility(&incomingParams); err != nil {
-			return fmt.Errorf("cannot share mount for volume %s: %w", volumeID, err)
+		// Source was confirmed healthy above. Bind mount to new target.
+		if err := dm.BindMount(entry.SourcePath, target); err != nil {
+			return err
 		}
-
-		// Check health before sharing.
-		if dm.IsSourceHealthy(entry.SourcePath) {
-			// Healthy source: bind mount to new target.
-			if err := dm.BindMount(entry.SourcePath, target); err != nil {
-				return err
-			}
-			entry.RefCount++
-			entry.Targets = append(entry.Targets, target)
-			klog.V(4).Infof("DaemonsetMounter: shared existing mount for volume %s → %s (refcount=%d)",
-				volumeID, target, entry.RefCount)
-			return nil
-		}
-		// Dead source: clean up and fall through to new mount.
-		klog.V(2).Infof("DaemonsetMounter: source %s is dead for volume %s, recovering", entry.SourcePath, volumeID)
-		if err := dm.mount.Unmount(entry.SourcePath); err != nil {
-			if !os.IsNotExist(err) {
-				return fmt.Errorf("failed to unmount dead source %q for volume %s, will retry: %w", entry.SourcePath, volumeID, err)
-			}
-		}
-		os.Remove(entry.SourcePath)
-		entry.initialized = false
+		entry.RefCount++
+		entry.Targets = append(entry.Targets, target)
+		klog.V(4).Infof("DaemonsetMounter: shared existing mount for volume %s → %s (refcount=%d)",
+			volumeID, target, entry.RefCount)
+		return nil
 	}
 
 	// New mount: FUSE mount at source, then bind to target.
 
-	// Persist meta to disk BEFORE mounting so that RebuildMountMap can find this volume
-	// if the driver crashes between fuseMount and the end of this function. If the mount
-	// fails, we clean up the meta file. An orphan meta file (crash after meta-write but
-	// before fuseMount) is harmless — RebuildMountMap detects no matching mount in
-	// /proc/self/mountinfo and deletes the stale meta file.
-	entry.Params = incomingParams
-	if err := WriteMeta(dm.kubeletPath, entry); err != nil {
-		klog.Errorf("DaemonsetMounter: failed to write meta for volume %s: %v (non-fatal)", volumeID, err)
-	}
-
-	if err := dm.fuseMount(ctx, bucketName, sourcePath, volumeID, args, userEnv, credsEnv); err != nil {
-		dm.cleanupCredentials(commDir, volumeID, credentialCtx.ToCleanupCtx())
+	if err := dm.fuseMount(ctx, bucketName, entry.SourcePath, volumeID, commDir, args, userEnv, credsEnv); err != nil {
+		if cleanErr := dm.cleanupMount(entry, credentialCtx.ToCleanupCtx()); cleanErr != nil {
+			klog.Errorf("DaemonsetMounter: cleanup after fuseMount failure for volume %s: %v", volumeID, cleanErr)
+		}
 		dm.mountMap.Delete(volumeID)
 		RemoveMeta(dm.kubeletPath, volumeID)
 		return err
 	}
 
 	// Bind mount source → target.
-	if err := dm.BindMount(sourcePath, target); err != nil {
-		// Cleanup source, credentials, map entry, and meta on bind failure.
-		dm.mount.Unmount(sourcePath)
-		os.Remove(sourcePath)
-		dm.cleanupCredentials(commDir, volumeID, credentialCtx.ToCleanupCtx())
+	if err := dm.BindMount(entry.SourcePath, target); err != nil {
+		if cleanErr := dm.cleanupMount(entry, credentialCtx.ToCleanupCtx()); cleanErr != nil {
+			klog.Errorf("DaemonsetMounter: cleanup after BindMount failure for volume %s: %v", volumeID, cleanErr)
+		}
 		dm.mountMap.Delete(volumeID)
 		RemoveMeta(dm.kubeletPath, volumeID)
 		return err
 	}
 
-	// Populate the entry.
-	entry.SourcePath = sourcePath
+	// Populate entry — SourcePath and CommDir already set above.
 	entry.RefCount = 1
 	entry.Targets = []string{target}
 	entry.initialized = true
 
-	klog.V(4).Infof("DaemonsetMounter: new shared mount for volume %s at source %s → %s", volumeID, sourcePath, target)
+	klog.V(4).Infof("DaemonsetMounter: new shared mount for volume %s at source %s → %s", volumeID, entry.SourcePath, target)
 	return nil
 }
 
 // fuseMount performs the FUSE mount + FD send + wait cycle at the given path.
 // Credentials are already provisioned by the caller (Mount).
+// commDir is passed from the caller to ensure a single GetCommDir() per NodePublishVolume.
 func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mountPath string,
-	volumeID string, args mountpoint.Args, userEnv envprovider.Environment, credsEnv envprovider.Environment) error {
-
-	commDir, err := dm.GetCommDir()
-	if err != nil {
-		return fmt.Errorf("connection to s3-csi-daemonset-mounter not yet established, allowing kubelet to retry NodePublishVolume: %w. %s", err, helpMessageForCheckingMounterPodStatus())
-	}
+	volumeID string, commDir string, args mountpoint.Args, userEnv envprovider.Environment, credsEnv envprovider.Environment) error {
 
 	if err := os.MkdirAll(mountPath, targetDirPerm); err != nil {
 		return fmt.Errorf("failed to create mount directory %q: %w", mountPath, err)
@@ -388,15 +383,20 @@ func (dm *DaemonsetMounter) Unmount(ctx context.Context, target string, credenti
 		return fmt.Errorf("failed to parse target path %q: %w", target, err)
 	}
 	volumeID := parsedTarget.VolumeID // This is the PV name
-	return dm.releaseTarget(target, volumeID)
+	return dm.releaseTarget(target, volumeID, credentialCtx)
 }
 
 // releaseTarget handles the Unmount flow with MountMap refcounting.
-func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string) error {
+func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string, credentialCtx credentialprovider.CleanupContext) error {
 	entry := dm.mountMap.Get(volumeID)
 	if entry == nil {
-		// No entry means we never mounted this volume. Return success (idempotency).
-		klog.V(4).Infof("DaemonsetMounter: no mount map entry for volume %s, unmount of %s is a no-op", volumeID, target)
+		// No entry means this volume is not tracked (e.g., after CSI node restart without
+		// successful RebuildMountMap recovery). Best-effort unmount the target in case a
+		// stale bind mount still exists in the kernel mount table.
+		klog.V(4).Infof("DaemonsetMounter: no mount map entry for volume %s, best-effort unmount of %s", volumeID, target)
+		if err := dm.mount.Unmount(target); err != nil && !os.IsNotExist(err) {
+			klog.Errorf("DaemonsetMounter: best-effort unmount of untracked target %s failed: %v", target, err)
+		}
 		return nil
 	}
 
@@ -420,31 +420,17 @@ func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string) error 
 	}
 
 	if entry.RefCount == 0 {
-		// Last consumer: clean up credentials first, then unmount the FUSE source.
-		klog.V(4).Infof("DaemonsetMounter: last consumer for volume %s, unmounting source %s", volumeID, entry.SourcePath)
+		// Last consumer: clean up all mount resources.
+		klog.V(4).Infof("DaemonsetMounter: last consumer for volume %s, cleaning up mount", volumeID)
 
-		// Clean up error file and credentials before unmount (ensures retrying cleanup on failure).
-		if dir := dm.commDir.Load(); dir != nil {
-			os.Remove(filepath.Join(*dir, GetErrorFileName(entry.VolumeID)))
-			if err := dm.cleanupCredentials(*dir, entry.VolumeID, credentialprovider.CleanupContext{
-				VolumeID:  volumeID,
-				MountKind: credentialprovider.MountKindDaemonset,
-			}); err != nil {
-				klog.Errorf("DaemonsetMounter: failed to cleanup credentials for volume %s: %v", volumeID, err)
-			}
+		if err := dm.cleanupMount(entry, credentialCtx); err != nil {
+			klog.Errorf("DaemonsetMounter: %v (will retry on next unmount attempt)", err)
+			// Don't remove meta or map entry — leave for retry/background cleanup.
+		} else {
+			// All resources confirmed cleaned — safe to remove bookkeeping.
+			dm.mountMap.Delete(volumeID)
+			RemoveMeta(dm.kubeletPath, volumeID)
 		}
-
-		// Unmount FUSE source — causes mount-s3 to exit via kernel FUSE teardown.
-		if err := dm.mount.Unmount(entry.SourcePath); err != nil {
-			klog.Errorf("DaemonsetMounter: failed to unmount source %q: %v (best-effort cleanup)", entry.SourcePath, err)
-		}
-		os.Remove(entry.SourcePath)
-
-		// Delete entry from the map — the retry loop in Mount handles the race.
-		dm.mountMap.Delete(volumeID)
-
-		// Remove persisted meta file.
-		RemoveMeta(dm.kubeletPath, volumeID)
 	}
 
 	klog.V(4).Infof("DaemonsetMounter: volume %s unmounted from %s", volumeID, target)
@@ -454,6 +440,46 @@ func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string) error 
 // GetErrorFileName returns the error file name for a given volume ID.
 func GetErrorFileName(volumeID string) string {
 	return volumeID + MountErrorSuffix
+}
+
+// cleanupMount removes all resources associated with a mount entry.
+// Returns nil only when ALL resources are confirmed absent (deleted or already gone).
+// Safe to call multiple times (idempotent). Caller must hold entry.mu if entry is in the map.
+func (dm *DaemonsetMounter) cleanupMount(entry *MountEntry, credentialCtx credentialprovider.CleanupContext) error {
+	var errs []error
+
+	// Clean credential files and error file (both live in commDir)
+	if entry.CommDir != "" {
+		if err := dm.cleanupCredentials(entry.CommDir, entry.VolumeID, credentialCtx); err != nil {
+			klog.Errorf("DaemonsetMounter: cleanup credentials for volume %s: %v", entry.VolumeID, err)
+			errs = append(errs, err)
+		}
+		errFile := filepath.Join(entry.CommDir, GetErrorFileName(entry.VolumeID))
+		if err := os.Remove(errFile); err != nil && !os.IsNotExist(err) {
+			klog.Errorf("DaemonsetMounter: cleanup error file %s: %v", errFile, err)
+			errs = append(errs, err)
+		}
+	}
+
+	// Unmount FUSE source (causes mount-s3 to exit via kernel FUSE teardown)
+	if entry.SourcePath != "" {
+		if err := dm.mount.Unmount(entry.SourcePath); err != nil && !os.IsNotExist(err) {
+			klog.Errorf("DaemonsetMounter: unmount source %s: %v", entry.SourcePath, err)
+			errs = append(errs, err)
+		}
+		if err := os.Remove(entry.SourcePath); err != nil && !os.IsNotExist(err) {
+			klog.Errorf("DaemonsetMounter: remove source dir %s: %v", entry.SourcePath, err)
+			errs = append(errs, err)
+		}
+	}
+
+	//[future] Clean cache dir
+	// [future] Verify no MP process running
+
+	if len(errs) > 0 {
+		return fmt.Errorf("incomplete cleanup for volume %s (%d errors)", entry.VolumeID, len(errs))
+	}
+	return nil
 }
 
 // helpMessageForGettingMounterLogs returns a help message with a command to get mounter logs.
@@ -637,7 +663,7 @@ func (dm *DaemonsetMounter) KubeletPath() string {
 }
 
 // mountInfoProviderWithDefault delegates to mountInfoProvider if set, or falls back to parseMountInfoFromProc.
-func (dm *DaemonsetMounter) mountInfoProviderWithDefault() ([]mountInfoEntry, error) {
+func (dm *DaemonsetMounter) mountInfoProviderWithDefault() ([]mountutils.MountInfo, error) {
 	if dm.mountInfoProvider != nil {
 		return dm.mountInfoProvider()
 	}
@@ -699,7 +725,7 @@ func (dm *DaemonsetMounter) RebuildMountMap() error {
 		}
 
 		// Count bind mounts sharing the same device ID (major:minor)
-		targets := findBindMountTargets(mountInfos, sourceMI.DeviceID, sourcePath)
+		targets := findBindMountTargets(mountInfos, deviceID(sourceMI), sourcePath)
 
 		entry, _ := dm.mountMap.GetOrCreate(meta.VolumeID)
 		entry.mu.Lock()

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -132,13 +132,16 @@ func NewDaemonsetMounter(clientset kubernetes.Interface, nodeID string, mount *m
 // Mount mounts the given S3 bucket at the target path with pod-sharing support.
 //
 // Flow:
-//  1. If target is already mounted (republish): refresh credentials without locking, return early
-//  2. Acquire per-volume lock via MountMap (serializes concurrent NodePublishVolume for same PV)
-//  3. Provision credentials (under lock to avoid race with cleanup on failure)
-//  4. If an existing healthy source mount exists for this volumeID → bind mount to target
-//  5. If no source exists (or dead) → FUSE mount at source path, send FD to mounter, wait for readiness
-//  6. Bind mount source → target
-//  7. Track the target in MountMap for refcounting
+//  1. Acquire per-volume lock via MountMap (serializes concurrent NodePublishVolume for same PV)
+//  2. If entry is initialized, check source health:
+//     - Dead source → tear down and reset entry to allow fresh mount
+//     - Healthy source → validate compatibility (reject incompatible params before any cred writes)
+//  3. If not initialized (fresh or recovered from dead): write meta, set SourcePath/CommDir
+//  4. Provision credentials (under lock to avoid race with cleanup on failure)
+//  5. If target is already mounted (republish/retry): creds refreshed above, return early
+//  6. If entry is initialized (healthy source) → bind mount to new target, bump refcount
+//  7. If not initialized → FUSE mount at source, send FD to mounter, wait for readiness,
+//     bind mount source → target, mark entry initialized
 //
 // On initial mount failure (fuseMount or bindMount), credentials are cleaned up immediately
 // under the lock. On unmount of last consumer, the FUSE source is unmounted (causing mount-s3

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -316,15 +316,9 @@ func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mo
 	}
 
 	fdClosed := false
-	unmount := true
 	defer func() {
 		if !fdClosed {
 			dm.closeFUSEDevFD(fd)
-		}
-		if unmount {
-			if umErr := dm.mount.Unmount(mountPath); umErr != nil {
-				klog.Errorf("Failed to unmount %q during cleanup: %v", mountPath, umErr)
-			}
 		}
 	}()
 
@@ -375,7 +369,6 @@ func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mo
 		return err
 	}
 
-	unmount = false
 	return nil
 }
 
@@ -738,6 +731,7 @@ func (dm *DaemonsetMounter) RebuildMountMap() error {
 		entry, _ := dm.mountMap.GetOrCreate(meta.VolumeID)
 		entry.mu.Lock()
 		entry.SourcePath = sourcePath
+		entry.CommDir = meta.CommDir
 		entry.Params = MountParams{
 			MountOptions:             meta.MountOptions,
 			AuthenticationSource:     meta.AuthenticationSource,

--- a/pkg/driver/node/mounter/daemonset_mounter_test.go
+++ b/pkg/driver/node/mounter/daemonset_mounter_test.go
@@ -2,10 +2,10 @@ package mounter_test
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -18,10 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/mount-utils"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
-	mock_credentialprovider "github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider/mocks"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/mounter"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/mounter/mountertest"
@@ -30,6 +27,17 @@ import (
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/mountpoint/mountoptions"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
 )
+
+// noopCredProvider is a no-op credential provider for unit tests.
+type noopCredProvider struct{}
+
+func (n *noopCredProvider) Provide(_ context.Context, _ credentialprovider.ProvideContext) (envprovider.Environment, credentialprovider.AuthenticationSource, error) {
+	return nil, "", nil
+}
+
+func (n *noopCredProvider) Cleanup(_ credentialprovider.CleanupContext) error {
+	return nil
+}
 
 type dmTestCtx struct {
 	t   *testing.T
@@ -47,10 +55,20 @@ type dmTestCtx struct {
 	mounterPodUID string
 	kubeletPath   string
 	commDir       string
-	targetPath    string
 }
 
-func setupDM(t *testing.T, credProvider ...credentialprovider.ProviderInterface) *dmTestCtx {
+// targetPath returns a valid kubelet-style target path that targetpath.Parse can parse.
+// Format: <kubeletPath>/pods/<podUID>/volumes/kubernetes.io~csi/<volumeID>/mount
+func (testCtx *dmTestCtx) targetPath(podUID string) string {
+	return filepath.Join(testCtx.kubeletPath, "pods", podUID, "volumes", "kubernetes.io~csi", testCtx.volumeID, "mount")
+}
+
+// targetPathWithVolume returns a valid kubelet-style target path for a specific volumeID.
+func (testCtx *dmTestCtx) targetPathWithVolume(podUID, volumeID string) string {
+	return filepath.Join(testCtx.kubeletPath, "pods", podUID, "volumes", "kubernetes.io~csi", volumeID, "mount")
+}
+
+func setupDM(t *testing.T) *dmTestCtx {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -97,8 +115,6 @@ func setupDM(t *testing.T, credProvider ...credentialprovider.ProviderInterface)
 	client := fake.NewSimpleClientset(pod)
 	fakeMounter := mount.NewFakeMounter(nil)
 
-	targetPath := filepath.Join(kubeletPath, "pods", podUID, "volumes", "kubernetes.io~csi", volumeID, "mount")
-
 	testCtx := &dmTestCtx{
 		t:             t,
 		ctx:           ctx,
@@ -111,7 +127,6 @@ func setupDM(t *testing.T, credProvider ...credentialprovider.ProviderInterface)
 		mounterPodUID: mounterPodUID,
 		kubeletPath:   kubeletPath,
 		commDir:       commDir,
-		targetPath:    targetPath,
 	}
 
 	mountSyscall := func(target string, opts mpmounter.MountOptions) (int, error) {
@@ -125,21 +140,9 @@ func setupDM(t *testing.T, credProvider ...credentialprovider.ProviderInterface)
 	}
 
 	t.Setenv("CONTAINER_KUBELET_PATH", kubeletPath)
-
-	var cp credentialprovider.ProviderInterface
-	if len(credProvider) > 0 && credProvider[0] != nil {
-		cp = credProvider[0]
-	} else {
-		mockCtl := gomock.NewController(t)
-		mockCP := mock_credentialprovider.NewMockProviderInterface(mockCtl)
-		mockCP.EXPECT().Provide(gomock.Any(), gomock.Any()).
-			Return(envprovider.Environment{}, credentialprovider.AuthenticationSourceDriver, nil).
-			AnyTimes()
-		mockCP.EXPECT().Cleanup(gomock.Any()).Return(nil).AnyTimes()
-		cp = mockCP
-	}
-
-	dm := mounter.NewDaemonsetMounter(client, nodeName, mpmounter.NewWithMount(fakeMounter), cp, mountSyscall)
+	dm := mounter.NewDaemonsetMounter(client, nodeName, mpmounter.NewWithMount(fakeMounter), &noopCredProvider{}, mountSyscall, func(source, target string) error {
+		return fakeMounter.Mount(source, target, "bind", []string{"bind"})
+	}, nil)
 	err = dm.DiscoverCommDir(ctx)
 	assert.NoError(t, err)
 
@@ -151,7 +154,7 @@ func TestDaemonsetMounter(t *testing.T) {
 	t.Run("Mounting", func(t *testing.T) {
 		t.Run("Correctly passes mount options", func(t *testing.T) {
 			testCtx := setupDM(t)
-			target := testCtx.targetPath
+			target := testCtx.targetPath(testCtx.podUID)
 
 			devNull := mountertest.OpenDevNull(t)
 			testCtx.mountSyscall = func(target string, opts mpmounter.MountOptions) (int, error) {
@@ -177,7 +180,8 @@ func TestDaemonsetMounter(t *testing.T) {
 			}()
 
 			got := testCtx.receiveMountOptions()
-			testCtx.mount.Mount("mountpoint-s3", target, "fuse", nil)
+			sourcePath := mounter.SourceMountPath(testCtx.kubeletPath, testCtx.volumeID)
+			testCtx.mount.Mount("mountpoint-s3", sourcePath, "fuse", nil)
 
 			err := <-mountRes
 			assert.NoError(t, err)
@@ -194,28 +198,13 @@ func TestDaemonsetMounter(t *testing.T) {
 				BucketName: testCtx.bucketName,
 				Args:       []string{"--prefix=data/"},
 				Env:        env.List(),
-				VolumeId:   mustGetMountId(t, testCtx.targetPath),
+				VolumeId:   testCtx.volumeID,
 			}, got)
 		})
 
-		t.Run("Does not duplicate mounts if target is already mounted and refreshes credentials", func(t *testing.T) {
-			mockCtl := gomock.NewController(t)
-			mockCredProvider := mock_credentialprovider.NewMockProviderInterface(mockCtl)
-
-			testCtx := setupDM(t, mockCredProvider)
-			target := testCtx.targetPath
-			mountId := mustGetMountId(t, target)
-
-			expectedWritePath := filepath.Join(testCtx.commDir, mountId)
-			expectedEnvPath := filepath.Join("/comm", mountId)
-
-			mockCredProvider.EXPECT().Provide(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, provideCtx credentialprovider.ProvideContext) (envprovider.Environment, credentialprovider.AuthenticationSource, error) {
-					assert.Equals(t, expectedWritePath, provideCtx.WritePath)
-					assert.Equals(t, expectedEnvPath, provideCtx.EnvPath)
-					assert.Equals(t, credentialprovider.MountKindDaemonset, provideCtx.MountKind)
-					return envprovider.Environment{}, credentialprovider.AuthenticationSourceDriver, nil
-				})
+		t.Run("Does not duplicate mounts if target is already mounted", func(t *testing.T) {
+			testCtx := setupDM(t)
+			target := testCtx.targetPath(testCtx.podUID)
 
 			err := os.MkdirAll(target, 0755)
 			assert.NoError(t, err)
@@ -240,7 +229,7 @@ func TestDaemonsetMounter(t *testing.T) {
 
 		t.Run("Unmounts source if mounter does not receive mount options", func(t *testing.T) {
 			testCtx := setupDM(t)
-			target := testCtx.targetPath
+			target := testCtx.targetPath(testCtx.podUID)
 
 			// Create socket but don't listen so no one receives mount options.
 			// mount_options.go Send -> dialWithRetry will retry until context deadline.
@@ -260,18 +249,20 @@ func TestDaemonsetMounter(t *testing.T) {
 			}
 			assert.Contains(t, err.Error(), "failed to send mount options")
 
-			// Expect false, nil output from mount.go CheckMountpoint
-			mounted, err := testCtx.dm.IsMountPoint(target)
+			// In sharing mode, FUSE mount goes to source path, not target.
+			// After failure, source should be unmounted and target should not exist.
+			sourcePath := filepath.Join(testCtx.kubeletPath, "plugins", "s3.csi.aws.com", "mnt", testCtx.volumeID)
+			mounted, err := testCtx.dm.IsMountPoint(sourcePath)
 			assert.NoError(t, err)
 			if mounted {
-				t.Error("it should unmount target if mounter does not receive the mount options")
+				t.Error("it should unmount source if mounter does not receive the mount options")
 			}
-			testCtx.assertUnmounted(target)
+			testCtx.assertUnmounted(sourcePath)
 		})
 
 		t.Run("Unmounts source if Mountpoint fails to start with error file", func(t *testing.T) {
 			testCtx := setupDM(t)
-			target := testCtx.targetPath
+			target := testCtx.targetPath(testCtx.podUID)
 
 			// Skip fakeMounter - it caused waitForMount's CheckMountpoint poll to win the race over .error file poll
 			testCtx.mountSyscall = func(tgt string, opts mpmounter.MountOptions) (int, error) {
@@ -281,7 +272,7 @@ func TestDaemonsetMounter(t *testing.T) {
 			}
 
 			// Construct error file path
-			mountId := mustGetMountId(t, testCtx.targetPath)
+			mountId := testCtx.volumeID
 			errFilePath := filepath.Join(testCtx.commDir, mounter.GetErrorFileName(mountId))
 
 			mountRes := make(chan error)
@@ -297,7 +288,6 @@ func TestDaemonsetMounter(t *testing.T) {
 			// Do not register mount - simulates Mountpoint receiving fd but fails to start serving.
 
 			// Write error file to simulate Mountpoint crash
-			// TODO(vlaad): write error file atomically (open,write,rename)
 			mountError := "mount-s3 exited with code 1"
 			err := os.WriteFile(errFilePath, []byte(mountError), 0644)
 			assert.NoError(t, err)
@@ -309,75 +299,16 @@ func TestDaemonsetMounter(t *testing.T) {
 			assert.Contains(t, err.Error(), mountError)
 
 			// Can't use IsMountpoint/CheckMountpoint (didn't register mount), so we
-			// verify Unmount was called via FakeMounter log.
-			testCtx.assertUnmounted(target)
-		})
-
-		t.Run("Credentials cleaned up on mount failure", func(t *testing.T) {
-			mockCtl := gomock.NewController(t)
-			mockCredProvider := mock_credentialprovider.NewMockProviderInterface(mockCtl)
-
-			testCtx := setupDM(t, mockCredProvider)
-			target := testCtx.targetPath
-			mountId := mustGetMountId(t, target)
-
-			expectedWritePath := filepath.Join(testCtx.commDir, mountId)
-			expectedEnvPath := filepath.Join("/comm", mountId)
-
-			provideCall := mockCredProvider.EXPECT().Provide(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, provideCtx credentialprovider.ProvideContext) (envprovider.Environment, credentialprovider.AuthenticationSource, error) {
-					assert.Equals(t, expectedWritePath, provideCtx.WritePath)
-					assert.Equals(t, expectedEnvPath, provideCtx.EnvPath)
-					assert.Equals(t, credentialprovider.MountKindDaemonset, provideCtx.MountKind)
-					return envprovider.Environment{}, credentialprovider.AuthenticationSourceDriver, nil
-				})
-
-			mockCredProvider.EXPECT().Cleanup(gomock.Any()).After(provideCall).
-				DoAndReturn(func(cleanupCtx credentialprovider.CleanupContext) error {
-					assert.Equals(t, expectedWritePath, cleanupCtx.WritePath)
-					assert.Equals(t, credentialprovider.MountKindDaemonset, cleanupCtx.MountKind)
-					return nil
-				})
-
-			mountErr := fmt.Errorf("simulated mount failure")
-			testCtx.mountSyscall = func(target string, opts mpmounter.MountOptions) (int, error) {
-				return 0, mountErr
-			}
-
-			err := testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target, credentialprovider.ProvideContext{
-				WorkloadPodID: testCtx.podUID,
-				VolumeID:      testCtx.volumeID,
-			}, mountpoint.ParseArgs(nil), "", nil)
-			if err == nil {
-				t.Fatal("mount should fail")
-			}
-			assert.Contains(t, err.Error(), "simulated mount failure")
-
-			_, err = os.Stat(expectedWritePath)
-			assert.ErrorIs(t, err, os.ErrNotExist)
+			// verify Unmount was called on source path via FakeMounter log.
+			sourcePath := filepath.Join(testCtx.kubeletPath, "plugins", "s3.csi.aws.com", "mnt", testCtx.volumeID)
+			testCtx.assertUnmounted(sourcePath)
 		})
 	})
 
 	t.Run("Unmounting", func(t *testing.T) {
-		t.Run("Removes mount from target and cleans up credentials", func(t *testing.T) {
-			mockCtl := gomock.NewController(t)
-			mockCredProvider := mock_credentialprovider.NewMockProviderInterface(mockCtl)
-
-			testCtx := setupDM(t, mockCredProvider)
-			target := testCtx.targetPath
-			mountId := mustGetMountId(t, target)
-
-			expectedWritePath := filepath.Join(testCtx.commDir, mountId)
-
-			mockCredProvider.EXPECT().Provide(gomock.Any(), gomock.Any()).
-				Return(envprovider.Environment{}, credentialprovider.AuthenticationSourceDriver, nil)
-
-			mockCredProvider.EXPECT().Cleanup(gomock.Any()).
-				DoAndReturn(func(cleanupCtx credentialprovider.CleanupContext) error {
-					assert.Equals(t, expectedWritePath, cleanupCtx.WritePath)
-					assert.Equals(t, credentialprovider.MountKindDaemonset, cleanupCtx.MountKind)
-					return nil
-				})
+		t.Run("Removes mount from target", func(t *testing.T) {
+			testCtx := setupDM(t)
+			target := testCtx.targetPath(testCtx.podUID)
 
 			mountRes := make(chan error)
 			go func() {
@@ -392,7 +323,8 @@ func TestDaemonsetMounter(t *testing.T) {
 			}()
 
 			testCtx.receiveMountOptions()
-			testCtx.mount.Mount("mountpoint-s3", target, "fuse", nil)
+			sourcePath := mounter.SourceMountPath(testCtx.kubeletPath, testCtx.volumeID)
+			testCtx.mount.Mount("mountpoint-s3", sourcePath, "fuse", nil)
 			err := <-mountRes
 			assert.NoError(t, err)
 
@@ -413,9 +345,6 @@ func TestDaemonsetMounter(t *testing.T) {
 			if mounted {
 				t.Error("target should not be mounted after Unmount")
 			}
-
-			_, err = os.Stat(expectedWritePath)
-			assert.ErrorIs(t, err, os.ErrNotExist)
 		})
 	})
 
@@ -442,7 +371,7 @@ func TestDaemonsetMounter(t *testing.T) {
 					t.Setenv("CONTAINER_KUBELET_PATH", t.TempDir())
 
 					client := fake.NewSimpleClientset(tt.pods...)
-					dm := mounter.NewDaemonsetMounter(client, "test-node", mpmounter.NewWithMount(mount.NewFakeMounter(nil)), nil, nil)
+					dm := mounter.NewDaemonsetMounter(client, "test-node", mpmounter.NewWithMount(mount.NewFakeMounter(nil)), &noopCredProvider{}, nil, nil, nil)
 
 					ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 					defer cancel()
@@ -479,7 +408,7 @@ func TestDaemonsetMounter(t *testing.T) {
 
 		t.Run("Mount fails fast when commDir not discovered", func(t *testing.T) {
 			testCtx := setupDM(t)
-			target := testCtx.targetPath
+			target := testCtx.targetPath(testCtx.podUID)
 
 			// Create a fresh DM which has not discovered commDir (setupDM called dm.DiscoverCommDir(ctx))
 			// and has no StartCommDirWatch process to populate it.
@@ -487,11 +416,13 @@ func TestDaemonsetMounter(t *testing.T) {
 			testCtx.dm = mounter.NewDaemonsetMounter(
 				testCtx.client, testCtx.nodeName,
 				mpmounter.NewWithMount(testCtx.mount),
-				nil,
+				&noopCredProvider{},
 				func(target string, opts mpmounter.MountOptions) (int, error) {
 					mountSyscallCalled = true
 					return 0, nil
 				},
+				nil,
+				nil,
 			)
 
 			err := testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target, credentialprovider.ProvideContext{
@@ -509,7 +440,7 @@ func TestDaemonsetMounter(t *testing.T) {
 
 		t.Run("Mount nils commDir on staleness (socket not found)", func(t *testing.T) {
 			testCtx := setupDM(t)
-			target := testCtx.targetPath
+			target := testCtx.targetPath("pod-timeout")
 
 			testCtx.mountSyscall = func(tgt string, opts mpmounter.MountOptions) (int, error) {
 				testCtx.mount.Mount("mountpoint-s3", tgt, "fuse", nil)
@@ -524,7 +455,7 @@ func TestDaemonsetMounter(t *testing.T) {
 			// No receiveMountOptions (socket does not exist). Send -> dialWithRetry will retry
 			// until context timeout (DeadlineExceeded) which should nil commDir on staleness
 			err := testCtx.dm.Mount(ctx, testCtx.bucketName, target, credentialprovider.ProvideContext{
-				WorkloadPodID: testCtx.podUID,
+				WorkloadPodID: "pod-timeout",
 				VolumeID:      testCtx.volumeID,
 			}, mountpoint.ParseArgs(nil), "", nil)
 			if err == nil {
@@ -542,7 +473,7 @@ func TestDaemonsetMounter(t *testing.T) {
 			// it incorrectly nils commDir, all subsequent mounts fail with "mounter pod
 			// not available" until the watcher re-discovers.
 			testCtx := setupDM(t)
-			target := testCtx.targetPath
+			target := testCtx.targetPath("pod-cancel")
 
 			testCtx.mountSyscall = func(tgt string, opts mpmounter.MountOptions) (int, error) {
 				testCtx.mount.Mount("mountpoint-s3", tgt, "fuse", nil)
@@ -555,7 +486,7 @@ func TestDaemonsetMounter(t *testing.T) {
 			cancel()
 
 			err := testCtx.dm.Mount(ctx, testCtx.bucketName, target, credentialprovider.ProvideContext{
-				WorkloadPodID: testCtx.podUID,
+				WorkloadPodID: "pod-cancel",
 				VolumeID:      testCtx.volumeID,
 			}, mountpoint.ParseArgs(nil), "", nil)
 			if err == nil {
@@ -567,6 +498,220 @@ func TestDaemonsetMounter(t *testing.T) {
 			_, err = testCtx.dm.GetCommDir()
 			assert.NoError(t, err)
 		})
+	})
+}
+
+func TestDaemonsetMounter_PodSharing(t *testing.T) {
+	t.Run("Second pod shares existing mount without new FUSE mount", func(t *testing.T) {
+		testCtx := setupDM(t)
+		target1 := testCtx.targetPath("pod-a-uid")
+		target2 := testCtx.targetPath("pod-b-uid")
+
+		fuseMountCount := 0
+		testCtx.mountSyscall = func(tgt string, opts mpmounter.MountOptions) (int, error) {
+			fuseMountCount++
+			testCtx.mount.Mount("mountpoint-s3", tgt, "fuse", nil)
+			fd, err := syscall.Dup(int(mountertest.OpenDevNull(t).Fd()))
+			assert.NoError(t, err)
+			return fd, nil
+		}
+
+		// Mount first pod
+		mountRes := make(chan error)
+		go func() {
+			mountRes <- testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target1, credentialprovider.ProvideContext{
+				WorkloadPodID:        "pod-a-uid",
+				VolumeID:             testCtx.volumeID,
+				AuthenticationSource: "driver",
+				ServiceAccountName:   "default",
+				PodNamespace:         "default",
+			}, mountpoint.ParseArgs(nil), "", nil)
+		}()
+
+		// Receive and complete the first mount
+		testCtx.receiveMountOptions()
+		sourcePath := mounter.SourceMountPath(testCtx.kubeletPath, testCtx.volumeID)
+		testCtx.mount.Mount("mountpoint-s3", sourcePath, "fuse", nil)
+
+		err := <-mountRes
+		assert.NoError(t, err)
+		assert.Equals(t, 1, fuseMountCount)
+
+		// Mount second pod — same volume, same params → should share via bind mount
+		err = testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target2, credentialprovider.ProvideContext{
+			WorkloadPodID:        "pod-b-uid",
+			VolumeID:             testCtx.volumeID,
+			AuthenticationSource: "driver",
+			ServiceAccountName:   "default",
+			PodNamespace:         "default",
+		}, mountpoint.ParseArgs(nil), "", nil)
+		assert.NoError(t, err)
+
+		// FUSE mount should NOT have been called again — only bind mount
+		assert.Equals(t, 1, fuseMountCount)
+	})
+
+	t.Run("Second pod rejected with different service account", func(t *testing.T) {
+		testCtx := setupDM(t)
+		target1 := testCtx.targetPath("pod-a-uid")
+		target2 := testCtx.targetPath("pod-b-uid")
+
+		testCtx.mountSyscall = func(tgt string, opts mpmounter.MountOptions) (int, error) {
+			testCtx.mount.Mount("mountpoint-s3", tgt, "fuse", nil)
+			fd, err := syscall.Dup(int(mountertest.OpenDevNull(t).Fd()))
+			assert.NoError(t, err)
+			return fd, nil
+		}
+
+		// Mount first pod with sa-a
+		mountRes := make(chan error)
+		go func() {
+			mountRes <- testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target1, credentialprovider.ProvideContext{
+				WorkloadPodID:        "pod-a-uid",
+				VolumeID:             testCtx.volumeID,
+				AuthenticationSource: "driver",
+				ServiceAccountName:   "sa-a",
+				PodNamespace:         "default",
+			}, mountpoint.ParseArgs(nil), "", nil)
+		}()
+
+		testCtx.receiveMountOptions()
+		sourcePath := mounter.SourceMountPath(testCtx.kubeletPath, testCtx.volumeID)
+		testCtx.mount.Mount("mountpoint-s3", sourcePath, "fuse", nil)
+
+		err := <-mountRes
+		assert.NoError(t, err)
+
+		// Second pod with sa-b — should be rejected
+		err = testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target2, credentialprovider.ProvideContext{
+			WorkloadPodID:        "pod-b-uid",
+			VolumeID:             testCtx.volumeID,
+			AuthenticationSource: "driver",
+			ServiceAccountName:   "sa-b",
+			PodNamespace:         "default",
+		}, mountpoint.ParseArgs(nil), "", nil)
+		if err == nil {
+			t.Fatal("expected error for mismatched service account")
+		}
+		assert.Contains(t, err.Error(), "serviceAccountName mismatch")
+	})
+
+	t.Run("Unmount last consumer resets entry, next mount with diff params succeeds", func(t *testing.T) {
+		testCtx := setupDM(t)
+		target1 := testCtx.targetPath("pod-a-uid")
+		target2 := testCtx.targetPath("pod-b-uid")
+
+		testCtx.mountSyscall = func(tgt string, opts mpmounter.MountOptions) (int, error) {
+			testCtx.mount.Mount("mountpoint-s3", tgt, "fuse", nil)
+			fd, err := syscall.Dup(int(mountertest.OpenDevNull(t).Fd()))
+			assert.NoError(t, err)
+			return fd, nil
+		}
+
+		// Mount with sa-a
+		mountRes := make(chan error)
+		go func() {
+			mountRes <- testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target1, credentialprovider.ProvideContext{
+				WorkloadPodID:        "pod-a-uid",
+				VolumeID:             testCtx.volumeID,
+				AuthenticationSource: "driver",
+				ServiceAccountName:   "sa-a",
+				PodNamespace:         "default",
+			}, mountpoint.ParseArgs(nil), "", nil)
+		}()
+
+		testCtx.receiveMountOptions()
+		sourcePath := mounter.SourceMountPath(testCtx.kubeletPath, testCtx.volumeID)
+		testCtx.mount.Mount("mountpoint-s3", sourcePath, "fuse", nil)
+
+		err := <-mountRes
+		assert.NoError(t, err)
+
+		// Unmount the only consumer
+		err = testCtx.dm.Unmount(testCtx.ctx, target1, credentialprovider.CleanupContext{
+			VolumeID: testCtx.volumeID,
+			PodID:    "pod-a-uid",
+		})
+		assert.NoError(t, err)
+
+		// Now mount with sa-b — should succeed because entry was reset
+		go func() {
+			mountRes <- testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target2, credentialprovider.ProvideContext{
+				WorkloadPodID:        "pod-b-uid",
+				VolumeID:             testCtx.volumeID,
+				AuthenticationSource: "driver",
+				ServiceAccountName:   "sa-b",
+				PodNamespace:         "default",
+			}, mountpoint.ParseArgs(nil), "", nil)
+		}()
+
+		testCtx.receiveMountOptions()
+		testCtx.mount.Mount("mountpoint-s3", sourcePath, "fuse", nil)
+
+		err = <-mountRes
+		assert.NoError(t, err)
+	})
+
+	t.Run("Concurrent mounts same volume same params no race", func(t *testing.T) {
+		testCtx := setupDM(t)
+
+		fuseMountCount := 0
+		testCtx.mountSyscall = func(tgt string, opts mpmounter.MountOptions) (int, error) {
+			fuseMountCount++
+			testCtx.mount.Mount("mountpoint-s3", tgt, "fuse", nil)
+			fd, err := syscall.Dup(int(mountertest.OpenDevNull(t).Fd()))
+			assert.NoError(t, err)
+			return fd, nil
+		}
+
+		// First mount to establish the source
+		target1 := testCtx.targetPath("pod-first")
+		mountRes := make(chan error)
+		go func() {
+			mountRes <- testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target1, credentialprovider.ProvideContext{
+				WorkloadPodID:        "pod-first",
+				VolumeID:             testCtx.volumeID,
+				AuthenticationSource: "driver",
+				ServiceAccountName:   "default",
+				PodNamespace:         "default",
+			}, mountpoint.ParseArgs(nil), "", nil)
+		}()
+
+		testCtx.receiveMountOptions()
+		sourcePath := mounter.SourceMountPath(testCtx.kubeletPath, testCtx.volumeID)
+		testCtx.mount.Mount("mountpoint-s3", sourcePath, "fuse", nil)
+
+		err := <-mountRes
+		assert.NoError(t, err)
+
+		// Now fire 5 concurrent mounts — all should share, no new FUSE mount
+		var results [5]error
+		var wg sync.WaitGroup
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				podUID := "pod-" + string(rune('a'+idx))
+				target := testCtx.targetPath(podUID)
+				results[idx] = testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target, credentialprovider.ProvideContext{
+					WorkloadPodID:        podUID,
+					VolumeID:             testCtx.volumeID,
+					AuthenticationSource: "driver",
+					ServiceAccountName:   "default",
+					PodNamespace:         "default",
+				}, mountpoint.ParseArgs(nil), "", nil)
+			}(i)
+		}
+		wg.Wait()
+
+		for i, err := range results {
+			if err != nil {
+				t.Errorf("concurrent mount %d failed: %v", i, err)
+			}
+		}
+
+		// Only 1 FUSE mount should have happened (the initial one)
+		assert.Equals(t, 1, fuseMountCount)
 	})
 }
 
@@ -586,13 +731,6 @@ func (testCtx *dmTestCtx) assertUnmounted(target string) {
 		}
 	}
 	testCtx.t.Errorf("expected Unmount to be called on %s, FakeMounter log: %v", target, testCtx.mount.GetLog())
-}
-
-func mustGetMountId(t *testing.T, target string) string {
-	t.Helper()
-	id, err := mounter.GetMountId(target)
-	assert.NoError(t, err)
-	return id
 }
 
 func mounterPod(name string, phase corev1.PodPhase) *corev1.Pod {

--- a/pkg/driver/node/mounter/daemonset_mounter_test.go
+++ b/pkg/driver/node/mounter/daemonset_mounter_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/mount-utils"
+	mountutils "k8s.io/mount-utils"
 
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
 	mock_credentialprovider "github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider/mocks"
@@ -136,7 +137,14 @@ func setupDM(t *testing.T) *dmTestCtx {
 
 	dm := mounter.NewDaemonsetMounter(client, nodeName, mpmounter.NewWithMount(fakeMounter), mockCredProvider, mountSyscall, func(source, target string) error {
 		return fakeMounter.Mount(source, target, "bind", []string{"bind"})
-	}, nil)
+	}, func() ([]mountutils.MountInfo, error) {
+		// Return mount info entries matching what FakeMounter has registered.
+		var infos []mountutils.MountInfo
+		for _, mp := range fakeMounter.MountPoints {
+			infos = append(infos, mountutils.MountInfo{MountPoint: mp.Path})
+		}
+		return infos, nil
+	})
 	err = dm.DiscoverCommDir(ctx)
 	assert.NoError(t, err)
 
@@ -334,8 +342,10 @@ func TestDaemonsetMounter(t *testing.T) {
 			testCtx := setupDM(t)
 			target := testCtx.targetPath(testCtx.podUID)
 
-			// Skip fakeMounter - it caused waitForMount's CheckMountpoint poll to win the race over .error file poll
+			// Skip fakeMounter's CheckMountpoint match (don't register as "mountpoint-s3")
+			// but register the path in the mount table so unmountIfMounted can find it.
 			testCtx.mountSyscall = func(tgt string, opts mpmounter.MountOptions) (int, error) {
+				testCtx.mount.Mount("fuse-pending", tgt, "fuse", nil)
 				fd, err := syscall.Dup(int(mountertest.OpenDevNull(t).Fd()))
 				assert.NoError(t, err)
 				return fd, nil

--- a/pkg/driver/node/mounter/daemonset_mounter_test.go
+++ b/pkg/driver/node/mounter/daemonset_mounter_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/mount-utils"
 	mountutils "k8s.io/mount-utils"
 
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
@@ -38,7 +37,7 @@ type dmTestCtx struct {
 
 	dm           *mounter.DaemonsetMounter
 	client       *fake.Clientset
-	mount        *mount.FakeMounter
+	mount        *mountutils.FakeMounter
 	mountSyscall func(target string, opts mpmounter.MountOptions) (int, error)
 
 	nodeName      string
@@ -65,7 +64,7 @@ func setupDM(t *testing.T) *dmTestCtx {
 	t.Setenv("MOUNTER_NAMESPACE", "kube-system")
 
 	kubeletPath := t.TempDir()
-	// Eval symlinks on `kubeletPath` as `mount.NewFakeMounter` also does that and we rely on
+	// Eval symlinks on `kubeletPath` as `mountutils.NewFakeMounter` also does that and we rely on
 	// `mount.List()` to compare mount points and they need to be the same.
 	parentDir, err := filepath.EvalSymlinks(filepath.Dir(kubeletPath))
 	assert.NoError(t, err)
@@ -101,7 +100,7 @@ func setupDM(t *testing.T) *dmTestCtx {
 		},
 	}
 	client := fake.NewSimpleClientset(pod)
-	fakeMounter := mount.NewFakeMounter(nil)
+	fakeMounter := mountutils.NewFakeMounter(nil)
 
 	testCtx := &dmTestCtx{
 		t:             t,
@@ -451,7 +450,7 @@ func TestDaemonsetMounter(t *testing.T) {
 					t.Setenv("CONTAINER_KUBELET_PATH", t.TempDir())
 
 					client := fake.NewSimpleClientset(tt.pods...)
-					dm := mounter.NewDaemonsetMounter(client, "test-node", mpmounter.NewWithMount(mount.NewFakeMounter(nil)), nil, nil, nil, nil)
+					dm := mounter.NewDaemonsetMounter(client, "test-node", mpmounter.NewWithMount(mountutils.NewFakeMounter(nil)), nil, nil, nil, nil)
 
 					ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 					defer cancel()
@@ -873,7 +872,7 @@ func (testCtx *dmTestCtx) receiveMountOptions() mountoptions.Options {
 func (testCtx *dmTestCtx) assertUnmounted(target string) {
 	testCtx.t.Helper()
 	for _, action := range testCtx.mount.GetLog() {
-		if action.Action == mount.FakeActionUnmount && action.Target == target {
+		if action.Action == mountutils.FakeActionUnmount && action.Target == target {
 			return
 		}
 	}

--- a/pkg/driver/node/mounter/daemonset_mounter_test.go
+++ b/pkg/driver/node/mounter/daemonset_mounter_test.go
@@ -55,11 +55,6 @@ func (testCtx *dmTestCtx) targetPath(podUID string) string {
 	return filepath.Join(testCtx.kubeletPath, "pods", podUID, "volumes", "kubernetes.io~csi", testCtx.volumeID, "mount")
 }
 
-// targetPathWithVolume returns a valid kubelet-style target path for a specific volumeID.
-func (testCtx *dmTestCtx) targetPathWithVolume(podUID, volumeID string) string {
-	return filepath.Join(testCtx.kubeletPath, "pods", podUID, "volumes", "kubernetes.io~csi", volumeID, "mount")
-}
-
 func setupDM(t *testing.T) *dmTestCtx {
 	t.Helper()
 

--- a/pkg/driver/node/mounter/daemonset_mounter_test.go
+++ b/pkg/driver/node/mounter/daemonset_mounter_test.go
@@ -2,6 +2,7 @@ package mounter_test
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +21,7 @@ import (
 	"k8s.io/mount-utils"
 
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
+	mock_credentialprovider "github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider/mocks"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/mounter"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/mounter/mountertest"
@@ -27,17 +30,6 @@ import (
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/mountpoint/mountoptions"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
 )
-
-// noopCredProvider is a no-op credential provider for unit tests.
-type noopCredProvider struct{}
-
-func (n *noopCredProvider) Provide(_ context.Context, _ credentialprovider.ProvideContext) (envprovider.Environment, credentialprovider.AuthenticationSource, error) {
-	return nil, "", nil
-}
-
-func (n *noopCredProvider) Cleanup(_ credentialprovider.CleanupContext) error {
-	return nil
-}
 
 type dmTestCtx struct {
 	t   *testing.T
@@ -140,7 +132,14 @@ func setupDM(t *testing.T) *dmTestCtx {
 	}
 
 	t.Setenv("CONTAINER_KUBELET_PATH", kubeletPath)
-	dm := mounter.NewDaemonsetMounter(client, nodeName, mpmounter.NewWithMount(fakeMounter), &noopCredProvider{}, mountSyscall, func(source, target string) error {
+	mockCtl := gomock.NewController(t)
+	mockCredProvider := mock_credentialprovider.NewMockProviderInterface(mockCtl)
+	mockCredProvider.EXPECT().Provide(gomock.Any(), gomock.Any()).
+		Return(envprovider.Environment{}, credentialprovider.AuthenticationSourceDriver, nil).
+		AnyTimes()
+	mockCredProvider.EXPECT().Cleanup(gomock.Any()).Return(nil).AnyTimes()
+
+	dm := mounter.NewDaemonsetMounter(client, nodeName, mpmounter.NewWithMount(fakeMounter), mockCredProvider, mountSyscall, func(source, target string) error {
 		return fakeMounter.Mount(source, target, "bind", []string{"bind"})
 	}, nil)
 	err = dm.DiscoverCommDir(ctx)
@@ -202,11 +201,37 @@ func TestDaemonsetMounter(t *testing.T) {
 			}, got)
 		})
 
-		t.Run("Does not duplicate mounts if target is already mounted", func(t *testing.T) {
+		t.Run("Does not duplicate mounts if target is already mounted and refreshes credentials", func(t *testing.T) {
+			mockCtl := gomock.NewController(t)
+			mockCredProvider := mock_credentialprovider.NewMockProviderInterface(mockCtl)
+
 			testCtx := setupDM(t)
 			target := testCtx.targetPath(testCtx.podUID)
 
-			err := os.MkdirAll(target, 0755)
+			// volumeID is the PV name extracted from target path — used as credential dir name
+			expectedWritePath := filepath.Join(testCtx.commDir, testCtx.volumeID)
+			expectedEnvPath := filepath.Join("/comm", testCtx.volumeID)
+
+			mockCredProvider.EXPECT().Provide(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, provideCtx credentialprovider.ProvideContext) (envprovider.Environment, credentialprovider.AuthenticationSource, error) {
+					assert.Equals(t, expectedWritePath, provideCtx.WritePath)
+					assert.Equals(t, expectedEnvPath, provideCtx.EnvPath)
+					assert.Equals(t, credentialprovider.MountKindDaemonset, provideCtx.MountKind)
+					return envprovider.Environment{}, credentialprovider.AuthenticationSourceDriver, nil
+				})
+
+			// Replace DM with one using the custom mock credential provider
+			testCtx.dm = mounter.NewDaemonsetMounter(testCtx.client, testCtx.nodeName,
+				mpmounter.NewWithMount(testCtx.mount), mockCredProvider,
+				func(tgt string, opts mpmounter.MountOptions) (int, error) {
+					return 0, nil
+				}, func(source, target string) error {
+					return testCtx.mount.Mount(source, target, "bind", []string{"bind"})
+				}, nil)
+			err := testCtx.dm.DiscoverCommDir(testCtx.ctx)
+			assert.NoError(t, err)
+
+			err = os.MkdirAll(target, 0755)
 			assert.NoError(t, err)
 			testCtx.mount.Mount("mountpoint-s3", target, "fuse", nil)
 
@@ -225,6 +250,53 @@ func TestDaemonsetMounter(t *testing.T) {
 			if mountSyscallCalled {
 				t.Error("mountSyscall should not be called for already-mounted target")
 			}
+		})
+
+		t.Run("Credentials cleaned up on mount failure", func(t *testing.T) {
+			mockCtl := gomock.NewController(t)
+			mockCredProvider := mock_credentialprovider.NewMockProviderInterface(mockCtl)
+
+			testCtx := setupDM(t)
+			target := testCtx.targetPath(testCtx.podUID)
+
+			expectedWritePath := filepath.Join(testCtx.commDir, testCtx.volumeID)
+			expectedEnvPath := filepath.Join("/comm", testCtx.volumeID)
+
+			provideCall := mockCredProvider.EXPECT().Provide(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, provideCtx credentialprovider.ProvideContext) (envprovider.Environment, credentialprovider.AuthenticationSource, error) {
+					assert.Equals(t, expectedWritePath, provideCtx.WritePath)
+					assert.Equals(t, expectedEnvPath, provideCtx.EnvPath)
+					assert.Equals(t, credentialprovider.MountKindDaemonset, provideCtx.MountKind)
+					return envprovider.Environment{}, credentialprovider.AuthenticationSourceDriver, nil
+				})
+
+			mockCredProvider.EXPECT().Cleanup(gomock.Any()).After(provideCall).
+				DoAndReturn(func(cleanupCtx credentialprovider.CleanupContext) error {
+					assert.Equals(t, expectedWritePath, cleanupCtx.WritePath)
+					assert.Equals(t, credentialprovider.MountKindDaemonset, cleanupCtx.MountKind)
+					return nil
+				})
+
+			// Replace DM with one using the custom mock credential provider
+			mountErr := fmt.Errorf("simulated mount failure")
+			testCtx.dm = mounter.NewDaemonsetMounter(testCtx.client, testCtx.nodeName,
+				mpmounter.NewWithMount(testCtx.mount), mockCredProvider,
+				func(tgt string, opts mpmounter.MountOptions) (int, error) {
+					return 0, mountErr
+				}, func(source, target string) error {
+					return testCtx.mount.Mount(source, target, "bind", []string{"bind"})
+				}, nil)
+			err := testCtx.dm.DiscoverCommDir(testCtx.ctx)
+			assert.NoError(t, err)
+
+			err = testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target, credentialprovider.ProvideContext{
+				WorkloadPodID: testCtx.podUID,
+				VolumeID:      testCtx.volumeID,
+			}, mountpoint.ParseArgs(nil), "", nil)
+			if err == nil {
+				t.Fatal("mount should fail")
+			}
+			assert.Contains(t, err.Error(), "simulated mount failure")
 		})
 
 		t.Run("Unmounts source if mounter does not receive mount options", func(t *testing.T) {
@@ -250,10 +322,13 @@ func TestDaemonsetMounter(t *testing.T) {
 			assert.Contains(t, err.Error(), "failed to send mount options")
 
 			// In sharing mode, FUSE mount goes to source path, not target.
-			// After failure, source should be unmounted and target should not exist.
+			// After failure, source should be unmounted and cleaned up (directory removed).
 			sourcePath := filepath.Join(testCtx.kubeletPath, "plugins", "s3.csi.aws.com", "mnt", testCtx.volumeID)
 			mounted, err := testCtx.dm.IsMountPoint(sourcePath)
-			assert.NoError(t, err)
+			// ErrNotExist is expected: cleanupMount removes the source directory after unmounting.
+			if err != nil && !os.IsNotExist(err) {
+				t.Fatalf("unexpected error checking mount point: %v", err)
+			}
 			if mounted {
 				t.Error("it should unmount source if mounter does not receive the mount options")
 			}
@@ -371,7 +446,7 @@ func TestDaemonsetMounter(t *testing.T) {
 					t.Setenv("CONTAINER_KUBELET_PATH", t.TempDir())
 
 					client := fake.NewSimpleClientset(tt.pods...)
-					dm := mounter.NewDaemonsetMounter(client, "test-node", mpmounter.NewWithMount(mount.NewFakeMounter(nil)), &noopCredProvider{}, nil, nil, nil)
+					dm := mounter.NewDaemonsetMounter(client, "test-node", mpmounter.NewWithMount(mount.NewFakeMounter(nil)), nil, nil, nil, nil)
 
 					ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 					defer cancel()
@@ -416,7 +491,7 @@ func TestDaemonsetMounter(t *testing.T) {
 			testCtx.dm = mounter.NewDaemonsetMounter(
 				testCtx.client, testCtx.nodeName,
 				mpmounter.NewWithMount(testCtx.mount),
-				&noopCredProvider{},
+				nil,
 				func(target string, opts mpmounter.MountOptions) (int, error) {
 					mountSyscallCalled = true
 					return 0, nil
@@ -551,10 +626,20 @@ func TestDaemonsetMounter_PodSharing(t *testing.T) {
 		assert.Equals(t, 1, fuseMountCount)
 	})
 
-	t.Run("Second pod rejected with different service account", func(t *testing.T) {
+	t.Run("Second pod rejected with different service account (pod auth) without overwriting credentials", func(t *testing.T) {
+		mockCtl := gomock.NewController(t)
+		mockCredProvider := mock_credentialprovider.NewMockProviderInterface(mockCtl)
+
 		testCtx := setupDM(t)
 		target1 := testCtx.targetPath("pod-a-uid")
 		target2 := testCtx.targetPath("pod-b-uid")
+
+		// Expect Provide to be called exactly once (for the first pod only).
+		// The second pod should be rejected BEFORE provideCredentials is reached.
+		mockCredProvider.EXPECT().Provide(gomock.Any(), gomock.Any()).
+			Return(envprovider.Environment{}, credentialprovider.AuthenticationSourceDriver, nil).
+			Times(1)
+		mockCredProvider.EXPECT().Cleanup(gomock.Any()).Return(nil).AnyTimes()
 
 		testCtx.mountSyscall = func(tgt string, opts mpmounter.MountOptions) (int, error) {
 			testCtx.mount.Mount("mountpoint-s3", tgt, "fuse", nil)
@@ -563,7 +648,64 @@ func TestDaemonsetMounter_PodSharing(t *testing.T) {
 			return fd, nil
 		}
 
-		// Mount first pod with sa-a
+		// Replace DM with one using the strict mock
+		testCtx.dm = mounter.NewDaemonsetMounter(testCtx.client, testCtx.nodeName,
+			mpmounter.NewWithMount(testCtx.mount), mockCredProvider,
+			testCtx.mountSyscall, func(source, target string) error {
+				return testCtx.mount.Mount(source, target, "bind", []string{"bind"})
+			}, nil)
+		err := testCtx.dm.DiscoverCommDir(testCtx.ctx)
+		assert.NoError(t, err)
+
+		// Mount first pod with sa-a using pod auth
+		mountRes := make(chan error)
+		go func() {
+			mountRes <- testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target1, credentialprovider.ProvideContext{
+				WorkloadPodID:        "pod-a-uid",
+				VolumeID:             testCtx.volumeID,
+				AuthenticationSource: "pod",
+				ServiceAccountName:   "sa-a",
+				PodNamespace:         "default",
+			}, mountpoint.ParseArgs(nil), "", nil)
+		}()
+
+		testCtx.receiveMountOptions()
+		sourcePath := mounter.SourceMountPath(testCtx.kubeletPath, testCtx.volumeID)
+		testCtx.mount.Mount("mountpoint-s3", sourcePath, "fuse", nil)
+
+		err = <-mountRes
+		assert.NoError(t, err)
+
+		// Second pod with sa-b — should be rejected because pod auth enforces SA match.
+		// Provide must NOT be called again (gomock Times(1) will fail if it is).
+		err = testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target2, credentialprovider.ProvideContext{
+			WorkloadPodID:        "pod-b-uid",
+			VolumeID:             testCtx.volumeID,
+			AuthenticationSource: "pod",
+			ServiceAccountName:   "sa-b",
+			PodNamespace:         "default",
+		}, mountpoint.ParseArgs(nil), "", nil)
+		if err == nil {
+			t.Fatal("expected error for mismatched service account with pod auth")
+		}
+		assert.Contains(t, err.Error(), "serviceAccountName mismatch")
+	})
+
+	t.Run("Second pod with different service account allowed with driver auth", func(t *testing.T) {
+		testCtx := setupDM(t)
+		target1 := testCtx.targetPath("pod-a-uid")
+		target2 := testCtx.targetPath("pod-b-uid")
+
+		fuseMountCount := 0
+		testCtx.mountSyscall = func(tgt string, opts mpmounter.MountOptions) (int, error) {
+			fuseMountCount++
+			testCtx.mount.Mount("mountpoint-s3", tgt, "fuse", nil)
+			fd, err := syscall.Dup(int(mountertest.OpenDevNull(t).Fd()))
+			assert.NoError(t, err)
+			return fd, nil
+		}
+
+		// Mount first pod with sa-a using driver auth
 		mountRes := make(chan error)
 		go func() {
 			mountRes <- testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target1, credentialprovider.ProvideContext{
@@ -582,7 +724,7 @@ func TestDaemonsetMounter_PodSharing(t *testing.T) {
 		err := <-mountRes
 		assert.NoError(t, err)
 
-		// Second pod with sa-b — should be rejected
+		// Second pod with sa-b — should SUCCEED because driver auth doesn't enforce SA match
 		err = testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target2, credentialprovider.ProvideContext{
 			WorkloadPodID:        "pod-b-uid",
 			VolumeID:             testCtx.volumeID,
@@ -590,10 +732,10 @@ func TestDaemonsetMounter_PodSharing(t *testing.T) {
 			ServiceAccountName:   "sa-b",
 			PodNamespace:         "default",
 		}, mountpoint.ParseArgs(nil), "", nil)
-		if err == nil {
-			t.Fatal("expected error for mismatched service account")
-		}
-		assert.Contains(t, err.Error(), "serviceAccountName mismatch")
+		assert.NoError(t, err)
+
+		// Only 1 FUSE mount — second pod shared via bind mount
+		assert.Equals(t, 1, fuseMountCount)
 	})
 
 	t.Run("Unmount last consumer resets entry, next mount with diff params succeeds", func(t *testing.T) {

--- a/pkg/driver/node/mounter/mount_map.go
+++ b/pkg/driver/node/mounter/mount_map.go
@@ -85,11 +85,9 @@ type MountEntry struct {
 	// SourcePath is the path where the FUSE mount lives (one Mountpoint process).
 	SourcePath string
 
-	// VolumeID is the CSI volume ID (volumeHandle from the PV).
+	// VolumeID is the PV name, used as the sharing key, credential directory name,
+	// error file name, and mount identifier when communicating with the secondary daemonset.
 	VolumeID string
-
-	// MountID is the identifier used when communicating with the secondary daemonset.
-	MountID string
 
 	// Params records the mount parameters for validation of subsequent share requests.
 	Params MountParams

--- a/pkg/driver/node/mounter/mount_map.go
+++ b/pkg/driver/node/mounter/mount_map.go
@@ -1,0 +1,148 @@
+// Package mounter provides mount implementations for the CSI driver.
+package mounter
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// MountParams captures the parameters that must be identical across all pods sharing a mount.
+// If any of these differ between the existing mount and a new share request, sharing is rejected.
+type MountParams struct {
+	// MountOptions is the sorted list of Mountpoint arguments used for this mount.
+	MountOptions []string
+
+	// AuthenticationSource is "driver" or "pod".
+	AuthenticationSource string
+
+	// ServiceAccountName is the K8s service account of the pod.
+	ServiceAccountName string
+
+	// ServiceAccountEKSRoleARN is the IAM role ARN from the service account's
+	// eks.amazonaws.com/role-arn annotation. Empty when authenticationSource is "driver".
+	ServiceAccountEKSRoleARN string
+
+	// PodNamespace is the namespace of the pod.
+	PodNamespace string
+
+	// FSGroup is the volume mount group (security context).
+	FSGroup string
+}
+
+// ValidateCompatibility checks whether the new request's params are compatible with the
+// existing mount's params. Returns nil if sharing is allowed, or an error describing
+// the first incompatibility found.
+func (existing *MountParams) ValidateCompatibility(incoming *MountParams) error {
+	if !slices.Equal(existing.MountOptions, incoming.MountOptions) {
+		return fmt.Errorf("mount options mismatch: existing=%v, incoming=%v",
+			existing.MountOptions, incoming.MountOptions)
+	}
+
+	if existing.AuthenticationSource != incoming.AuthenticationSource {
+		return fmt.Errorf("authenticationSource mismatch: existing=%q, incoming=%q",
+			existing.AuthenticationSource, incoming.AuthenticationSource)
+	}
+
+	if existing.ServiceAccountName != incoming.ServiceAccountName {
+		return fmt.Errorf("serviceAccountName mismatch: existing=%q, incoming=%q",
+			existing.ServiceAccountName, incoming.ServiceAccountName)
+	}
+
+	if existing.ServiceAccountEKSRoleARN != incoming.ServiceAccountEKSRoleARN {
+		return fmt.Errorf("serviceAccountEKSRoleARN mismatch: existing=%q, incoming=%q",
+			existing.ServiceAccountEKSRoleARN, incoming.ServiceAccountEKSRoleARN)
+	}
+
+	if existing.PodNamespace != incoming.PodNamespace {
+		return fmt.Errorf("podNamespace mismatch: existing=%q, incoming=%q",
+			existing.PodNamespace, incoming.PodNamespace)
+	}
+
+	if existing.FSGroup != incoming.FSGroup {
+		return fmt.Errorf("fsGroup (security context) mismatch: existing=%q, incoming=%q",
+			existing.FSGroup, incoming.FSGroup)
+	}
+
+	return nil
+}
+
+// String returns a human-readable summary of the params for logging.
+func (p *MountParams) String() string {
+	return fmt.Sprintf("{auth=%s, sa=%s, roleARN=%s, ns=%s, fsGroup=%s, opts=[%s]}",
+		p.AuthenticationSource, p.ServiceAccountName, p.ServiceAccountEKSRoleARN,
+		p.PodNamespace, p.FSGroup, strings.Join(p.MountOptions, ", "))
+}
+
+// MountEntry tracks a shared source mount and the set of bind-mount targets referencing it.
+// The embedded mutex provides per-PV locking — callers hold entry.mu during multi-step
+// operations (health check → validate → bind mount → add target).
+type MountEntry struct {
+	mu sync.Mutex // per-PV lock, held during mount/unmount operations
+
+	// SourcePath is the path where the FUSE mount lives (one Mountpoint process).
+	SourcePath string
+
+	// VolumeID is the CSI volume ID (volumeHandle from the PV).
+	VolumeID string
+
+	// MountID is the identifier used when communicating with the secondary daemonset.
+	MountID string
+
+	// Params records the mount parameters for validation of subsequent share requests.
+	Params MountParams
+
+	// RefCount is the number of pods currently using this mount via bind mounts.
+	// Invariant: RefCount == len(Targets) when entry.mu is not held.
+	RefCount int
+
+	// Targets is the set of active per-pod bind-mount target paths.
+	Targets []string
+
+	// initialized is true once the entry has a real source mount backing it.
+	// Used to distinguish between a placeholder (LoadOrStore created) and a populated entry.
+	initialized bool
+}
+
+// MountMap is a lock-free map tracking active source mounts keyed by volume ID.
+// Uses sync.Map for zero-contention concurrent access across different volumes.
+// Per-PV locking is achieved by locking entry.mu on the MountEntry itself.
+type MountMap struct {
+	entries sync.Map // map[volumeID]*MountEntry
+}
+
+// NewMountMap creates a new empty MountMap.
+func NewMountMap() *MountMap {
+	return &MountMap{}
+}
+
+// GetOrCreate returns the existing entry for volumeID, or creates a new uninitialized one.
+// The caller must lock the returned entry before using it.
+// The bool indicates whether the entry already existed (true) or was just created (false).
+func (m *MountMap) GetOrCreate(volumeID string) (*MountEntry, bool) {
+	entry := &MountEntry{VolumeID: volumeID}
+	actual, loaded := m.entries.LoadOrStore(volumeID, entry)
+	return actual.(*MountEntry), loaded
+}
+
+// Get returns the mount entry for the given volume ID, or nil if not found.
+func (m *MountMap) Get(volumeID string) *MountEntry {
+	val, ok := m.entries.Load(volumeID)
+	if !ok {
+		return nil
+	}
+	return val.(*MountEntry)
+}
+
+// Delete removes the entry for the given volume ID from the map.
+func (m *MountMap) Delete(volumeID string) {
+	m.entries.Delete(volumeID)
+}
+
+// SourceMountPath returns the source mount directory for a given volume.
+// This path is stable across pod lifecycles — it's keyed by volume, not pod.
+func SourceMountPath(kubeletPath, volumeID string) string {
+	return filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt", volumeID)
+}

--- a/pkg/driver/node/mounter/mount_map.go
+++ b/pkg/driver/node/mounter/mount_map.go
@@ -46,9 +46,15 @@ func (existing *MountParams) ValidateCompatibility(incoming *MountParams) error 
 			existing.AuthenticationSource, incoming.AuthenticationSource)
 	}
 
-	// SA and role ARN only matter for pod-level authentication. When auth source is "driver",
-	// credentials come from the CSI driver's own service account — the workload pod's SA is irrelevant.
+	// SA, role ARN, and namespace only matter for pod-level authentication. When auth source is "driver",
+	// credentials come from the CSI driver's own service account — the workload pod's namespace and SA are irrelevant.
+	// This matches V2 PodMounter behavior (see buildFieldFilters in reconciler.go).
 	if existing.AuthenticationSource == "pod" {
+		if existing.PodNamespace != incoming.PodNamespace {
+			return fmt.Errorf("podNamespace mismatch: existing=%q, incoming=%q",
+				existing.PodNamespace, incoming.PodNamespace)
+		}
+
 		if existing.ServiceAccountName != incoming.ServiceAccountName {
 			return fmt.Errorf("serviceAccountName mismatch: existing=%q, incoming=%q",
 				existing.ServiceAccountName, incoming.ServiceAccountName)
@@ -58,11 +64,6 @@ func (existing *MountParams) ValidateCompatibility(incoming *MountParams) error 
 			return fmt.Errorf("serviceAccountEKSRoleARN mismatch: existing=%q, incoming=%q",
 				existing.ServiceAccountEKSRoleARN, incoming.ServiceAccountEKSRoleARN)
 		}
-	}
-
-	if existing.PodNamespace != incoming.PodNamespace {
-		return fmt.Errorf("podNamespace mismatch: existing=%q, incoming=%q",
-			existing.PodNamespace, incoming.PodNamespace)
 	}
 
 	if existing.FSGroup != incoming.FSGroup {

--- a/pkg/driver/node/mounter/mount_map.go
+++ b/pkg/driver/node/mounter/mount_map.go
@@ -108,9 +108,9 @@ type MountEntry struct {
 	// Targets is the set of active per-pod bind-mount target paths.
 	Targets []string
 
-	// initialized is true once the entry has a real source mount backing it.
+	// sourceMounted is true once the FUSE source mount exists and is serving.
 	// Used to distinguish between a placeholder (LoadOrStore created) and a populated entry.
-	initialized bool
+	sourceMounted bool
 }
 
 // MountMap is a lock-free map tracking active source mounts keyed by volume ID.
@@ -125,7 +125,7 @@ func NewMountMap() *MountMap {
 	return &MountMap{}
 }
 
-// GetOrCreate returns the existing entry for volumeID, or creates a new uninitialized one.
+// GetOrCreate returns the existing entry for volumeID, or creates a new unmounted one.
 // The caller must lock the returned entry before using it.
 // The bool indicates whether the entry already existed (true) or was just created (false).
 func (m *MountMap) GetOrCreate(volumeID string) (*MountEntry, bool) {

--- a/pkg/driver/node/mounter/mount_map.go
+++ b/pkg/driver/node/mounter/mount_map.go
@@ -46,14 +46,18 @@ func (existing *MountParams) ValidateCompatibility(incoming *MountParams) error 
 			existing.AuthenticationSource, incoming.AuthenticationSource)
 	}
 
-	if existing.ServiceAccountName != incoming.ServiceAccountName {
-		return fmt.Errorf("serviceAccountName mismatch: existing=%q, incoming=%q",
-			existing.ServiceAccountName, incoming.ServiceAccountName)
-	}
+	// SA and role ARN only matter for pod-level authentication. When auth source is "driver",
+	// credentials come from the CSI driver's own service account — the workload pod's SA is irrelevant.
+	if existing.AuthenticationSource == "pod" {
+		if existing.ServiceAccountName != incoming.ServiceAccountName {
+			return fmt.Errorf("serviceAccountName mismatch: existing=%q, incoming=%q",
+				existing.ServiceAccountName, incoming.ServiceAccountName)
+		}
 
-	if existing.ServiceAccountEKSRoleARN != incoming.ServiceAccountEKSRoleARN {
-		return fmt.Errorf("serviceAccountEKSRoleARN mismatch: existing=%q, incoming=%q",
-			existing.ServiceAccountEKSRoleARN, incoming.ServiceAccountEKSRoleARN)
+		if existing.ServiceAccountEKSRoleARN != incoming.ServiceAccountEKSRoleARN {
+			return fmt.Errorf("serviceAccountEKSRoleARN mismatch: existing=%q, incoming=%q",
+				existing.ServiceAccountEKSRoleARN, incoming.ServiceAccountEKSRoleARN)
+		}
 	}
 
 	if existing.PodNamespace != incoming.PodNamespace {
@@ -88,6 +92,11 @@ type MountEntry struct {
 	// VolumeID is the PV name, used as the sharing key, credential directory name,
 	// error file name, and mount identifier when communicating with the secondary daemonset.
 	VolumeID string
+
+	// CommDir is the comm directory path at the time this mount was created.
+	// Cleanup uses this to ensure resources are cleaned in the same location where they were
+	// provisioned, avoiding mismatches if the mounter pod restarts between mount and unmount.
+	CommDir string
 
 	// Params records the mount parameters for validation of subsequent share requests.
 	Params MountParams

--- a/pkg/driver/node/mounter/mount_map_persistence.go
+++ b/pkg/driver/node/mounter/mount_map_persistence.go
@@ -1,0 +1,145 @@
+// Package mounter provides mount implementations for the CSI driver.
+package mounter
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// MetaFileName returns the path to the .meta.json file for a given volume.
+// The file lives alongside the FUSE source mount directory.
+func MetaFileName(kubeletPath, volumeID string) string {
+	return filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt", volumeID+".meta.json")
+}
+
+// MountMeta is the JSON-serializable structure persisted alongside each source mount.
+// It records the parameters used to create the mount — enabling validation on recovery
+// and for subsequent share requests after driver restart.
+type MountMeta struct {
+	VolumeID                 string   `json:"volumeID"`
+	MountOptions             []string `json:"mountOptions"`
+	AuthenticationSource     string   `json:"authenticationSource"`
+	ServiceAccountName       string   `json:"serviceAccountName"`
+	ServiceAccountEKSRoleARN string   `json:"serviceAccountEKSRoleARN,omitempty"`
+	PodNamespace             string   `json:"podNamespace"`
+	FSGroup                  string   `json:"fsGroup"`
+}
+
+// WriteMeta atomically writes the .meta.json file for the given volume.
+// Uses temp file + os.Rename for atomicity (rename is atomic on Linux).
+func WriteMeta(kubeletPath string, entry *MountEntry) error {
+	meta := MountMeta{
+		VolumeID:                 entry.VolumeID,
+		MountOptions:             entry.Params.MountOptions,
+		AuthenticationSource:     entry.Params.AuthenticationSource,
+		ServiceAccountName:       entry.Params.ServiceAccountName,
+		ServiceAccountEKSRoleARN: entry.Params.ServiceAccountEKSRoleARN,
+		PodNamespace:             entry.Params.PodNamespace,
+		FSGroup:                  entry.Params.FSGroup,
+	}
+
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal mount meta for volume %s: %w", entry.VolumeID, err)
+	}
+
+	metaPath := MetaFileName(kubeletPath, entry.VolumeID)
+	if err := os.MkdirAll(filepath.Dir(metaPath), 0750); err != nil {
+		return fmt.Errorf("failed to create meta directory: %w", err)
+	}
+
+	tmpPath := metaPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write temp meta file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, metaPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename meta file: %w", err)
+	}
+
+	klog.V(4).Infof("MountMap: wrote meta for volume %s at %s", entry.VolumeID, metaPath)
+	return nil
+}
+
+// RemoveMeta removes the .meta.json file for the given volume.
+// Called when the last consumer disconnects and the source mount is torn down.
+func RemoveMeta(kubeletPath, volumeID string) {
+	metaPath := MetaFileName(kubeletPath, volumeID)
+	if err := os.Remove(metaPath); err != nil && !os.IsNotExist(err) {
+		klog.Warningf("MountMap: failed to remove meta file %s: %v", metaPath, err)
+	}
+}
+
+// readMeta reads and parses a .meta.json file.
+func readMeta(path string) (*MountMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var meta MountMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal %s: %w", path, err)
+	}
+	return &meta, nil
+}
+
+// mountInfoEntry represents a single line from /proc/self/mountinfo.
+type mountInfoEntry struct {
+	MountPoint string // the mount point path
+	DeviceID   string // major:minor device ID
+}
+
+// parseMountInfoFromProc reads /proc/self/mountinfo and returns all entries.
+// This is the default implementation used in production (Linux).
+func parseMountInfoFromProc() ([]mountInfoEntry, error) {
+	f, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var entries []mountInfoEntry
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		// mountinfo format: mountID parentID major:minor root mountPoint ...
+		if len(fields) < 5 {
+			continue
+		}
+		entries = append(entries, mountInfoEntry{
+			DeviceID:   fields[2], // major:minor
+			MountPoint: fields[4], // mount point
+		})
+	}
+	return entries, scanner.Err()
+}
+
+// findMountByPath finds the mountinfo entry for a given mount path.
+func findMountByPath(entries []mountInfoEntry, path string) *mountInfoEntry {
+	for i := range entries {
+		if entries[i].MountPoint == path {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
+// findBindMountTargets finds all mount points sharing the same device ID as the source,
+// excluding the source path itself. These are the bind mount targets.
+func findBindMountTargets(entries []mountInfoEntry, deviceID, sourcePath string) []string {
+	var targets []string
+	for _, e := range entries {
+		if e.DeviceID == deviceID && e.MountPoint != sourcePath {
+			targets = append(targets, e.MountPoint)
+		}
+	}
+	return targets
+}

--- a/pkg/driver/node/mounter/mount_map_persistence.go
+++ b/pkg/driver/node/mounter/mount_map_persistence.go
@@ -2,14 +2,13 @@
 package mounter
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"k8s.io/klog/v2"
+	mountutils "k8s.io/mount-utils"
 )
 
 // MetaFileName returns the path to the .meta.json file for a given volume.
@@ -23,10 +22,11 @@ func MetaFileName(kubeletPath, volumeID string) string {
 // and for subsequent share requests after driver restart.
 type MountMeta struct {
 	VolumeID                 string   `json:"volumeID"`
+	CommDir                  string   `json:"commDir,omitempty"`
 	MountOptions             []string `json:"mountOptions"`
 	AuthenticationSource     string   `json:"authenticationSource"`
 	ServiceAccountName       string   `json:"serviceAccountName"`
-	ServiceAccountEKSRoleARN string   `json:"serviceAccountEKSRoleARN,omitempty"`
+	ServiceAccountEKSRoleARN string   `json:"serviceAccountEKSRoleARN"`
 	PodNamespace             string   `json:"podNamespace"`
 	FSGroup                  string   `json:"fsGroup"`
 }
@@ -36,6 +36,7 @@ type MountMeta struct {
 func WriteMeta(kubeletPath string, entry *MountEntry) error {
 	meta := MountMeta{
 		VolumeID:                 entry.VolumeID,
+		CommDir:                  entry.CommDir,
 		MountOptions:             entry.Params.MountOptions,
 		AuthenticationSource:     entry.Params.AuthenticationSource,
 		ServiceAccountName:       entry.Params.ServiceAccountName,
@@ -90,40 +91,19 @@ func readMeta(path string) (*MountMeta, error) {
 	return &meta, nil
 }
 
-// mountInfoEntry represents a single line from /proc/self/mountinfo.
-type mountInfoEntry struct {
-	MountPoint string // the mount point path
-	DeviceID   string // major:minor device ID
+// parseMountInfoFromProc reads /proc/self/mountinfo and returns all entries
+// using the well-tested k8s.io/mount-utils library.
+func parseMountInfoFromProc() ([]mountutils.MountInfo, error) {
+	return mountutils.ParseMountInfo("/proc/self/mountinfo")
 }
 
-// parseMountInfoFromProc reads /proc/self/mountinfo and returns all entries.
-// This is the default implementation used in production (Linux).
-func parseMountInfoFromProc() ([]mountInfoEntry, error) {
-	f, err := os.Open("/proc/self/mountinfo")
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	var entries []mountInfoEntry
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		fields := strings.Fields(line)
-		// mountinfo format: mountID parentID major:minor root mountPoint ...
-		if len(fields) < 5 {
-			continue
-		}
-		entries = append(entries, mountInfoEntry{
-			DeviceID:   fields[2], // major:minor
-			MountPoint: fields[4], // mount point
-		})
-	}
-	return entries, scanner.Err()
+// deviceID returns the "major:minor" string for a MountInfo entry.
+func deviceID(mi *mountutils.MountInfo) string {
+	return fmt.Sprintf("%d:%d", mi.Major, mi.Minor)
 }
 
 // findMountByPath finds the mountinfo entry for a given mount path.
-func findMountByPath(entries []mountInfoEntry, path string) *mountInfoEntry {
+func findMountByPath(entries []mountutils.MountInfo, path string) *mountutils.MountInfo {
 	for i := range entries {
 		if entries[i].MountPoint == path {
 			return &entries[i]
@@ -134,11 +114,11 @@ func findMountByPath(entries []mountInfoEntry, path string) *mountInfoEntry {
 
 // findBindMountTargets finds all mount points sharing the same device ID as the source,
 // excluding the source path itself. These are the bind mount targets.
-func findBindMountTargets(entries []mountInfoEntry, deviceID, sourcePath string) []string {
+func findBindMountTargets(entries []mountutils.MountInfo, majorMinor, sourcePath string) []string {
 	var targets []string
-	for _, e := range entries {
-		if e.DeviceID == deviceID && e.MountPoint != sourcePath {
-			targets = append(targets, e.MountPoint)
+	for i := range entries {
+		if deviceID(&entries[i]) == majorMinor && entries[i].MountPoint != sourcePath {
+			targets = append(targets, entries[i].MountPoint)
 		}
 	}
 	return targets

--- a/pkg/driver/node/mounter/mount_map_persistence.go
+++ b/pkg/driver/node/mounter/mount_map_persistence.go
@@ -12,9 +12,10 @@ import (
 )
 
 // MetaFileName returns the path to the .meta.json file for a given volume.
-// The file lives alongside the FUSE source mount directory.
+// Meta files live in a dedicated directory separate from FUSE source mounts to avoid
+// collisions with PV names that could end in ".meta.json".
 func MetaFileName(kubeletPath, volumeID string) string {
-	return filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt", volumeID+".meta.json")
+	return filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "meta", volumeID+".meta.json")
 }
 
 // MountMeta is the JSON-serializable structure persisted alongside each source mount.
@@ -22,7 +23,7 @@ func MetaFileName(kubeletPath, volumeID string) string {
 // and for subsequent share requests after driver restart.
 type MountMeta struct {
 	VolumeID                 string   `json:"volumeID"`
-	CommDir                  string   `json:"commDir,omitempty"`
+	CommDir                  string   `json:"commDir"`
 	MountOptions             []string `json:"mountOptions"`
 	AuthenticationSource     string   `json:"authenticationSource"`
 	ServiceAccountName       string   `json:"serviceAccountName"`

--- a/pkg/driver/node/mounter/mount_map_persistence_test.go
+++ b/pkg/driver/node/mounter/mount_map_persistence_test.go
@@ -31,7 +31,6 @@ func TestWriteMeta_CreatesFile(t *testing.T) {
 
 	entry := &MountEntry{
 		VolumeID:   "vol-abc123",
-		MountID:    "vol-abc123",
 		SourcePath: filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt", "vol-abc123"),
 		Params: MountParams{
 			MountOptions:             []string{"--allow-other", "--region=us-east-1"},
@@ -77,7 +76,6 @@ func TestWriteMeta_OverwritesExisting(t *testing.T) {
 
 	entry1 := &MountEntry{
 		VolumeID:   "vol-overwrite",
-		MountID:    "vol-overwrite",
 		SourcePath: "/source-1",
 		Params:     MountParams{ServiceAccountName: "sa-first"},
 	}
@@ -86,7 +84,6 @@ func TestWriteMeta_OverwritesExisting(t *testing.T) {
 
 	entry2 := &MountEntry{
 		VolumeID:   "vol-overwrite",
-		MountID:    "vol-overwrite",
 		SourcePath: "/source-2",
 		Params:     MountParams{ServiceAccountName: "sa-second"},
 	}
@@ -101,13 +98,14 @@ func TestWriteMeta_OverwritesExisting(t *testing.T) {
 func TestWriteMeta_CreatesDirectoryIfMissing(t *testing.T) {
 	kubeletPath := t.TempDir()
 
+	entry := &MountEntry{VolumeID: "vol-mkdir", SourcePath: "/source"}
+
 	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
 	_, err := os.Stat(metaDir)
 	if !os.IsNotExist(err) {
 		t.Fatal("expected meta directory to not exist initially")
 	}
 
-	entry := &MountEntry{VolumeID: "vol-mkdir", MountID: "vol-mkdir", SourcePath: "/source"}
 	err = WriteMeta(kubeletPath, entry)
 	assert.NoError(t, err)
 
@@ -121,7 +119,7 @@ func TestWriteMeta_CreatesDirectoryIfMissing(t *testing.T) {
 func TestRemoveMeta_RemovesFile(t *testing.T) {
 	kubeletPath := t.TempDir()
 
-	entry := &MountEntry{VolumeID: "vol-remove", MountID: "vol-remove", SourcePath: "/source"}
+	entry := &MountEntry{VolumeID: "vol-remove", SourcePath: "/source"}
 	err := WriteMeta(kubeletPath, entry)
 	assert.NoError(t, err)
 
@@ -147,7 +145,6 @@ func TestReadMeta_ParsesCorrectly(t *testing.T) {
 
 	entry := &MountEntry{
 		VolumeID:   "vol-read",
-		MountID:    "vol-read",
 		SourcePath: "/my/source/path",
 		Params: MountParams{
 			MountOptions:             []string{"--read-only"},
@@ -207,8 +204,8 @@ func TestWriteMeta_EmptyMountOptions(t *testing.T) {
 	kubeletPath := t.TempDir()
 
 	entry := &MountEntry{
-		VolumeID: "vol-empty-opts", MountID: "vol-empty-opts", SourcePath: "/source",
-		Params: MountParams{MountOptions: nil, AuthenticationSource: "driver"},
+		VolumeID: "vol-empty-opts",
+		Params:   MountParams{MountOptions: nil, AuthenticationSource: "driver"},
 	}
 	err := WriteMeta(kubeletPath, entry)
 	assert.NoError(t, err)
@@ -224,8 +221,8 @@ func TestWriteMeta_EmptyEKSRoleARN_OmittedInJSON(t *testing.T) {
 	kubeletPath := t.TempDir()
 
 	entry := &MountEntry{
-		VolumeID: "vol-no-arn", MountID: "vol-no-arn", SourcePath: "/source",
-		Params: MountParams{AuthenticationSource: "driver", ServiceAccountEKSRoleARN: ""},
+		VolumeID: "vol-no-arn",
+		Params:   MountParams{AuthenticationSource: "driver", ServiceAccountEKSRoleARN: ""},
 	}
 	err := WriteMeta(kubeletPath, entry)
 	assert.NoError(t, err)
@@ -364,8 +361,9 @@ func TestRebuildMountMap_CleansUpDeadSourceMounts(t *testing.T) {
 	sourcePath := SourceMountPath(kubeletPath, "vol-dead")
 
 	entry := &MountEntry{
-		VolumeID: "vol-dead", MountID: "vol-dead", SourcePath: sourcePath,
-		Params: MountParams{AuthenticationSource: "driver", ServiceAccountName: "default"},
+		VolumeID:   "vol-dead",
+		SourcePath: sourcePath,
+		Params:     MountParams{AuthenticationSource: "driver", ServiceAccountName: "default"},
 	}
 	err := WriteMeta(kubeletPath, entry)
 	assert.NoError(t, err)
@@ -394,7 +392,8 @@ func TestRebuildMountMap_RecoversLiveSourceWithBindMounts(t *testing.T) {
 	sourcePath := SourceMountPath(kubeletPath, "vol-live")
 
 	entry := &MountEntry{
-		VolumeID: "vol-live", MountID: "vol-live", SourcePath: sourcePath,
+		VolumeID:   "vol-live",
+		SourcePath: sourcePath,
 		Params: MountParams{
 			MountOptions:             []string{"--allow-other"},
 			AuthenticationSource:     "pod",
@@ -424,7 +423,6 @@ func TestRebuildMountMap_RecoversLiveSourceWithBindMounts(t *testing.T) {
 	}
 
 	assert.Equals(t, sourcePath, recovered.SourcePath)
-	assert.Equals(t, "vol-live", recovered.MountID)
 	assert.Equals(t, 3, recovered.RefCount)
 	assert.Equals(t, 3, len(recovered.Targets))
 	assert.Equals(t, true, recovered.initialized)
@@ -444,8 +442,9 @@ func TestRebuildMountMap_SourceWithNoBindMounts(t *testing.T) {
 	sourcePath := SourceMountPath(kubeletPath, "vol-orphan")
 
 	entry := &MountEntry{
-		VolumeID: "vol-orphan", MountID: "vol-orphan", SourcePath: sourcePath,
-		Params: MountParams{AuthenticationSource: "driver"},
+		VolumeID:   "vol-orphan",
+		SourcePath: sourcePath,
+		Params:     MountParams{AuthenticationSource: "driver"},
 	}
 	err := WriteMeta(kubeletPath, entry)
 	assert.NoError(t, err)
@@ -474,12 +473,14 @@ func TestRebuildMountMap_MultipleVolumes(t *testing.T) {
 	sourceB := SourceMountPath(kubeletPath, "vol-b")
 
 	entryA := &MountEntry{
-		VolumeID: "vol-a", MountID: "vol-a", SourcePath: sourceA,
-		Params: MountParams{ServiceAccountName: "sa-a"},
+		VolumeID:   "vol-a",
+		SourcePath: sourceA,
+		Params:     MountParams{ServiceAccountName: "sa-a"},
 	}
 	entryB := &MountEntry{
-		VolumeID: "vol-b", MountID: "vol-b", SourcePath: sourceB,
-		Params: MountParams{ServiceAccountName: "sa-b"},
+		VolumeID:   "vol-b",
+		SourcePath: sourceB,
+		Params:     MountParams{ServiceAccountName: "sa-b"},
 	}
 	err := WriteMeta(kubeletPath, entryA)
 	assert.NoError(t, err)
@@ -514,7 +515,6 @@ func TestWriteReadMetaCycle(t *testing.T) {
 
 	entry := &MountEntry{
 		VolumeID:   "vol-roundtrip",
-		MountID:    "vol-roundtrip",
 		SourcePath: SourceMountPath(kubeletPath, "vol-roundtrip"),
 		Params: MountParams{
 			MountOptions:             []string{"--allow-other", "--prefix=data/", "--read-only"},
@@ -547,7 +547,7 @@ func TestRemoveMeta_OnlyRemovesTargetVolume(t *testing.T) {
 	kubeletPath := t.TempDir()
 
 	for _, volID := range []string{"vol-keep", "vol-remove", "vol-also-keep"} {
-		entry := &MountEntry{VolumeID: volID, MountID: volID, SourcePath: "/source/" + volID}
+		entry := &MountEntry{VolumeID: volID, SourcePath: "/source/" + volID}
 		err := WriteMeta(kubeletPath, entry)
 		assert.NoError(t, err)
 	}

--- a/pkg/driver/node/mounter/mount_map_persistence_test.go
+++ b/pkg/driver/node/mounter/mount_map_persistence_test.go
@@ -1,0 +1,565 @@
+package mounter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+// fakeMountInfoProvider returns a mountInfoProviderFunc that returns the given entries.
+func fakeMountInfoProvider(entries []mountInfoEntry) mountInfoProviderFunc {
+	return func() ([]mountInfoEntry, error) {
+		return entries, nil
+	}
+}
+
+// newTestDMWithMountInfo creates a minimal DaemonsetMounter for persistence tests.
+// It sets kubeletPath and mountInfoProvider — no clientset/mount needed for RebuildMountMap.
+func newTestDMWithMountInfo(kubeletPath string, provider mountInfoProviderFunc) *DaemonsetMounter {
+	return &DaemonsetMounter{
+		kubeletPath:       kubeletPath,
+		mountInfoProvider: provider,
+		mountMap:          NewMountMap(),
+	}
+}
+
+func TestWriteMeta_CreatesFile(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	entry := &MountEntry{
+		VolumeID:   "vol-abc123",
+		MountID:    "vol-abc123",
+		SourcePath: filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt", "vol-abc123"),
+		Params: MountParams{
+			MountOptions:             []string{"--allow-other", "--region=us-east-1"},
+			AuthenticationSource:     "driver",
+			ServiceAccountName:       "default",
+			ServiceAccountEKSRoleARN: "arn:aws:iam::111111111111:role/my-role",
+			PodNamespace:             "default",
+			FSGroup:                  "1000",
+		},
+		RefCount: 1,
+		Targets:  []string{"/target-a"},
+	}
+
+	err := WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	// Verify file exists at expected path
+	metaPath := MetaFileName(kubeletPath, "vol-abc123")
+	_, err = os.Stat(metaPath)
+	assert.NoError(t, err)
+
+	// Verify content is valid JSON with correct fields
+	data, err := os.ReadFile(metaPath)
+	assert.NoError(t, err)
+
+	var meta MountMeta
+	err = json.Unmarshal(data, &meta)
+	assert.NoError(t, err)
+
+	assert.Equals(t, "vol-abc123", meta.VolumeID)
+	assert.Equals(t, "driver", meta.AuthenticationSource)
+	assert.Equals(t, "default", meta.ServiceAccountName)
+	assert.Equals(t, "arn:aws:iam::111111111111:role/my-role", meta.ServiceAccountEKSRoleARN)
+	assert.Equals(t, "default", meta.PodNamespace)
+	assert.Equals(t, "1000", meta.FSGroup)
+	assert.Equals(t, 2, len(meta.MountOptions))
+	assert.Equals(t, "--allow-other", meta.MountOptions[0])
+	assert.Equals(t, "--region=us-east-1", meta.MountOptions[1])
+}
+
+func TestWriteMeta_OverwritesExisting(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	entry1 := &MountEntry{
+		VolumeID:   "vol-overwrite",
+		MountID:    "vol-overwrite",
+		SourcePath: "/source-1",
+		Params:     MountParams{ServiceAccountName: "sa-first"},
+	}
+	err := WriteMeta(kubeletPath, entry1)
+	assert.NoError(t, err)
+
+	entry2 := &MountEntry{
+		VolumeID:   "vol-overwrite",
+		MountID:    "vol-overwrite",
+		SourcePath: "/source-2",
+		Params:     MountParams{ServiceAccountName: "sa-second"},
+	}
+	err = WriteMeta(kubeletPath, entry2)
+	assert.NoError(t, err)
+
+	meta, err := readMeta(MetaFileName(kubeletPath, "vol-overwrite"))
+	assert.NoError(t, err)
+	assert.Equals(t, "sa-second", meta.ServiceAccountName)
+}
+
+func TestWriteMeta_CreatesDirectoryIfMissing(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
+	_, err := os.Stat(metaDir)
+	if !os.IsNotExist(err) {
+		t.Fatal("expected meta directory to not exist initially")
+	}
+
+	entry := &MountEntry{VolumeID: "vol-mkdir", MountID: "vol-mkdir", SourcePath: "/source"}
+	err = WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	info, err := os.Stat(metaDir)
+	assert.NoError(t, err)
+	if !info.IsDir() {
+		t.Fatal("expected meta directory to be a directory")
+	}
+}
+
+func TestRemoveMeta_RemovesFile(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	entry := &MountEntry{VolumeID: "vol-remove", MountID: "vol-remove", SourcePath: "/source"}
+	err := WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	metaPath := MetaFileName(kubeletPath, "vol-remove")
+	_, err = os.Stat(metaPath)
+	assert.NoError(t, err)
+
+	RemoveMeta(kubeletPath, "vol-remove")
+
+	_, err = os.Stat(metaPath)
+	if !os.IsNotExist(err) {
+		t.Fatal("expected meta file to be removed")
+	}
+}
+
+func TestRemoveMeta_NoopIfNotExists(t *testing.T) {
+	kubeletPath := t.TempDir()
+	RemoveMeta(kubeletPath, "vol-nonexistent")
+}
+
+func TestReadMeta_ParsesCorrectly(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	entry := &MountEntry{
+		VolumeID:   "vol-read",
+		MountID:    "vol-read",
+		SourcePath: "/my/source/path",
+		Params: MountParams{
+			MountOptions:             []string{"--read-only"},
+			AuthenticationSource:     "pod",
+			ServiceAccountName:       "my-sa",
+			ServiceAccountEKSRoleARN: "arn:aws:iam::222222222222:role/pod-role",
+			PodNamespace:             "production",
+			FSGroup:                  "2000",
+		},
+	}
+	err := WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	meta, err := readMeta(MetaFileName(kubeletPath, "vol-read"))
+	assert.NoError(t, err)
+
+	assert.Equals(t, "vol-read", meta.VolumeID)
+	assert.Equals(t, "pod", meta.AuthenticationSource)
+	assert.Equals(t, "my-sa", meta.ServiceAccountName)
+	assert.Equals(t, "arn:aws:iam::222222222222:role/pod-role", meta.ServiceAccountEKSRoleARN)
+	assert.Equals(t, "production", meta.PodNamespace)
+	assert.Equals(t, "2000", meta.FSGroup)
+	assert.Equals(t, 1, len(meta.MountOptions))
+	assert.Equals(t, "--read-only", meta.MountOptions[0])
+}
+
+func TestReadMeta_InvalidJSON(t *testing.T) {
+	kubeletPath := t.TempDir()
+	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
+	err := os.MkdirAll(metaDir, 0750)
+	assert.NoError(t, err)
+
+	metaPath := filepath.Join(metaDir, "vol-bad.meta.json")
+	err = os.WriteFile(metaPath, []byte("not json{{{"), 0640)
+	assert.NoError(t, err)
+
+	_, err = readMeta(metaPath)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestReadMeta_FileNotFound(t *testing.T) {
+	_, err := readMeta("/nonexistent/path/vol.meta.json")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestMetaFileName_Format(t *testing.T) {
+	path := MetaFileName("/var/lib/kubelet", "vol-test-123")
+	expected := "/var/lib/kubelet/plugins/s3.csi.aws.com/mnt/vol-test-123.meta.json"
+	assert.Equals(t, expected, path)
+}
+
+func TestWriteMeta_EmptyMountOptions(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	entry := &MountEntry{
+		VolumeID: "vol-empty-opts", MountID: "vol-empty-opts", SourcePath: "/source",
+		Params: MountParams{MountOptions: nil, AuthenticationSource: "driver"},
+	}
+	err := WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	meta, err := readMeta(MetaFileName(kubeletPath, "vol-empty-opts"))
+	assert.NoError(t, err)
+	if meta.MountOptions != nil {
+		t.Fatalf("expected nil mount options, got: %v", meta.MountOptions)
+	}
+}
+
+func TestWriteMeta_EmptyEKSRoleARN_OmittedInJSON(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	entry := &MountEntry{
+		VolumeID: "vol-no-arn", MountID: "vol-no-arn", SourcePath: "/source",
+		Params: MountParams{AuthenticationSource: "driver", ServiceAccountEKSRoleARN: ""},
+	}
+	err := WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	data, err := os.ReadFile(MetaFileName(kubeletPath, "vol-no-arn"))
+	assert.NoError(t, err)
+
+	var raw map[string]interface{}
+	err = json.Unmarshal(data, &raw)
+	assert.NoError(t, err)
+	if _, exists := raw["serviceAccountEKSRoleARN"]; exists {
+		t.Fatal("expected serviceAccountEKSRoleARN to be omitted when empty")
+	}
+
+	meta, err := readMeta(MetaFileName(kubeletPath, "vol-no-arn"))
+	assert.NoError(t, err)
+	assert.Equals(t, "", meta.ServiceAccountEKSRoleARN)
+}
+
+// --- Tests for mountinfo parsing helpers ---
+
+func TestFindMountByPath_Found(t *testing.T) {
+	entries := []mountInfoEntry{
+		{MountPoint: "/mnt/a", DeviceID: "0:100"},
+		{MountPoint: "/mnt/b", DeviceID: "0:101"},
+		{MountPoint: "/mnt/c", DeviceID: "0:102"},
+	}
+	result := findMountByPath(entries, "/mnt/b")
+	if result == nil {
+		t.Fatal("expected to find entry for /mnt/b")
+	}
+	assert.Equals(t, "0:101", result.DeviceID)
+}
+
+func TestFindMountByPath_NotFound(t *testing.T) {
+	entries := []mountInfoEntry{{MountPoint: "/mnt/a", DeviceID: "0:100"}}
+	result := findMountByPath(entries, "/mnt/nonexistent")
+	if result != nil {
+		t.Fatal("expected nil for nonexistent path")
+	}
+}
+
+func TestFindMountByPath_EmptyEntries(t *testing.T) {
+	result := findMountByPath(nil, "/mnt/a")
+	if result != nil {
+		t.Fatal("expected nil for empty entries")
+	}
+}
+
+func TestFindBindMountTargets_MultipleTargets(t *testing.T) {
+	entries := []mountInfoEntry{
+		{MountPoint: "/source", DeviceID: "0:50"},
+		{MountPoint: "/target-a", DeviceID: "0:50"},
+		{MountPoint: "/target-b", DeviceID: "0:50"},
+		{MountPoint: "/other", DeviceID: "0:99"},
+		{MountPoint: "/target-c", DeviceID: "0:50"},
+	}
+	targets := findBindMountTargets(entries, "0:50", "/source")
+	assert.Equals(t, 3, len(targets))
+	for _, tgt := range targets {
+		if tgt == "/source" {
+			t.Fatal("source path should not be in targets")
+		}
+	}
+}
+
+func TestFindBindMountTargets_NoTargets(t *testing.T) {
+	entries := []mountInfoEntry{
+		{MountPoint: "/source", DeviceID: "0:50"},
+		{MountPoint: "/other", DeviceID: "0:99"},
+	}
+	targets := findBindMountTargets(entries, "0:50", "/source")
+	assert.Equals(t, 0, len(targets))
+}
+
+func TestFindBindMountTargets_EmptyEntries(t *testing.T) {
+	targets := findBindMountTargets(nil, "0:50", "/source")
+	if targets != nil {
+		t.Fatal("expected nil for empty entries")
+	}
+}
+
+// --- RebuildMountMap tests (using injectable mountInfoProvider on DaemonsetMounter) ---
+
+func TestRebuildMountMap_NoMetaDirectory(t *testing.T) {
+	kubeletPath := t.TempDir()
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider(nil))
+
+	err := dm.RebuildMountMap()
+	assert.NoError(t, err)
+
+	if dm.mountMap.Get("anything") != nil {
+		t.Fatal("expected empty mount map")
+	}
+}
+
+func TestRebuildMountMap_SkipsNonMetaFiles(t *testing.T) {
+	kubeletPath := t.TempDir()
+	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
+	err := os.MkdirAll(metaDir, 0750)
+	assert.NoError(t, err)
+
+	// Create non-meta files
+	os.Mkdir(filepath.Join(metaDir, "vol-123"), 0750)
+	os.WriteFile(filepath.Join(metaDir, "something.txt"), []byte("hello"), 0640)
+
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider(nil))
+	err = dm.RebuildMountMap()
+	assert.NoError(t, err)
+
+	if dm.mountMap.Get("vol-123") != nil {
+		t.Fatal("should not create entries for non-meta files")
+	}
+}
+
+func TestRebuildMountMap_SkipsInvalidMetaJSON(t *testing.T) {
+	kubeletPath := t.TempDir()
+	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
+	err := os.MkdirAll(metaDir, 0750)
+	assert.NoError(t, err)
+
+	// Invalid meta file
+	os.WriteFile(filepath.Join(metaDir, "vol-bad.meta.json"), []byte("not-json"), 0640)
+
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider(nil))
+	err = dm.RebuildMountMap()
+	assert.NoError(t, err) // should not error, just skip
+
+	if dm.mountMap.Get("vol-bad") != nil {
+		t.Fatal("should not create entry for invalid meta")
+	}
+}
+
+func TestRebuildMountMap_CleansUpDeadSourceMounts(t *testing.T) {
+	kubeletPath := t.TempDir()
+	sourcePath := SourceMountPath(kubeletPath, "vol-dead")
+
+	entry := &MountEntry{
+		VolumeID: "vol-dead", MountID: "vol-dead", SourcePath: sourcePath,
+		Params: MountParams{AuthenticationSource: "driver", ServiceAccountName: "default"},
+	}
+	err := WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	// Mount table has NO entry for sourcePath → source is dead
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountInfoEntry{
+		{MountPoint: "/some/other/mount", DeviceID: "0:99"},
+	}))
+	err = dm.RebuildMountMap()
+	assert.NoError(t, err)
+
+	// Entry should NOT be in the mount map (dead source skipped)
+	if dm.mountMap.Get("vol-dead") != nil {
+		t.Fatal("expected dead source volume to be skipped")
+	}
+
+	// Meta file should be cleaned up
+	_, err = os.Stat(MetaFileName(kubeletPath, "vol-dead"))
+	if !os.IsNotExist(err) {
+		t.Fatal("expected meta file to be removed for dead source")
+	}
+}
+
+func TestRebuildMountMap_RecoversLiveSourceWithBindMounts(t *testing.T) {
+	kubeletPath := t.TempDir()
+	sourcePath := SourceMountPath(kubeletPath, "vol-live")
+
+	entry := &MountEntry{
+		VolumeID: "vol-live", MountID: "vol-live", SourcePath: sourcePath,
+		Params: MountParams{
+			MountOptions:             []string{"--allow-other"},
+			AuthenticationSource:     "pod",
+			ServiceAccountName:       "my-sa",
+			ServiceAccountEKSRoleARN: "arn:aws:iam::123:role/r",
+			PodNamespace:             "ns-a",
+			FSGroup:                  "1000",
+		},
+	}
+	err := WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	// Simulate mount table: source + 3 bind mount targets share device ID
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountInfoEntry{
+		{MountPoint: sourcePath, DeviceID: "0:42"},
+		{MountPoint: "/pods/pod-a/volumes/mount", DeviceID: "0:42"},
+		{MountPoint: "/pods/pod-b/volumes/mount", DeviceID: "0:42"},
+		{MountPoint: "/pods/pod-c/volumes/mount", DeviceID: "0:42"},
+		{MountPoint: "/unrelated", DeviceID: "0:99"},
+	}))
+	err = dm.RebuildMountMap()
+	assert.NoError(t, err)
+
+	recovered := dm.mountMap.Get("vol-live")
+	if recovered == nil {
+		t.Fatal("expected recovered entry for vol-live")
+	}
+
+	assert.Equals(t, sourcePath, recovered.SourcePath)
+	assert.Equals(t, "vol-live", recovered.MountID)
+	assert.Equals(t, 3, recovered.RefCount)
+	assert.Equals(t, 3, len(recovered.Targets))
+	assert.Equals(t, true, recovered.initialized)
+
+	// Verify params were restored
+	assert.Equals(t, "pod", recovered.Params.AuthenticationSource)
+	assert.Equals(t, "my-sa", recovered.Params.ServiceAccountName)
+	assert.Equals(t, "arn:aws:iam::123:role/r", recovered.Params.ServiceAccountEKSRoleARN)
+	assert.Equals(t, "ns-a", recovered.Params.PodNamespace)
+	assert.Equals(t, "1000", recovered.Params.FSGroup)
+	assert.Equals(t, 1, len(recovered.Params.MountOptions))
+	assert.Equals(t, "--allow-other", recovered.Params.MountOptions[0])
+}
+
+func TestRebuildMountMap_SourceWithNoBindMounts(t *testing.T) {
+	kubeletPath := t.TempDir()
+	sourcePath := SourceMountPath(kubeletPath, "vol-orphan")
+
+	entry := &MountEntry{
+		VolumeID: "vol-orphan", MountID: "vol-orphan", SourcePath: sourcePath,
+		Params: MountParams{AuthenticationSource: "driver"},
+	}
+	err := WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	// Source exists in mount table but no bind mounts share its device ID
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountInfoEntry{
+		{MountPoint: sourcePath, DeviceID: "0:55"},
+		{MountPoint: "/unrelated", DeviceID: "0:99"},
+	}))
+	err = dm.RebuildMountMap()
+	assert.NoError(t, err)
+
+	recovered := dm.mountMap.Get("vol-orphan")
+	if recovered == nil {
+		t.Fatal("expected recovered entry for vol-orphan")
+	}
+	assert.Equals(t, 0, recovered.RefCount)
+	assert.Equals(t, 0, len(recovered.Targets))
+	assert.Equals(t, true, recovered.initialized)
+}
+
+func TestRebuildMountMap_MultipleVolumes(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	sourceA := SourceMountPath(kubeletPath, "vol-a")
+	sourceB := SourceMountPath(kubeletPath, "vol-b")
+
+	entryA := &MountEntry{
+		VolumeID: "vol-a", MountID: "vol-a", SourcePath: sourceA,
+		Params: MountParams{ServiceAccountName: "sa-a"},
+	}
+	entryB := &MountEntry{
+		VolumeID: "vol-b", MountID: "vol-b", SourcePath: sourceB,
+		Params: MountParams{ServiceAccountName: "sa-b"},
+	}
+	err := WriteMeta(kubeletPath, entryA)
+	assert.NoError(t, err)
+	err = WriteMeta(kubeletPath, entryB)
+	assert.NoError(t, err)
+
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountInfoEntry{
+		{MountPoint: sourceA, DeviceID: "0:10"},
+		{MountPoint: "/target-a1", DeviceID: "0:10"},
+		{MountPoint: "/target-a2", DeviceID: "0:10"},
+		{MountPoint: sourceB, DeviceID: "0:20"},
+		{MountPoint: "/target-b1", DeviceID: "0:20"},
+	}))
+	err = dm.RebuildMountMap()
+	assert.NoError(t, err)
+
+	recA := dm.mountMap.Get("vol-a")
+	recB := dm.mountMap.Get("vol-b")
+	if recA == nil || recB == nil {
+		t.Fatal("expected both volumes to be recovered")
+	}
+	assert.Equals(t, 2, recA.RefCount)
+	assert.Equals(t, "sa-a", recA.Params.ServiceAccountName)
+	assert.Equals(t, 1, recB.RefCount)
+	assert.Equals(t, "sa-b", recB.Params.ServiceAccountName)
+}
+
+// --- Write → Read round-trip ---
+
+func TestWriteReadMetaCycle(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	entry := &MountEntry{
+		VolumeID:   "vol-roundtrip",
+		MountID:    "vol-roundtrip",
+		SourcePath: SourceMountPath(kubeletPath, "vol-roundtrip"),
+		Params: MountParams{
+			MountOptions:             []string{"--allow-other", "--prefix=data/", "--read-only"},
+			AuthenticationSource:     "pod",
+			ServiceAccountName:       "my-service-account",
+			ServiceAccountEKSRoleARN: "arn:aws:iam::123456789012:role/s3-reader",
+			PodNamespace:             "my-namespace",
+			FSGroup:                  "65534",
+		},
+	}
+	err := WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	meta, err := readMeta(MetaFileName(kubeletPath, "vol-roundtrip"))
+	assert.NoError(t, err)
+
+	assert.Equals(t, entry.VolumeID, meta.VolumeID)
+	assert.Equals(t, entry.Params.AuthenticationSource, meta.AuthenticationSource)
+	assert.Equals(t, entry.Params.ServiceAccountName, meta.ServiceAccountName)
+	assert.Equals(t, entry.Params.ServiceAccountEKSRoleARN, meta.ServiceAccountEKSRoleARN)
+	assert.Equals(t, entry.Params.PodNamespace, meta.PodNamespace)
+	assert.Equals(t, entry.Params.FSGroup, meta.FSGroup)
+	assert.Equals(t, len(entry.Params.MountOptions), len(meta.MountOptions))
+	for i, opt := range entry.Params.MountOptions {
+		assert.Equals(t, opt, meta.MountOptions[i])
+	}
+}
+
+func TestRemoveMeta_OnlyRemovesTargetVolume(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	for _, volID := range []string{"vol-keep", "vol-remove", "vol-also-keep"} {
+		entry := &MountEntry{VolumeID: volID, MountID: volID, SourcePath: "/source/" + volID}
+		err := WriteMeta(kubeletPath, entry)
+		assert.NoError(t, err)
+	}
+
+	RemoveMeta(kubeletPath, "vol-remove")
+
+	_, err := os.Stat(MetaFileName(kubeletPath, "vol-remove"))
+	if !os.IsNotExist(err) {
+		t.Fatal("expected vol-remove meta to be deleted")
+	}
+	_, err = os.Stat(MetaFileName(kubeletPath, "vol-keep"))
+	assert.NoError(t, err)
+	_, err = os.Stat(MetaFileName(kubeletPath, "vol-also-keep"))
+	assert.NoError(t, err)
+}

--- a/pkg/driver/node/mounter/mount_map_persistence_test.go
+++ b/pkg/driver/node/mounter/mount_map_persistence_test.go
@@ -427,7 +427,7 @@ func TestRebuildMountMap_RecoversLiveSourceWithBindMounts(t *testing.T) {
 	assert.Equals(t, sourcePath, recovered.SourcePath)
 	assert.Equals(t, 3, recovered.RefCount)
 	assert.Equals(t, 3, len(recovered.Targets))
-	assert.Equals(t, true, recovered.initialized)
+	assert.Equals(t, true, recovered.sourceMounted)
 
 	// Verify params were restored
 	assert.Equals(t, "pod", recovered.Params.AuthenticationSource)
@@ -465,7 +465,7 @@ func TestRebuildMountMap_SourceWithNoBindMounts(t *testing.T) {
 	}
 	assert.Equals(t, 0, recovered.RefCount)
 	assert.Equals(t, 0, len(recovered.Targets))
-	assert.Equals(t, true, recovered.initialized)
+	assert.Equals(t, true, recovered.sourceMounted)
 }
 
 func TestRebuildMountMap_MultipleVolumes(t *testing.T) {

--- a/pkg/driver/node/mounter/mount_map_persistence_test.go
+++ b/pkg/driver/node/mounter/mount_map_persistence_test.go
@@ -2,16 +2,18 @@ package mounter
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+	mountutils "k8s.io/mount-utils"
 )
 
 // fakeMountInfoProvider returns a mountInfoProviderFunc that returns the given entries.
-func fakeMountInfoProvider(entries []mountInfoEntry) mountInfoProviderFunc {
-	return func() ([]mountInfoEntry, error) {
+func fakeMountInfoProvider(entries []mountutils.MountInfo) mountInfoProviderFunc {
+	return func() ([]mountutils.MountInfo, error) {
 		return entries, nil
 	}
 }
@@ -217,7 +219,7 @@ func TestWriteMeta_EmptyMountOptions(t *testing.T) {
 	}
 }
 
-func TestWriteMeta_EmptyEKSRoleARN_OmittedInJSON(t *testing.T) {
+func TestWriteMeta_EmptyEKSRoleARN_PresentInJSON(t *testing.T) {
 	kubeletPath := t.TempDir()
 
 	entry := &MountEntry{
@@ -233,8 +235,8 @@ func TestWriteMeta_EmptyEKSRoleARN_OmittedInJSON(t *testing.T) {
 	var raw map[string]interface{}
 	err = json.Unmarshal(data, &raw)
 	assert.NoError(t, err)
-	if _, exists := raw["serviceAccountEKSRoleARN"]; exists {
-		t.Fatal("expected serviceAccountEKSRoleARN to be omitted when empty")
+	if _, exists := raw["serviceAccountEKSRoleARN"]; !exists {
+		t.Fatal("expected serviceAccountEKSRoleARN to be present in JSON even when empty")
 	}
 
 	meta, err := readMeta(MetaFileName(kubeletPath, "vol-no-arn"))
@@ -245,20 +247,20 @@ func TestWriteMeta_EmptyEKSRoleARN_OmittedInJSON(t *testing.T) {
 // --- Tests for mountinfo parsing helpers ---
 
 func TestFindMountByPath_Found(t *testing.T) {
-	entries := []mountInfoEntry{
-		{MountPoint: "/mnt/a", DeviceID: "0:100"},
-		{MountPoint: "/mnt/b", DeviceID: "0:101"},
-		{MountPoint: "/mnt/c", DeviceID: "0:102"},
+	entries := []mountutils.MountInfo{
+		{MountPoint: "/mnt/a", Major: 0, Minor: 100},
+		{MountPoint: "/mnt/b", Major: 0, Minor: 101},
+		{MountPoint: "/mnt/c", Major: 0, Minor: 102},
 	}
 	result := findMountByPath(entries, "/mnt/b")
 	if result == nil {
 		t.Fatal("expected to find entry for /mnt/b")
 	}
-	assert.Equals(t, "0:101", result.DeviceID)
+	assert.Equals(t, "0:101", fmt.Sprintf("%d:%d", result.Major, result.Minor))
 }
 
 func TestFindMountByPath_NotFound(t *testing.T) {
-	entries := []mountInfoEntry{{MountPoint: "/mnt/a", DeviceID: "0:100"}}
+	entries := []mountutils.MountInfo{{MountPoint: "/mnt/a", Major: 0, Minor: 100}}
 	result := findMountByPath(entries, "/mnt/nonexistent")
 	if result != nil {
 		t.Fatal("expected nil for nonexistent path")
@@ -273,12 +275,12 @@ func TestFindMountByPath_EmptyEntries(t *testing.T) {
 }
 
 func TestFindBindMountTargets_MultipleTargets(t *testing.T) {
-	entries := []mountInfoEntry{
-		{MountPoint: "/source", DeviceID: "0:50"},
-		{MountPoint: "/target-a", DeviceID: "0:50"},
-		{MountPoint: "/target-b", DeviceID: "0:50"},
-		{MountPoint: "/other", DeviceID: "0:99"},
-		{MountPoint: "/target-c", DeviceID: "0:50"},
+	entries := []mountutils.MountInfo{
+		{MountPoint: "/source", Major: 0, Minor: 50},
+		{MountPoint: "/target-a", Major: 0, Minor: 50},
+		{MountPoint: "/target-b", Major: 0, Minor: 50},
+		{MountPoint: "/other", Major: 0, Minor: 99},
+		{MountPoint: "/target-c", Major: 0, Minor: 50},
 	}
 	targets := findBindMountTargets(entries, "0:50", "/source")
 	assert.Equals(t, 3, len(targets))
@@ -290,9 +292,9 @@ func TestFindBindMountTargets_MultipleTargets(t *testing.T) {
 }
 
 func TestFindBindMountTargets_NoTargets(t *testing.T) {
-	entries := []mountInfoEntry{
-		{MountPoint: "/source", DeviceID: "0:50"},
-		{MountPoint: "/other", DeviceID: "0:99"},
+	entries := []mountutils.MountInfo{
+		{MountPoint: "/source", Major: 0, Minor: 50},
+		{MountPoint: "/other", Major: 0, Minor: 99},
 	}
 	targets := findBindMountTargets(entries, "0:50", "/source")
 	assert.Equals(t, 0, len(targets))
@@ -369,8 +371,8 @@ func TestRebuildMountMap_CleansUpDeadSourceMounts(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Mount table has NO entry for sourcePath → source is dead
-	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountInfoEntry{
-		{MountPoint: "/some/other/mount", DeviceID: "0:99"},
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountutils.MountInfo{
+		{MountPoint: "/some/other/mount", Major: 0, Minor: 99},
 	}))
 	err = dm.RebuildMountMap()
 	assert.NoError(t, err)
@@ -407,12 +409,12 @@ func TestRebuildMountMap_RecoversLiveSourceWithBindMounts(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Simulate mount table: source + 3 bind mount targets share device ID
-	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountInfoEntry{
-		{MountPoint: sourcePath, DeviceID: "0:42"},
-		{MountPoint: "/pods/pod-a/volumes/mount", DeviceID: "0:42"},
-		{MountPoint: "/pods/pod-b/volumes/mount", DeviceID: "0:42"},
-		{MountPoint: "/pods/pod-c/volumes/mount", DeviceID: "0:42"},
-		{MountPoint: "/unrelated", DeviceID: "0:99"},
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountutils.MountInfo{
+		{MountPoint: sourcePath, Major: 0, Minor: 42},
+		{MountPoint: "/pods/pod-a/volumes/mount", Major: 0, Minor: 42},
+		{MountPoint: "/pods/pod-b/volumes/mount", Major: 0, Minor: 42},
+		{MountPoint: "/pods/pod-c/volumes/mount", Major: 0, Minor: 42},
+		{MountPoint: "/unrelated", Major: 0, Minor: 99},
 	}))
 	err = dm.RebuildMountMap()
 	assert.NoError(t, err)
@@ -450,9 +452,9 @@ func TestRebuildMountMap_SourceWithNoBindMounts(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Source exists in mount table but no bind mounts share its device ID
-	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountInfoEntry{
-		{MountPoint: sourcePath, DeviceID: "0:55"},
-		{MountPoint: "/unrelated", DeviceID: "0:99"},
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountutils.MountInfo{
+		{MountPoint: sourcePath, Major: 0, Minor: 55},
+		{MountPoint: "/unrelated", Major: 0, Minor: 99},
 	}))
 	err = dm.RebuildMountMap()
 	assert.NoError(t, err)
@@ -487,12 +489,12 @@ func TestRebuildMountMap_MultipleVolumes(t *testing.T) {
 	err = WriteMeta(kubeletPath, entryB)
 	assert.NoError(t, err)
 
-	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountInfoEntry{
-		{MountPoint: sourceA, DeviceID: "0:10"},
-		{MountPoint: "/target-a1", DeviceID: "0:10"},
-		{MountPoint: "/target-a2", DeviceID: "0:10"},
-		{MountPoint: sourceB, DeviceID: "0:20"},
-		{MountPoint: "/target-b1", DeviceID: "0:20"},
+	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountutils.MountInfo{
+		{MountPoint: sourceA, Major: 0, Minor: 10},
+		{MountPoint: "/target-a1", Major: 0, Minor: 10},
+		{MountPoint: "/target-a2", Major: 0, Minor: 10},
+		{MountPoint: sourceB, Major: 0, Minor: 20},
+		{MountPoint: "/target-b1", Major: 0, Minor: 20},
 	}))
 	err = dm.RebuildMountMap()
 	assert.NoError(t, err)

--- a/pkg/driver/node/mounter/mount_map_persistence_test.go
+++ b/pkg/driver/node/mounter/mount_map_persistence_test.go
@@ -1,15 +1,30 @@
 package mounter
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
+	mpmounter "github.com/awslabs/mountpoint-s3-csi-driver/pkg/mountpoint/mounter"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
 	mountutils "k8s.io/mount-utils"
 )
+
+// noopCredProvider is a credential provider that does nothing, for tests that need cleanupMount.
+type noopCredProvider struct{}
+
+func (p *noopCredProvider) Provide(_ context.Context, _ credentialprovider.ProvideContext) (envprovider.Environment, string, error) {
+	return nil, "", nil
+}
+
+func (p *noopCredProvider) Cleanup(_ credentialprovider.CleanupContext) error {
+	return nil
+}
 
 // fakeMountInfoProvider returns a mountInfoProviderFunc that returns the given entries.
 func fakeMountInfoProvider(entries []mountutils.MountInfo) mountInfoProviderFunc {
@@ -25,6 +40,19 @@ func newTestDMWithMountInfo(kubeletPath string, provider mountInfoProviderFunc) 
 		kubeletPath:       kubeletPath,
 		mountInfoProvider: provider,
 		mountMap:          NewMountMap(),
+	}
+}
+
+// newTestDMWithMountInfoAndCredProvider creates a DaemonsetMounter with a no-op credential
+// provider and fake mounter, suitable for tests that exercise cleanupMount during rebuild.
+func newTestDMWithMountInfoAndCredProvider(kubeletPath string, provider mountInfoProviderFunc) *DaemonsetMounter {
+	fakeMounter := mountutils.NewFakeMounter(nil)
+	return &DaemonsetMounter{
+		kubeletPath:       kubeletPath,
+		mountInfoProvider: provider,
+		mountMap:          NewMountMap(),
+		mount:             mpmounter.NewWithMount(fakeMounter),
+		credProvider:      &noopCredProvider{},
 	}
 }
 
@@ -102,7 +130,7 @@ func TestWriteMeta_CreatesDirectoryIfMissing(t *testing.T) {
 
 	entry := &MountEntry{VolumeID: "vol-mkdir", SourcePath: "/source"}
 
-	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
+	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "meta")
 	_, err := os.Stat(metaDir)
 	if !os.IsNotExist(err) {
 		t.Fatal("expected meta directory to not exist initially")
@@ -175,7 +203,7 @@ func TestReadMeta_ParsesCorrectly(t *testing.T) {
 
 func TestReadMeta_InvalidJSON(t *testing.T) {
 	kubeletPath := t.TempDir()
-	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
+	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "meta")
 	err := os.MkdirAll(metaDir, 0750)
 	assert.NoError(t, err)
 
@@ -198,7 +226,7 @@ func TestReadMeta_FileNotFound(t *testing.T) {
 
 func TestMetaFileName_Format(t *testing.T) {
 	path := MetaFileName("/var/lib/kubelet", "vol-test-123")
-	expected := "/var/lib/kubelet/plugins/s3.csi.aws.com/mnt/vol-test-123.meta.json"
+	expected := "/var/lib/kubelet/plugins/s3.csi.aws.com/meta/vol-test-123.meta.json"
 	assert.Equals(t, expected, path)
 }
 
@@ -323,7 +351,7 @@ func TestRebuildMountMap_NoMetaDirectory(t *testing.T) {
 
 func TestRebuildMountMap_SkipsNonMetaFiles(t *testing.T) {
 	kubeletPath := t.TempDir()
-	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
+	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "meta")
 	err := os.MkdirAll(metaDir, 0750)
 	assert.NoError(t, err)
 
@@ -342,7 +370,7 @@ func TestRebuildMountMap_SkipsNonMetaFiles(t *testing.T) {
 
 func TestRebuildMountMap_SkipsInvalidMetaJSON(t *testing.T) {
 	kubeletPath := t.TempDir()
-	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "mnt")
+	metaDir := filepath.Join(kubeletPath, "plugins", "s3.csi.aws.com", "meta")
 	err := os.MkdirAll(metaDir, 0750)
 	assert.NoError(t, err)
 
@@ -371,7 +399,7 @@ func TestRebuildMountMap_CleansUpDeadSourceMounts(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Mount table has NO entry for sourcePath → source is dead
-	dm := newTestDMWithMountInfo(kubeletPath, fakeMountInfoProvider([]mountutils.MountInfo{
+	dm := newTestDMWithMountInfoAndCredProvider(kubeletPath, fakeMountInfoProvider([]mountutils.MountInfo{
 		{MountPoint: "/some/other/mount", Major: 0, Minor: 99},
 	}))
 	err = dm.RebuildMountMap()
@@ -392,10 +420,12 @@ func TestRebuildMountMap_CleansUpDeadSourceMounts(t *testing.T) {
 func TestRebuildMountMap_RecoversLiveSourceWithBindMounts(t *testing.T) {
 	kubeletPath := t.TempDir()
 	sourcePath := SourceMountPath(kubeletPath, "vol-live")
+	commDir := "/var/lib/kubelet/pods/mounter-uid-abc/volumes/kubernetes.io~empty-dir/comm"
 
 	entry := &MountEntry{
 		VolumeID:   "vol-live",
 		SourcePath: sourcePath,
+		CommDir:    commDir,
 		Params: MountParams{
 			MountOptions:             []string{"--allow-other"},
 			AuthenticationSource:     "pod",
@@ -425,6 +455,7 @@ func TestRebuildMountMap_RecoversLiveSourceWithBindMounts(t *testing.T) {
 	}
 
 	assert.Equals(t, sourcePath, recovered.SourcePath)
+	assert.Equals(t, commDir, recovered.CommDir)
 	assert.Equals(t, 3, recovered.RefCount)
 	assert.Equals(t, 3, len(recovered.Targets))
 	assert.Equals(t, true, recovered.sourceMounted)
@@ -564,4 +595,50 @@ func TestRemoveMeta_OnlyRemovesTargetVolume(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = os.Stat(MetaFileName(kubeletPath, "vol-also-keep"))
 	assert.NoError(t, err)
+}
+
+func TestRebuildMountMap_DeadSourceCleansCredentials(t *testing.T) {
+	kubeletPath := t.TempDir()
+
+	// Create a comm dir with credential files that should be cleaned up
+	commDir := filepath.Join(kubeletPath, "pods", "mounter-uid", "volumes", "kubernetes.io~empty-dir", "comm")
+	credDir := filepath.Join(commDir, "vol-dead-creds")
+	err := os.MkdirAll(credDir, 0750)
+	assert.NoError(t, err)
+	// Simulate a token file in the cred dir
+	os.WriteFile(filepath.Join(credDir, "token.jwt"), []byte("secret"), 0600)
+	// Simulate an error file
+	os.WriteFile(filepath.Join(commDir, "vol-dead-creds.error"), []byte("mount failed"), 0600)
+
+	entry := &MountEntry{
+		VolumeID:   "vol-dead-creds",
+		SourcePath: SourceMountPath(kubeletPath, "vol-dead-creds"),
+		CommDir:    commDir,
+		Params:     MountParams{AuthenticationSource: "driver"},
+	}
+	err = WriteMeta(kubeletPath, entry)
+	assert.NoError(t, err)
+
+	// Mount table has NO entry for sourcePath → source is dead
+	dm := newTestDMWithMountInfoAndCredProvider(kubeletPath, fakeMountInfoProvider(nil))
+	err = dm.RebuildMountMap()
+	assert.NoError(t, err)
+
+	// Credential directory should be cleaned up
+	_, err = os.Stat(credDir)
+	if !os.IsNotExist(err) {
+		t.Fatal("expected credential directory to be removed for dead source")
+	}
+
+	// Error file should be cleaned up
+	_, err = os.Stat(filepath.Join(commDir, "vol-dead-creds.error"))
+	if !os.IsNotExist(err) {
+		t.Fatal("expected error file to be removed for dead source")
+	}
+
+	// Meta file should be cleaned up
+	_, err = os.Stat(MetaFileName(kubeletPath, "vol-dead-creds"))
+	if !os.IsNotExist(err) {
+		t.Fatal("expected meta file to be removed for dead source")
+	}
 }

--- a/pkg/driver/node/mounter/mount_map_test.go
+++ b/pkg/driver/node/mounter/mount_map_test.go
@@ -1,0 +1,408 @@
+package mounter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+)
+
+func TestMountMap_GetOrCreate_NewEntry(t *testing.T) {
+	m := NewMountMap()
+	entry, existed := m.GetOrCreate("vol-1")
+	assert.Equals(t, false, existed)
+	assert.Equals(t, "vol-1", entry.VolumeID)
+	assert.Equals(t, false, entry.initialized)
+}
+
+func TestMountMap_GetOrCreate_ExistingEntry(t *testing.T) {
+	m := NewMountMap()
+	entry1, _ := m.GetOrCreate("vol-1")
+	entry1.mu.Lock()
+	entry1.initialized = true
+	entry1.SourcePath = "/source"
+	entry1.mu.Unlock()
+
+	entry2, existed := m.GetOrCreate("vol-1")
+	assert.Equals(t, true, existed)
+	if entry1 != entry2 {
+		t.Fatal("expected same pointer for same volumeID")
+	}
+	assert.Equals(t, "/source", entry2.SourcePath)
+}
+
+func TestMountMap_Get_NotFound(t *testing.T) {
+	m := NewMountMap()
+	entry := m.Get("nonexistent")
+	if entry != nil {
+		t.Fatal("expected nil for nonexistent volume")
+	}
+}
+
+func TestMountMap_ConcurrentGetOrCreate_SameVolume(t *testing.T) {
+	m := NewMountMap()
+	var wg sync.WaitGroup
+	entries := make([]*MountEntry, 10)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			entry, _ := m.GetOrCreate("vol-shared")
+			entries[idx] = entry
+		}(i)
+	}
+	wg.Wait()
+
+	// All goroutines should get the same entry pointer
+	for i := 1; i < 10; i++ {
+		if entries[i] != entries[0] {
+			t.Fatalf("entry[%d] != entry[0]: different pointers for same volumeID", i)
+		}
+	}
+}
+
+func TestMountMap_ConcurrentGetOrCreate_DifferentVolumes(t *testing.T) {
+	m := NewMountMap()
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			volumeID := "vol-" + string(rune('A'+idx%26))
+			entry, _ := m.GetOrCreate(volumeID)
+			entry.mu.Lock()
+			entry.RefCount++
+			entry.mu.Unlock()
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestValidateCompatibility_AllMatch(t *testing.T) {
+	existing := &MountParams{
+		MountOptions:         []string{"--allow-other", "--region us-east-1"},
+		AuthenticationSource: "driver",
+		ServiceAccountName:   "default",
+		PodNamespace:         "default",
+		FSGroup:              "1000",
+	}
+	incoming := &MountParams{
+		MountOptions:         []string{"--allow-other", "--region us-east-1"},
+		AuthenticationSource: "driver",
+		ServiceAccountName:   "default",
+		PodNamespace:         "default",
+		FSGroup:              "1000",
+	}
+	err := existing.ValidateCompatibility(incoming)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateCompatibility_MountOptionsMismatch(t *testing.T) {
+	existing := &MountParams{MountOptions: []string{"--read-only"}}
+	incoming := &MountParams{MountOptions: []string{"--allow-delete"}}
+	err := existing.ValidateCompatibility(incoming)
+	assert.Contains(t, err.Error(), "mount options mismatch")
+}
+
+func TestValidateCompatibility_AuthMismatch(t *testing.T) {
+	existing := &MountParams{AuthenticationSource: "driver"}
+	incoming := &MountParams{AuthenticationSource: "pod"}
+	err := existing.ValidateCompatibility(incoming)
+	assert.Contains(t, err.Error(), "authenticationSource mismatch")
+}
+
+func TestValidateCompatibility_ServiceAccountMismatch(t *testing.T) {
+	existing := &MountParams{ServiceAccountName: "sa-a"}
+	incoming := &MountParams{ServiceAccountName: "sa-b"}
+	err := existing.ValidateCompatibility(incoming)
+	assert.Contains(t, err.Error(), "serviceAccountName mismatch")
+}
+
+func TestValidateCompatibility_NamespaceMismatch(t *testing.T) {
+	existing := &MountParams{PodNamespace: "ns-a"}
+	incoming := &MountParams{PodNamespace: "ns-b"}
+	err := existing.ValidateCompatibility(incoming)
+	assert.Contains(t, err.Error(), "podNamespace mismatch")
+}
+
+func TestValidateCompatibility_FSGroupMismatch(t *testing.T) {
+	existing := &MountParams{FSGroup: "1000"}
+	incoming := &MountParams{FSGroup: "2000"}
+	err := existing.ValidateCompatibility(incoming)
+	assert.Contains(t, err.Error(), "fsGroup")
+}
+
+func TestValidateCompatibility_ServiceAccountEKSRoleARNMismatch(t *testing.T) {
+	existing := &MountParams{
+		ServiceAccountName:       "sa-a",
+		ServiceAccountEKSRoleARN: "arn:aws:iam::111111111111:role/role-a",
+	}
+	incoming := &MountParams{
+		ServiceAccountName:       "sa-a",
+		ServiceAccountEKSRoleARN: "arn:aws:iam::111111111111:role/role-b",
+	}
+	err := existing.ValidateCompatibility(incoming)
+	assert.Contains(t, err.Error(), "serviceAccountEKSRoleARN mismatch")
+}
+
+func TestValidateCompatibility_ServiceAccountEKSRoleARNMatch(t *testing.T) {
+	existing := &MountParams{
+		ServiceAccountName:       "sa-a",
+		AuthenticationSource:     "pod",
+		PodNamespace:             "default",
+		ServiceAccountEKSRoleARN: "arn:aws:iam::111111111111:role/role-a",
+		MountOptions:             []string{"--allow-other"},
+	}
+	incoming := &MountParams{
+		ServiceAccountName:       "sa-a",
+		AuthenticationSource:     "pod",
+		PodNamespace:             "default",
+		ServiceAccountEKSRoleARN: "arn:aws:iam::111111111111:role/role-a",
+		MountOptions:             []string{"--allow-other"},
+	}
+	err := existing.ValidateCompatibility(incoming)
+	if err != nil {
+		t.Fatalf("expected no error for matching EKS role ARN, got: %v", err)
+	}
+}
+
+func TestMountEntry_ResetAllowsDifferentParams(t *testing.T) {
+	m := NewMountMap()
+
+	// First workload mounts with SA "sa-a"
+	entry, _ := m.GetOrCreate("vol-1")
+	entry.mu.Lock()
+	entry.SourcePath = "/source"
+	entry.MountID = "mount-1"
+	entry.Params = MountParams{ServiceAccountName: "sa-a", AuthenticationSource: "driver"}
+	entry.RefCount = 1
+	entry.Targets = []string{"/target-a"}
+	entry.initialized = true
+	entry.mu.Unlock()
+
+	// Simulate unmount of last consumer
+	entry.mu.Lock()
+	entry.RefCount--
+	entry.initialized = false
+	entry.SourcePath = ""
+	entry.MountID = ""
+	entry.Params = MountParams{}
+	entry.Targets = nil
+	entry.mu.Unlock()
+
+	// Second workload with different SA should be able to mount
+	entry2, existed := m.GetOrCreate("vol-1")
+	assert.Equals(t, true, existed)
+	entry2.mu.Lock()
+	defer entry2.mu.Unlock()
+
+	// entry.initialized is false, so no validation runs — new mount is allowed
+	assert.Equals(t, false, entry2.initialized)
+
+	// Simulate new mount with different params
+	newParams := MountParams{ServiceAccountName: "sa-b", AuthenticationSource: "pod"}
+	entry2.SourcePath = "/new-source"
+	entry2.MountID = "mount-2"
+	entry2.Params = newParams
+	entry2.RefCount = 1
+	entry2.Targets = []string{"/target-b"}
+	entry2.initialized = true
+
+	// Verify new params took effect
+	assert.Equals(t, "sa-b", entry2.Params.ServiceAccountName)
+	assert.Equals(t, "pod", entry2.Params.AuthenticationSource)
+}
+
+func TestMountEntry_ShareRejectedWithDifferentParams(t *testing.T) {
+	m := NewMountMap()
+
+	// First workload mounts
+	entry, _ := m.GetOrCreate("vol-1")
+	entry.mu.Lock()
+	entry.SourcePath = "/source"
+	entry.Params = MountParams{ServiceAccountName: "sa-a", AuthenticationSource: "driver"}
+	entry.RefCount = 1
+	entry.Targets = []string{"/target-a"}
+	entry.initialized = true
+	entry.mu.Unlock()
+
+	// Second workload tries to share with different SA — should fail
+	entry2, _ := m.GetOrCreate("vol-1")
+	entry2.mu.Lock()
+	defer entry2.mu.Unlock()
+
+	incoming := &MountParams{ServiceAccountName: "sa-b", AuthenticationSource: "driver"}
+	err := entry2.Params.ValidateCompatibility(incoming)
+	if err == nil {
+		t.Fatal("expected validation error for different SA, got nil")
+	}
+	assert.Contains(t, err.Error(), "serviceAccountName mismatch")
+}
+
+func TestMountEntry_ShareAllowedWithSameParams(t *testing.T) {
+	m := NewMountMap()
+
+	// First workload mounts
+	entry, _ := m.GetOrCreate("vol-1")
+	entry.mu.Lock()
+	entry.SourcePath = "/source"
+	entry.Params = MountParams{
+		ServiceAccountName:   "sa-a",
+		AuthenticationSource: "driver",
+		PodNamespace:         "default",
+		FSGroup:              "",
+		MountOptions:         []string{"--allow-other"},
+	}
+	entry.RefCount = 1
+	entry.Targets = []string{"/target-a"}
+	entry.initialized = true
+	entry.mu.Unlock()
+
+	// Second workload tries to share with same params — should succeed
+	entry2, _ := m.GetOrCreate("vol-1")
+	entry2.mu.Lock()
+	defer entry2.mu.Unlock()
+
+	incoming := &MountParams{
+		ServiceAccountName:   "sa-a",
+		AuthenticationSource: "driver",
+		PodNamespace:         "default",
+		FSGroup:              "",
+		MountOptions:         []string{"--allow-other"},
+	}
+	err := entry2.Params.ValidateCompatibility(incoming)
+	if err != nil {
+		t.Fatalf("expected no error for matching params, got: %v", err)
+	}
+
+	// Simulate adding the target
+	entry2.RefCount++
+	entry2.Targets = append(entry2.Targets, "/target-b")
+	assert.Equals(t, 2, entry2.RefCount)
+	assert.Equals(t, 2, len(entry2.Targets))
+}
+
+func TestMountMap_Delete_EntryRemoved(t *testing.T) {
+	m := NewMountMap()
+	entry, _ := m.GetOrCreate("vol-1")
+	entry.mu.Lock()
+	entry.initialized = true
+	entry.RefCount = 1
+	entry.mu.Unlock()
+
+	m.Delete("vol-1")
+
+	if m.Get("vol-1") != nil {
+		t.Fatal("expected nil after delete")
+	}
+}
+
+func TestMountMap_Delete_GetOrCreateReturnsNewEntry(t *testing.T) {
+	m := NewMountMap()
+
+	// Create and populate an entry
+	entry1, _ := m.GetOrCreate("vol-1")
+	entry1.mu.Lock()
+	entry1.initialized = true
+	entry1.SourcePath = "/old-source"
+	entry1.mu.Unlock()
+
+	// Delete it
+	m.Delete("vol-1")
+
+	// GetOrCreate should return a fresh entry (different pointer)
+	entry2, existed := m.GetOrCreate("vol-1")
+	assert.Equals(t, false, existed)
+	if entry2 == entry1 {
+		t.Fatal("expected new entry after delete, got same pointer")
+	}
+	assert.Equals(t, false, entry2.initialized)
+	assert.Equals(t, "", entry2.SourcePath)
+}
+
+func TestMountMap_RetryLoop_ConvergesAfterDelete(t *testing.T) {
+	// Simulates the retry-loop pattern used in mountWithSharing:
+	// 1. GetOrCreate returns entry
+	// 2. Lock it
+	// 3. Check if it's still canonical (in the map)
+	// 4. If not, unlock and retry
+	m := NewMountMap()
+
+	// Create an entry and immediately delete it (simulates unmount racing)
+	orphan, _ := m.GetOrCreate("vol-1")
+	m.Delete("vol-1")
+
+	// Retry loop should converge on a new canonical entry
+	var entry *MountEntry
+	iterations := 0
+	for {
+		entry, _ = m.GetOrCreate("vol-1")
+		entry.mu.Lock()
+		if m.Get("vol-1") == entry {
+			break
+		}
+		entry.mu.Unlock()
+		iterations++
+		if iterations > 10 {
+			t.Fatal("retry loop did not converge")
+		}
+	}
+	defer entry.mu.Unlock()
+
+	// The entry we hold should NOT be the orphan
+	if entry == orphan {
+		t.Fatal("expected a new entry, not the orphaned one")
+	}
+	assert.Equals(t, false, entry.initialized)
+}
+
+func TestMountMap_ConcurrentDeleteAndGetOrCreate(t *testing.T) {
+	// Stress test: concurrent deletes and GetOrCreate on the same volumeID.
+	// Verifies no panic, no infinite loop, and final state is consistent.
+	m := NewMountMap()
+	var wg sync.WaitGroup
+
+	const goroutines = 20
+	const volumeID = "vol-race"
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			if idx%2 == 0 {
+				// Mount path: retry loop
+				var entry *MountEntry
+				for {
+					entry, _ = m.GetOrCreate(volumeID)
+					entry.mu.Lock()
+					if m.Get(volumeID) == entry {
+						break
+					}
+					entry.mu.Unlock()
+				}
+				entry.initialized = true
+				entry.RefCount++
+				entry.mu.Unlock()
+			} else {
+				// Unmount path: delete
+				entry := m.Get(volumeID)
+				if entry == nil {
+					return
+				}
+				entry.mu.Lock()
+				entry.RefCount--
+				if entry.RefCount <= 0 {
+					m.Delete(volumeID)
+				}
+				entry.mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// No panic = success. Final state may or may not have an entry depending on ordering.
+}

--- a/pkg/driver/node/mounter/mount_map_test.go
+++ b/pkg/driver/node/mounter/mount_map_test.go
@@ -177,7 +177,6 @@ func TestMountEntry_ResetAllowsDifferentParams(t *testing.T) {
 	entry, _ := m.GetOrCreate("vol-1")
 	entry.mu.Lock()
 	entry.SourcePath = "/source"
-	entry.MountID = "mount-1"
 	entry.Params = MountParams{ServiceAccountName: "sa-a", AuthenticationSource: "driver"}
 	entry.RefCount = 1
 	entry.Targets = []string{"/target-a"}
@@ -189,7 +188,6 @@ func TestMountEntry_ResetAllowsDifferentParams(t *testing.T) {
 	entry.RefCount--
 	entry.initialized = false
 	entry.SourcePath = ""
-	entry.MountID = ""
 	entry.Params = MountParams{}
 	entry.Targets = nil
 	entry.mu.Unlock()
@@ -206,7 +204,6 @@ func TestMountEntry_ResetAllowsDifferentParams(t *testing.T) {
 	// Simulate new mount with different params
 	newParams := MountParams{ServiceAccountName: "sa-b", AuthenticationSource: "pod"}
 	entry2.SourcePath = "/new-source"
-	entry2.MountID = "mount-2"
 	entry2.Params = newParams
 	entry2.RefCount = 1
 	entry2.Targets = []string{"/target-b"}

--- a/pkg/driver/node/mounter/mount_map_test.go
+++ b/pkg/driver/node/mounter/mount_map_test.go
@@ -131,11 +131,20 @@ func TestValidateCompatibility_ServiceAccountIgnoredWithDriverAuth(t *testing.T)
 	}
 }
 
-func TestValidateCompatibility_NamespaceMismatch(t *testing.T) {
-	existing := &MountParams{PodNamespace: "ns-a"}
-	incoming := &MountParams{PodNamespace: "ns-b"}
+func TestValidateCompatibility_NamespaceMismatch_PodAuth(t *testing.T) {
+	existing := &MountParams{AuthenticationSource: "pod", PodNamespace: "ns-a"}
+	incoming := &MountParams{AuthenticationSource: "pod", PodNamespace: "ns-b"}
 	err := existing.ValidateCompatibility(incoming)
 	assert.Contains(t, err.Error(), "podNamespace mismatch")
+}
+
+func TestValidateCompatibility_NamespaceIgnoredWithDriverAuth(t *testing.T) {
+	existing := &MountParams{AuthenticationSource: "driver", PodNamespace: "ns-a"}
+	incoming := &MountParams{AuthenticationSource: "driver", PodNamespace: "ns-b"}
+	err := existing.ValidateCompatibility(incoming)
+	if err != nil {
+		t.Errorf("expected no error for namespace mismatch with driver auth, got: %v", err)
+	}
 }
 
 func TestValidateCompatibility_FSGroupMismatch(t *testing.T) {

--- a/pkg/driver/node/mounter/mount_map_test.go
+++ b/pkg/driver/node/mounter/mount_map_test.go
@@ -116,10 +116,19 @@ func TestValidateCompatibility_AuthMismatch(t *testing.T) {
 }
 
 func TestValidateCompatibility_ServiceAccountMismatch(t *testing.T) {
-	existing := &MountParams{ServiceAccountName: "sa-a"}
-	incoming := &MountParams{ServiceAccountName: "sa-b"}
+	existing := &MountParams{AuthenticationSource: "pod", ServiceAccountName: "sa-a"}
+	incoming := &MountParams{AuthenticationSource: "pod", ServiceAccountName: "sa-b"}
 	err := existing.ValidateCompatibility(incoming)
 	assert.Contains(t, err.Error(), "serviceAccountName mismatch")
+}
+
+func TestValidateCompatibility_ServiceAccountIgnoredWithDriverAuth(t *testing.T) {
+	existing := &MountParams{AuthenticationSource: "driver", ServiceAccountName: "sa-a"}
+	incoming := &MountParams{AuthenticationSource: "driver", ServiceAccountName: "sa-b"}
+	err := existing.ValidateCompatibility(incoming)
+	if err != nil {
+		t.Errorf("expected no error for SA mismatch with driver auth, got: %v", err)
+	}
 }
 
 func TestValidateCompatibility_NamespaceMismatch(t *testing.T) {
@@ -138,10 +147,12 @@ func TestValidateCompatibility_FSGroupMismatch(t *testing.T) {
 
 func TestValidateCompatibility_ServiceAccountEKSRoleARNMismatch(t *testing.T) {
 	existing := &MountParams{
+		AuthenticationSource:     "pod",
 		ServiceAccountName:       "sa-a",
 		ServiceAccountEKSRoleARN: "arn:aws:iam::111111111111:role/role-a",
 	}
 	incoming := &MountParams{
+		AuthenticationSource:     "pod",
 		ServiceAccountName:       "sa-a",
 		ServiceAccountEKSRoleARN: "arn:aws:iam::111111111111:role/role-b",
 	}
@@ -217,7 +228,33 @@ func TestMountEntry_ResetAllowsDifferentParams(t *testing.T) {
 func TestMountEntry_ShareRejectedWithDifferentParams(t *testing.T) {
 	m := NewMountMap()
 
-	// First workload mounts
+	// First workload mounts with pod auth
+	entry, _ := m.GetOrCreate("vol-1")
+	entry.mu.Lock()
+	entry.SourcePath = "/source"
+	entry.Params = MountParams{ServiceAccountName: "sa-a", AuthenticationSource: "pod"}
+	entry.RefCount = 1
+	entry.Targets = []string{"/target-a"}
+	entry.initialized = true
+	entry.mu.Unlock()
+
+	// Second workload tries to share with different SA — should fail with pod auth
+	entry2, _ := m.GetOrCreate("vol-1")
+	entry2.mu.Lock()
+	defer entry2.mu.Unlock()
+
+	incoming := &MountParams{ServiceAccountName: "sa-b", AuthenticationSource: "pod"}
+	err := entry2.Params.ValidateCompatibility(incoming)
+	if err == nil {
+		t.Fatal("expected validation error for different SA with pod auth, got nil")
+	}
+	assert.Contains(t, err.Error(), "serviceAccountName mismatch")
+}
+
+func TestMountEntry_ShareAllowedWithDifferentSADriverAuth(t *testing.T) {
+	m := NewMountMap()
+
+	// First workload mounts with driver auth
 	entry, _ := m.GetOrCreate("vol-1")
 	entry.mu.Lock()
 	entry.SourcePath = "/source"
@@ -227,17 +264,16 @@ func TestMountEntry_ShareRejectedWithDifferentParams(t *testing.T) {
 	entry.initialized = true
 	entry.mu.Unlock()
 
-	// Second workload tries to share with different SA — should fail
+	// Second workload with different SA — should succeed with driver auth
 	entry2, _ := m.GetOrCreate("vol-1")
 	entry2.mu.Lock()
 	defer entry2.mu.Unlock()
 
 	incoming := &MountParams{ServiceAccountName: "sa-b", AuthenticationSource: "driver"}
 	err := entry2.Params.ValidateCompatibility(incoming)
-	if err == nil {
-		t.Fatal("expected validation error for different SA, got nil")
+	if err != nil {
+		t.Fatalf("expected no error for different SA with driver auth, got: %v", err)
 	}
-	assert.Contains(t, err.Error(), "serviceAccountName mismatch")
 }
 
 func TestMountEntry_ShareAllowedWithSameParams(t *testing.T) {

--- a/pkg/driver/node/mounter/mount_map_test.go
+++ b/pkg/driver/node/mounter/mount_map_test.go
@@ -12,14 +12,14 @@ func TestMountMap_GetOrCreate_NewEntry(t *testing.T) {
 	entry, existed := m.GetOrCreate("vol-1")
 	assert.Equals(t, false, existed)
 	assert.Equals(t, "vol-1", entry.VolumeID)
-	assert.Equals(t, false, entry.initialized)
+	assert.Equals(t, false, entry.sourceMounted)
 }
 
 func TestMountMap_GetOrCreate_ExistingEntry(t *testing.T) {
 	m := NewMountMap()
 	entry1, _ := m.GetOrCreate("vol-1")
 	entry1.mu.Lock()
-	entry1.initialized = true
+	entry1.sourceMounted = true
 	entry1.SourcePath = "/source"
 	entry1.mu.Unlock()
 
@@ -191,13 +191,13 @@ func TestMountEntry_ResetAllowsDifferentParams(t *testing.T) {
 	entry.Params = MountParams{ServiceAccountName: "sa-a", AuthenticationSource: "driver"}
 	entry.RefCount = 1
 	entry.Targets = []string{"/target-a"}
-	entry.initialized = true
+	entry.sourceMounted = true
 	entry.mu.Unlock()
 
 	// Simulate unmount of last consumer
 	entry.mu.Lock()
 	entry.RefCount--
-	entry.initialized = false
+	entry.sourceMounted = false
 	entry.SourcePath = ""
 	entry.Params = MountParams{}
 	entry.Targets = nil
@@ -209,8 +209,8 @@ func TestMountEntry_ResetAllowsDifferentParams(t *testing.T) {
 	entry2.mu.Lock()
 	defer entry2.mu.Unlock()
 
-	// entry.initialized is false, so no validation runs — new mount is allowed
-	assert.Equals(t, false, entry2.initialized)
+	// entry.sourceMounted is false, so no validation runs — new mount is allowed
+	assert.Equals(t, false, entry2.sourceMounted)
 
 	// Simulate new mount with different params
 	newParams := MountParams{ServiceAccountName: "sa-b", AuthenticationSource: "pod"}
@@ -218,7 +218,7 @@ func TestMountEntry_ResetAllowsDifferentParams(t *testing.T) {
 	entry2.Params = newParams
 	entry2.RefCount = 1
 	entry2.Targets = []string{"/target-b"}
-	entry2.initialized = true
+	entry2.sourceMounted = true
 
 	// Verify new params took effect
 	assert.Equals(t, "sa-b", entry2.Params.ServiceAccountName)
@@ -235,7 +235,7 @@ func TestMountEntry_ShareRejectedWithDifferentParams(t *testing.T) {
 	entry.Params = MountParams{ServiceAccountName: "sa-a", AuthenticationSource: "pod"}
 	entry.RefCount = 1
 	entry.Targets = []string{"/target-a"}
-	entry.initialized = true
+	entry.sourceMounted = true
 	entry.mu.Unlock()
 
 	// Second workload tries to share with different SA — should fail with pod auth
@@ -261,7 +261,7 @@ func TestMountEntry_ShareAllowedWithDifferentSADriverAuth(t *testing.T) {
 	entry.Params = MountParams{ServiceAccountName: "sa-a", AuthenticationSource: "driver"}
 	entry.RefCount = 1
 	entry.Targets = []string{"/target-a"}
-	entry.initialized = true
+	entry.sourceMounted = true
 	entry.mu.Unlock()
 
 	// Second workload with different SA — should succeed with driver auth
@@ -292,7 +292,7 @@ func TestMountEntry_ShareAllowedWithSameParams(t *testing.T) {
 	}
 	entry.RefCount = 1
 	entry.Targets = []string{"/target-a"}
-	entry.initialized = true
+	entry.sourceMounted = true
 	entry.mu.Unlock()
 
 	// Second workload tries to share with same params — should succeed
@@ -323,7 +323,7 @@ func TestMountMap_Delete_EntryRemoved(t *testing.T) {
 	m := NewMountMap()
 	entry, _ := m.GetOrCreate("vol-1")
 	entry.mu.Lock()
-	entry.initialized = true
+	entry.sourceMounted = true
 	entry.RefCount = 1
 	entry.mu.Unlock()
 
@@ -340,7 +340,7 @@ func TestMountMap_Delete_GetOrCreateReturnsNewEntry(t *testing.T) {
 	// Create and populate an entry
 	entry1, _ := m.GetOrCreate("vol-1")
 	entry1.mu.Lock()
-	entry1.initialized = true
+	entry1.sourceMounted = true
 	entry1.SourcePath = "/old-source"
 	entry1.mu.Unlock()
 
@@ -353,7 +353,7 @@ func TestMountMap_Delete_GetOrCreateReturnsNewEntry(t *testing.T) {
 	if entry2 == entry1 {
 		t.Fatal("expected new entry after delete, got same pointer")
 	}
-	assert.Equals(t, false, entry2.initialized)
+	assert.Equals(t, false, entry2.sourceMounted)
 	assert.Equals(t, "", entry2.SourcePath)
 }
 
@@ -390,7 +390,7 @@ func TestMountMap_RetryLoop_ConvergesAfterDelete(t *testing.T) {
 	if entry == orphan {
 		t.Fatal("expected a new entry, not the orphaned one")
 	}
-	assert.Equals(t, false, entry.initialized)
+	assert.Equals(t, false, entry.sourceMounted)
 }
 
 func TestMountMap_ConcurrentDeleteAndGetOrCreate(t *testing.T) {
@@ -417,7 +417,7 @@ func TestMountMap_ConcurrentDeleteAndGetOrCreate(t *testing.T) {
 					}
 					entry.mu.Unlock()
 				}
-				entry.initialized = true
+				entry.sourceMounted = true
 				entry.RefCount++
 				entry.mu.Unlock()
 			} else {

--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -239,8 +239,13 @@ func (ns *S3NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUn
 		return nil, status.Errorf(codes.Internal, "Could not unmount %q: %v", targetContainer, err)
 	}
 	if !mounted {
-		klog.V(4).Infof("NodeUnpublishVolume: target path %s not mounted, skipping unmount", targetContainer)
-		return &csi.NodeUnpublishVolumeResponse{}, nil
+		// For daemonset mounter, always call Unmount for bookkeeping (MountMap refcount).
+		// For other mounters, skip if not mounted (original behavior).
+		if _, isDaemonset := ns.Mounter.(*mounter.DaemonsetMounter); !isDaemonset {
+			klog.V(4).Infof("NodeUnpublishVolume: target path %s not mounted, skipping unmount", targetContainer)
+			return &csi.NodeUnpublishVolumeResponse{}, nil
+		}
+		klog.V(4).Infof("NodeUnpublishVolume: target path %s not mounted, calling Unmount for bookkeeping", targetContainer)
 	}
 
 	credentialCtx := credentialCleanupContextFromUnpublishRequest(req)

--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -4,6 +4,8 @@ package mounter
 import (
 	"errors"
 	"fmt"
+	"io"
+	"os"
 
 	"k8s.io/klog/v2"
 	mountutils "k8s.io/mount-utils"
@@ -117,6 +119,30 @@ func (m *Mounter) CheckMountpoint(target Target) (bool, error) {
 // FindReferencesToMountpoint returns list of references to Mountpoint at `target`.
 func (m *Mounter) FindReferencesToMountpoint(target Target) ([]string, error) {
 	return m.mount.GetMountRefs(target)
+}
+
+// IsHealthyMountpoint checks whether `target` is both a valid Mountpoint mount AND the FUSE daemon is alive.
+// A dead FUSE mount (after mounter pod crash) stays in the mount table but returns ENOTCONN on any I/O.
+func (m *Mounter) IsHealthyMountpoint(target Target) bool {
+	isMounted, err := m.CheckMountpoint(target)
+	if err != nil || !isMounted {
+		return false
+	}
+
+	// Mount entry exists in the table — verify the FUSE daemon is alive
+	// by attempting to read the directory. A dead mount returns ENOTCONN.
+	// We use Open+Readdirnames(1) to issue a single getdents syscall,
+	// avoiding enumeration of potentially millions of entries.
+	f, err := os.Open(target)
+	if err != nil {
+		return false
+	}
+	_, err = f.Readdirnames(1)
+	f.Close()
+	// err == nil means at least one entry was read (healthy).
+	// err == io.EOF means empty directory (still healthy — FUSE responded).
+	// Any other error (ENOTCONN, EIO, etc.) means dead.
+	return err == nil || errors.Is(err, io.EOF)
 }
 
 // IsMountpointCorrupted returns whether an error returned from [Mounter.CheckMountpoint]

--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -4,7 +4,6 @@ package mounter
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 
 	"k8s.io/klog/v2"
@@ -121,6 +120,12 @@ func (m *Mounter) FindReferencesToMountpoint(target Target) ([]string, error) {
 	return m.mount.GetMountRefs(target)
 }
 
+// IsMountPoint checks whether `target` is any mount point (not necessarily Mountpoint).
+// Uses the kernel mount table via mount-utils.
+func (m *Mounter) IsMountPoint(target Target) (bool, error) {
+	return m.mount.IsMountPoint(target)
+}
+
 // IsHealthyMountpoint checks whether `target` is both a valid Mountpoint mount AND the FUSE daemon is alive.
 // A dead FUSE mount (after mounter pod crash) stays in the mount table but returns ENOTCONN on any I/O.
 func (m *Mounter) IsHealthyMountpoint(target Target) bool {
@@ -129,20 +134,18 @@ func (m *Mounter) IsHealthyMountpoint(target Target) bool {
 		return false
 	}
 
-	// Mount entry exists in the table — verify the FUSE daemon is alive
-	// by attempting to read the directory. A dead mount returns ENOTCONN.
-	// We use Open+Readdirnames(1) to issue a single getdents syscall,
-	// avoiding enumeration of potentially millions of entries.
+	// Mount entry exists in the table — verify the FUSE daemon is alive.
+	// Opening the root directory issues a FUSE OPENDIR to the daemon. Mountpoint does NOT
+	// set FUSE_NO_OPENDIR_SUPPORT, so the kernel always forwards opendir to userspace.
+	// A dead mount returns ENOTCONN; a live daemon succeeds without requiring S3 connectivity.
+	// We intentionally avoid Readdirnames which would trigger a ListObjectsV2 call to S3,
+	// causing false negatives during transient network issues.
 	f, err := os.Open(target)
 	if err != nil {
 		return false
 	}
-	_, err = f.Readdirnames(1)
 	f.Close()
-	// err == nil means at least one entry was read (healthy).
-	// err == io.EOF means empty directory (still healthy — FUSE responded).
-	// Any other error (ENOTCONN, EIO, etc.) means dead.
-	return err == nil || errors.Is(err, io.EOF)
+	return true
 }
 
 // IsMountpointCorrupted returns whether an error returned from [Mounter.CheckMountpoint]

--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -68,6 +68,7 @@ var CSITestSuites = []func() framework.TestSuite{
 	custom_testsuites.InitS3CSIMultiVolumeTestSuite,
 	custom_testsuites.InitS3MountOptionsTestSuite,
 	custom_testsuites.InitS3CSICredentialsTestSuite,
+	custom_testsuites.InitS3CSIPodSharingDaemonsetTestSuite,
 	// TODO: reenable or rewrite when credentials / cache / pod sharing are implemented for daemonset mode
 	// custom_testsuites.InitS3CSICacheTestSuite,
 	// custom_testsuites.InitS3CSIPodSharingTestSuite,

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -753,6 +753,13 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				})
 
 				It("should not mix different pod's service account tokens even when they are using the same volume", func(ctx context.Context) {
+					// In daemonset mode, pods with different service accounts sharing the same PV
+					// on the same node will be rejected by ValidateCompatibility. This test relies
+					// on both pods mounting successfully which only works with per-pod Mountpoint processes.
+					if isDaemonsetMounterMode(ctx, f) {
+						Skip("Skipping in daemonset mode: different SAs cannot share the same FUSE source mount on the same node")
+					}
+
 					mountOptions := []string{"allow-delete", fmt.Sprintf("region %s", DefaultRegion)}
 					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, mountOptions)
 					deferCleanup(vol.CleanupResource)
@@ -891,6 +898,13 @@ func (t *s3CSICredentialsTestSuite) DefineTests(driver storageframework.TestDriv
 				})
 
 				It("should not mix different pod's service account tokens even when they are using the same volume", func(ctx context.Context) {
+					// In daemonset mode, pods with different service accounts sharing the same PV
+					// on the same node will be rejected by ValidateCompatibility. This test relies
+					// on both pods mounting successfully which only works with per-pod Mountpoint processes.
+					if isDaemonsetMounterMode(ctx, f) {
+						Skip("Skipping in daemonset mode: different SAs cannot share the same FUSE source mount on the same node")
+					}
+
 					mountOptions := []string{"allow-delete", fmt.Sprintf("region %s", DefaultRegion)}
 					vol := createVolumeResourceWithMountOptions(enablePodLevelIdentity(ctx), l.config, pattern, mountOptions)
 					deferCleanup(vol.CleanupResource)

--- a/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
@@ -619,9 +619,10 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			// mount-s3 process should be running while pod is mounted
 			ginkgo.By("Verifying mount-s3 process exists while pod is mounted")
 			dumpMountpointProcesses(ctx, f, targetNode, "while pod mounted")
-			mpProcessCountBefore := countMountpointProcessesForVolume(ctx, f, targetNode, bucketName)
-			gomega.Expect(mpProcessCountBefore).To(gomega.Equal(1),
-				"expected exactly 1 mount-s3 process for bucket %s while pod is mounted, got %d", bucketName, mpProcessCountBefore)
+			framework.Gomega().Eventually(ctx, func(ctx context.Context) (int, error) {
+				count := countMountpointProcessesForVolume(ctx, f, targetNode, bucketName)
+				return count, nil
+			}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(gomega.Equal(1))
 
 			// Delete the pod — last consumer, should clean up meta AND source mount
 			ginkgo.By("Deleting the last pod and verifying meta file and source mount are removed")
@@ -644,9 +645,10 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			// Verify mount-s3 process for this volume has terminated in the mounter pod
 			ginkgo.By("Verifying mount-s3 process terminated after last consumer unmounts")
 			dumpMountpointProcesses(ctx, f, targetNode, "after last consumer unmounts")
-			mpProcessCountAfter := countMountpointProcessesForVolume(ctx, f, targetNode, bucketName)
-			gomega.Expect(mpProcessCountAfter).To(gomega.Equal(0),
-				"expected 0 mount-s3 processes for bucket %s after last consumer unmounts, got %d", bucketName, mpProcessCountAfter)
+			framework.Gomega().Eventually(ctx, func(ctx context.Context) (int, error) {
+				count := countMountpointProcessesForVolume(ctx, f, targetNode, bucketName)
+				return count, nil
+			}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(gomega.Equal(0))
 		})
 
 		ginkgo.It("should recover from mounter pod crash with fresh source mount for new pods", func(ctx context.Context) {
@@ -1296,34 +1298,31 @@ func waitForCSINodePodStable(ctx context.Context, f *framework.Framework, nodeNa
 }
 
 // countMountpointProcessesForVolume execs into the mounter pod on the given node and counts
-// mount-s3 processes for the specific bucket. Uses /proc/*/cmdline
-// mount-s3's first arg is the bucket name.
+// mount-s3 processes for the specific bucket. Uses /proc/*/cmdline.
+// Returns the count or -1 on error. Callers should use Eventually for retry logic.
 func countMountpointProcessesForVolume(ctx context.Context, f *framework.Framework, nodeName, bucketName string) int {
-	var result int
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (int, error) {
-		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
-			LabelSelector: "app=s3-csi-daemonset-mounter",
-			FieldSelector: "spec.nodeName=" + nodeName,
-		})
-		if err != nil || len(pods.Items) == 0 {
-			return -1, fmt.Errorf("mounter pod not found on node %s", nodeName)
-		}
+	pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=s3-csi-daemonset-mounter",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil || len(pods.Items) == 0 {
+		framework.Logf("mounter pod not found on node %s (retrying): %v", nodeName, err)
+		return -1
+	}
 
-		mounterPod := &pods.Items[0]
-		// Count mount-s3 processes for this specific bucket using case pattern match (no grep, avoids self-match)
-		cmd := fmt.Sprintf("count=0; for p in /proc/[0-9]*/cmdline; do line=$(cat $p 2>/dev/null | tr '\\0' ' '); case \"$line\" in '/mountpoint-s3/bin/mount-s3 %s '*) count=$((count+1));; esac; done; echo $count", bucketName)
-		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, mounterPod.Name, "mounter", []string{"/bin/sh", "-c", cmd})
-		if err != nil {
-			return -1, fmt.Errorf("exec failed: %w", err)
-		}
+	mounterPod := &pods.Items[0]
+	// Count mount-s3 processes for this specific bucket using case pattern match (no grep, avoids self-match)
+	cmd := fmt.Sprintf("count=0; for p in /proc/[0-9]*/cmdline; do line=$(cat $p 2>/dev/null | tr '\\0' ' '); case \"$line\" in '/mountpoint-s3/bin/mount-s3 %s '*) count=$((count+1));; esac; done; echo $count", bucketName)
+	stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, mounterPod.Name, "mounter", []string{"/bin/sh", "-c", cmd})
+	if err != nil {
+		framework.Logf("exec into mounter pod failed (retrying): %v", err)
+		return -1
+	}
 
-		count := 0
-		fmt.Sscanf(strings.TrimSpace(stdout), "%d", &count)
-		framework.Logf("mount-s3 process count for bucket %s on node %s: %d", bucketName, nodeName, count)
-		result = count
-		return count, nil
-	}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(gomega.BeNumerically(">=", 0))
-	return result
+	count := 0
+	fmt.Sscanf(strings.TrimSpace(stdout), "%d", &count)
+	framework.Logf("mount-s3 process count for bucket %s on node %s: %d", bucketName, nodeName, count)
+	return count
 }
 
 // dumpMountpointProcesses logs all mount-s3 processes running in the mounter pod on the given node.

--- a/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
@@ -1,0 +1,1353 @@
+package custom_testsuites
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+type s3CSIPodSharingDaemonsetTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+func InitS3CSIPodSharingDaemonsetTestSuite() storageframework.TestSuite {
+	return &s3CSIPodSharingDaemonsetTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "podsharingdaemonset",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+func (t *s3CSIPodSharingDaemonsetTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *s3CSIPodSharingDaemonsetTestSuite) SkipUnsupportedTests(_ storageframework.TestDriver, _ storageframework.TestPattern) {
+}
+
+func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	type local struct {
+		resources []*storageframework.VolumeResource
+		config    *storageframework.PerTestConfig
+	}
+	var l local
+
+	f := framework.NewFrameworkWithCustomTimeouts(NamespacePrefix+"podsharing-ds", storageframework.GetDriverTimeouts(driver))
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	cleanup := func(ctx context.Context) {
+		var errs []error
+		for _, resource := range l.resources {
+			errs = append(errs, resource.CleanupResource(ctx))
+		}
+		framework.ExpectNoError(errors.NewAggregate(errs), "while cleanup resource")
+	}
+
+	ginkgo.Describe("Pod Sharing (Daemonset Architecture)", func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			l = local{}
+			l.config = driver.PrepareTest(ctx, f)
+			ginkgo.DeferCleanup(cleanup)
+		})
+
+		ginkgo.It("should share data between two pods on the same node via shared mount", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			_, pods := createPodsOnSameNode(ctx, f, 2, resource)
+			defer deletePodsInOrder(ctx, f, pods)
+
+			checkCrossReadWriteDaemonset(ctx, f, pods[0], pods[1])
+		})
+
+		ginkgo.It("should keep second pod serving after first pod is deleted", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			_, pods := createPodsOnSameNode(ctx, f, 2, resource)
+			defer deletePodsInOrder(ctx, f, pods)
+
+			// Verify both pods can read/write
+			checkCrossReadWriteDaemonset(ctx, f, pods[0], pods[1])
+
+			// Delete first pod
+			ginkgo.By("Deleting the first pod")
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pods[0]))
+
+			// Second pod should still work
+			ginkgo.By("Verifying second pod can still read and write after first pod deletion")
+			toWrite := 1024
+			path := "/mnt/volume1/after-pod1-delete.txt"
+			seed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pods[1], path, toWrite, seed)
+			checkReadFromPathSucceed(ctx, f, pods[1], path, toWrite, seed)
+		})
+
+		ginkgo.It("should use only a single mount-s3 process for pods sharing the same PV", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			targetNode, pods := createPodsOnSameNode(ctx, f, 3, resource)
+			defer deletePodsInOrder(ctx, f, pods)
+
+			// All pods should be able to read/write
+			checkCrossReadWriteDaemonset(ctx, f, pods[0], pods[1])
+
+			// Assert only one FUSE mount exists for this volume by checking mount table
+			// The source mount path is /var/lib/kubelet/plugins/s3.csi.aws.com/mnt/<pvName>
+			ginkgo.By("Verifying only one FUSE source mount exists in the mount table")
+			pvName := resource.Pv.Name
+			dumpMountTable(ctx, f, targetNode, "single mount-s3 check")
+			fuseCount := countFuseMountsForVolume(ctx, f, targetNode, pvName)
+			gomega.Expect(fuseCount).To(gomega.Equal(1),
+				"expected exactly 1 FUSE source mount for volume %s, got %d", pvName, fuseCount)
+		})
+
+		ginkgo.It("should reject second pod with different fsGroup on the same PV", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// First pod with fsGroup 1000
+			ginkgo.By("Creating first pod with fsGroup 1000")
+			pod1 := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			pod1.Spec.SecurityContext = &v1.PodSecurityContext{FSGroup: ptrInt64(1000)}
+			pod1, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod1)
+			framework.ExpectNoError(err)
+			targetNode := pod1.Spec.NodeName
+			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, pod1) }()
+
+			// Verify first pod works
+			checkWriteToPathSucceed(ctx, f, pod1, "/mnt/volume1/from-pod1.txt", 512, time.Now().UTC().UnixNano())
+
+			// Second pod with different fsGroup 2000 — should fail to mount
+			ginkgo.By("Creating second pod with fsGroup 2000 on the same node (should fail)")
+			pod2 := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			pod2.Spec.SecurityContext = &v1.PodSecurityContext{FSGroup: ptrInt64(2000)}
+			pod2, err = createPodWithoutWaiting(ctx, f.ClientSet, f.Namespace.Name, pod2)
+			framework.ExpectNoError(err)
+			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, pod2) }()
+
+			// Wait and verify the pod does NOT become Running (mount should be rejected)
+			ginkgo.By("Verifying second pod fails to start due to fsGroup mismatch")
+			assertPodFailsToMount(ctx, f, pod2, "cannot share mount")
+		})
+
+		ginkgo.It("should allow different fsGroup after previous pod is deleted", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// First pod with fsGroup 1000
+			ginkgo.By("Creating first pod with fsGroup 1000")
+			pod1 := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			pod1.Spec.SecurityContext = &v1.PodSecurityContext{FSGroup: ptrInt64(1000)}
+			pod1, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod1)
+			framework.ExpectNoError(err)
+			targetNode := pod1.Spec.NodeName
+
+			// Verify first pod works
+			checkWriteToPathSucceed(ctx, f, pod1, "/mnt/volume1/from-fsgroup-1000.txt", 512, time.Now().UTC().UnixNano())
+
+			// Delete the first pod — entry should reset
+			ginkgo.By("Deleting first pod to release the mount")
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod1))
+
+			// Second pod with different fsGroup 2000 — should now succeed
+			ginkgo.By("Creating second pod with fsGroup 2000 on the same node (should succeed after deletion)")
+			pod2 := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			pod2.Spec.SecurityContext = &v1.PodSecurityContext{FSGroup: ptrInt64(2000)}
+			pod2, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod2)
+			framework.ExpectNoError(err)
+			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, pod2) }()
+
+			// Verify the new pod can read/write
+			ginkgo.By("Verifying second pod with different fsGroup can read and write")
+			checkWriteToPathSucceed(ctx, f, pod2, "/mnt/volume1/from-fsgroup-2000.txt", 512, time.Now().UTC().UnixNano())
+		})
+
+		ginkgo.It("should handle concurrent pod creation on the same node sharing same volume", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// Get a target node by creating first pod
+			ginkgo.By("Creating first pod to identify target node")
+			pod1 := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			pod1, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod1)
+			framework.ExpectNoError(err)
+			targetNode := pod1.Spec.NodeName
+			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, pod1) }()
+
+			// Concurrently create 4 more pods on the same node
+			ginkgo.By(fmt.Sprintf("Concurrently creating 4 pods on node %s", targetNode))
+			const concurrentPods = 4
+			var wg sync.WaitGroup
+			podsCh := make(chan *v1.Pod, concurrentPods)
+			errsCh := make(chan error, concurrentPods)
+
+			for i := range concurrentPods {
+				wg.Add(1)
+				go func(idx int) {
+					defer wg.Done()
+					pod := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+					pod, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+					if err != nil {
+						errsCh <- fmt.Errorf("pod %d creation failed: %w", idx, err)
+						return
+					}
+					podsCh <- pod
+				}(i)
+			}
+			wg.Wait()
+			close(podsCh)
+			close(errsCh)
+
+			// Collect errors
+			for err := range errsCh {
+				framework.ExpectNoError(err)
+			}
+
+			// Collect pods
+			var concPods []*v1.Pod
+			for pod := range podsCh {
+				concPods = append(concPods, pod)
+				defer func(p *v1.Pod) { e2epod.DeletePodWithWait(ctx, f.ClientSet, p) }(pod)
+			}
+			gomega.Expect(len(concPods)).To(gomega.Equal(concurrentPods))
+
+			// All pods should be able to read a file written by pod1
+			ginkgo.By("Verifying all concurrent pods can access shared data")
+			toWrite := 1024
+			sharedFile := "/mnt/volume1/concurrent-shared.txt"
+			seed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pod1, sharedFile, toWrite, seed)
+
+			for i, pod := range concPods {
+				ginkgo.By(fmt.Sprintf("Verifying concurrent pod %d can read shared file", i))
+				checkReadFromPathSucceed(ctx, f, pod, sharedFile, toWrite, seed)
+			}
+		})
+
+		ginkgo.It("should handle concurrent mount and unmount of pods sharing the same volume", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// Create initial pods
+			_, pods := createPodsOnSameNode(ctx, f, 3, resource)
+			targetNode := pods[0].Spec.NodeName
+
+			// Write a file from pod 0
+			toWrite := 1024
+			sharedFile := "/mnt/volume1/churn-test.txt"
+			seed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+
+			// Delete pod 0 and pod 1 while simultaneously creating 2 new pods
+			ginkgo.By("Concurrently deleting 2 pods and creating 2 new pods")
+			var wg sync.WaitGroup
+			newPodsCh := make(chan *v1.Pod, 2)
+			deleteErrsCh := make(chan error, 2)
+			createErrsCh := make(chan error, 2)
+
+			// Delete pods 0 and 1
+			for i := range 2 {
+				wg.Add(1)
+				go func(idx int) {
+					defer wg.Done()
+					if err := e2epod.DeletePodWithWait(ctx, f.ClientSet, pods[idx]); err != nil {
+						deleteErrsCh <- fmt.Errorf("delete pod %d failed: %w", idx, err)
+					}
+				}(i)
+			}
+
+			// Create 2 new pods on the same node
+			for i := range 2 {
+				wg.Add(1)
+				go func(idx int) {
+					defer wg.Done()
+					pod := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+					pod, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+					if err != nil {
+						createErrsCh <- fmt.Errorf("create new pod %d failed: %w", idx, err)
+						return
+					}
+					newPodsCh <- pod
+				}(i)
+			}
+			wg.Wait()
+			close(newPodsCh)
+			close(deleteErrsCh)
+			close(createErrsCh)
+
+			for err := range deleteErrsCh {
+				framework.ExpectNoError(err)
+			}
+			for err := range createErrsCh {
+				framework.ExpectNoError(err)
+			}
+
+			var newPods []*v1.Pod
+			for pod := range newPodsCh {
+				newPods = append(newPods, pod)
+				defer func(p *v1.Pod) { e2epod.DeletePodWithWait(ctx, f.ClientSet, p) }(pod)
+			}
+
+			// pod 2 (never deleted) should still have access
+			ginkgo.By("Verifying surviving pod still has access")
+			checkReadFromPathSucceed(ctx, f, pods[2], sharedFile, toWrite, seed)
+
+			// New pods should also have access
+			for i, pod := range newPods {
+				ginkgo.By(fmt.Sprintf("Verifying new pod %d can read shared file", i))
+				checkReadFromPathSucceed(ctx, f, pod, sharedFile, toWrite, seed)
+			}
+
+			// Clean up pod 2
+			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, pods[2]) }()
+		})
+
+		ginkgo.It("should handle rapid pod churn on the same volume", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// Create a pod, write data, delete it — repeat N times. Final pod should read all data.
+			const iterations = 5
+			var targetNode string
+
+			for i := range iterations {
+				ginkgo.By(fmt.Sprintf("Churn iteration %d: creating pod", i+1))
+				var nodeSelector map[string]string
+				if targetNode != "" {
+					nodeSelector = map[string]string{"kubernetes.io/hostname": targetNode}
+				}
+				pod := e2epod.MakePod(f.Namespace.Name, nodeSelector, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+				pod, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+				framework.ExpectNoError(err)
+
+				if targetNode == "" {
+					targetNode = pod.Spec.NodeName
+				}
+
+				// Write a unique file
+				path := fmt.Sprintf("/mnt/volume1/churn-%d.txt", i)
+				seed := time.Now().UTC().UnixNano() + int64(i)
+				checkWriteToPathSucceed(ctx, f, pod, path, 512, seed)
+
+				ginkgo.By(fmt.Sprintf("Churn iteration %d: deleting pod", i+1))
+				framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+			}
+
+			// Create final pod and verify all files exist
+			ginkgo.By("Creating final pod to verify all churned files are readable")
+			finalPod := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			finalPod, err := createPod(ctx, f.ClientSet, f.Namespace.Name, finalPod)
+			framework.ExpectNoError(err)
+			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, finalPod) }()
+
+			for i := range iterations {
+				path := fmt.Sprintf("/mnt/volume1/churn-%d.txt", i)
+				ginkgo.By(fmt.Sprintf("Verifying file %s exists", path))
+				checkListingPathSucceed(ctx, f, finalPod, path)
+			}
+		})
+
+		ginkgo.It("should allow N pods to concurrently write different files to the shared volume", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			const podCount = 5
+			_, pods := createPodsOnSameNode(ctx, f, podCount, resource)
+			defer deletePodsInOrder(ctx, f, pods)
+
+			// Each pod writes a unique file concurrently
+			ginkgo.By(fmt.Sprintf("Having %d pods concurrently write unique files", podCount))
+			toWrite := 1024
+			seeds := make([]int64, podCount)
+			var wg sync.WaitGroup
+			for i := range podCount {
+				seeds[i] = time.Now().UTC().UnixNano() + int64(i)
+				wg.Add(1)
+				go func(idx int) {
+					defer ginkgo.GinkgoRecover()
+					defer wg.Done()
+					path := fmt.Sprintf("/mnt/volume1/pod%d-file.txt", idx)
+					checkWriteToPathSucceed(ctx, f, pods[idx], path, toWrite, seeds[idx])
+				}(i)
+			}
+			wg.Wait()
+
+			// Each pod reads all other pods' files
+			ginkgo.By("Verifying all pods can read all files")
+			for reader := range podCount {
+				for writer := range podCount {
+					path := fmt.Sprintf("/mnt/volume1/pod%d-file.txt", writer)
+					checkReadFromPathSucceed(ctx, f, pods[reader], path, toWrite, seeds[writer])
+				}
+			}
+		})
+
+		ginkgo.It("should survive deleting pods in reverse order", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			const podCount = 4
+			_, pods := createPodsOnSameNode(ctx, f, podCount, resource)
+
+			// Write from first pod
+			toWrite := 1024
+			sharedFile := "/mnt/volume1/reverse-delete.txt"
+			seed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+
+			// Delete pods in reverse order (last created first), verifying remaining pods still work
+			for i := podCount - 1; i > 0; i-- {
+				ginkgo.By(fmt.Sprintf("Deleting pod %d (of %d remaining)", i, i+1))
+				framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pods[i]))
+
+				// Verify pod 0 (first pod) still has access
+				ginkgo.By(fmt.Sprintf("Verifying pod 0 still has access after deleting pod %d", i))
+				checkReadFromPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+			}
+
+			// Finally delete pod 0
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pods[0]))
+		})
+
+		ginkgo.It("should handle pod recreation on same node after all pods are deleted", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// First generation: create 2 pods, write data, delete both
+			targetNode, pods := createPodsOnSameNode(ctx, f, 2, resource)
+
+			toWrite := 1024
+			file1 := "/mnt/volume1/gen1-file.txt"
+			seed1 := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pods[0], file1, toWrite, seed1)
+			checkReadFromPathSucceed(ctx, f, pods[1], file1, toWrite, seed1)
+
+			ginkgo.By("Deleting all first-generation pods")
+			for _, pod := range pods {
+				framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
+			}
+
+			// Second generation: create 2 new pods on same node, verify old data still readable
+			ginkgo.By("Creating second-generation pods on the same node")
+			var gen2Pods []*v1.Pod
+			for i := range 2 {
+				pod := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+				pod, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+				framework.ExpectNoError(err, "failed to create gen2 pod %d", i)
+				gen2Pods = append(gen2Pods, pod)
+				defer func(p *v1.Pod) { e2epod.DeletePodWithWait(ctx, f.ClientSet, p) }(pod)
+			}
+
+			// Gen2 pods should be able to read gen1 data (persisted in S3)
+			ginkgo.By("Verifying second-generation pods can read first-generation data")
+			for i, pod := range gen2Pods {
+				ginkgo.By(fmt.Sprintf("Gen2 pod %d reading gen1 file", i))
+				checkReadFromPathSucceed(ctx, f, pod, file1, toWrite, seed1)
+			}
+
+			// Gen2 pods should share with each other
+			file2 := "/mnt/volume1/gen2-file.txt"
+			seed2 := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, gen2Pods[0], file2, toWrite, seed2)
+			checkReadFromPathSucceed(ctx, f, gen2Pods[1], file2, toWrite, seed2)
+		})
+
+		ginkgo.It("should recover mount map after CSI node pod restart and existing pods keep working", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// Create 2 pods sharing the volume
+			targetNode, pods := createPodsOnSameNode(ctx, f, 2, resource)
+			defer deletePodsInOrder(ctx, f, pods)
+
+			// Write data from pod 0
+			toWrite := 1024
+			sharedFile := "/mnt/volume1/pre-restart.txt"
+			seed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+			checkReadFromPathSucceed(ctx, f, pods[1], sharedFile, toWrite, seed)
+
+			// Kill the CSI node pod on this node (only the node pod, not the mounter)
+			ginkgo.By(fmt.Sprintf("Killing CSI node pod on node %s to lose in-memory mount map", targetNode))
+			killCSINodePodOnNode(ctx, f, targetNode)
+
+			// Wait for CSI node pod to come back (RebuildMountMap runs on startup)
+			ginkgo.By("Waiting for CSI node pod to restart and rebuild mount map")
+			waitForCSINodePodReady(ctx, f, targetNode)
+			waitForCSINodePodStable(ctx, f, targetNode)
+
+			// Existing pods should still work — FUSE mounts never died (mounter pod stayed up)
+			// Use Eventually variant because reads can transiently fail with "Transport endpoint
+			// is not connected" for a few seconds after CSI node pod restart.
+			ginkgo.By("Verifying existing pods still have working mounts after CSI node restart")
+			checkReadFromPathSucceedEventually(ctx, f, pods[0], sharedFile, toWrite, seed)
+			checkReadFromPathSucceedEventually(ctx, f, pods[1], sharedFile, toWrite, seed)
+
+			// Write new data to verify write path also works
+			postRestartFile := "/mnt/volume1/post-restart.txt"
+			postSeed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceedEventually(ctx, f, pods[0], postRestartFile, toWrite, postSeed)
+			checkReadFromPathSucceedEventually(ctx, f, pods[1], postRestartFile, toWrite, postSeed)
+		})
+
+		ginkgo.It("should allow new pod to join shared mount after CSI node pod restart", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// Create 1 pod and write data
+			targetNode, pods := createPodsOnSameNode(ctx, f, 1, resource)
+			defer deletePodsInOrder(ctx, f, pods)
+
+			toWrite := 1024
+			sharedFile := "/mnt/volume1/before-restart.txt"
+			seed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+
+			// Kill CSI node pod
+			ginkgo.By(fmt.Sprintf("Killing CSI node pod on node %s", targetNode))
+			killCSINodePodOnNode(ctx, f, targetNode)
+			waitForCSINodePodReady(ctx, f, targetNode)
+			waitForCSINodePodStable(ctx, f, targetNode)
+
+			// Create a new pod on the same node — should join the existing share
+			// (mount map was rebuilt, so it knows about the existing source mount)
+			ginkgo.By("Creating new pod after CSI node restart — should share existing mount")
+			pod2 := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			pod2, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod2)
+			framework.ExpectNoError(err)
+			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, pod2) }()
+
+			// New pod should read data written before the restart
+			ginkgo.By("Verifying new pod can read data written before CSI node restart")
+			checkReadFromPathSucceed(ctx, f, pod2, sharedFile, toWrite, seed)
+
+			// Verify still only 1 FUSE mount (sharing, not a new one)
+			ginkgo.By("Verifying only one FUSE source mount exists (mount was shared, not duplicated)")
+			pvName := resource.Pv.Name
+			fuseCount := countFuseMountsForVolume(ctx, f, targetNode, pvName)
+			gomega.Expect(fuseCount).To(gomega.Equal(1),
+				"expected exactly 1 FUSE source mount for volume %s after restart, got %d", pvName, fuseCount)
+		})
+
+		ginkgo.It("should correctly unmount after CSI node pod restart with recovered refcount", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// Create 3 pods sharing the volume
+			targetNode, pods := createPodsOnSameNode(ctx, f, 3, resource)
+
+			toWrite := 1024
+			sharedFile := "/mnt/volume1/refcount-test.txt"
+			seed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+
+			// Kill CSI node pod — refcount lost from memory
+			ginkgo.By(fmt.Sprintf("Killing CSI node pod on node %s", targetNode))
+			killCSINodePodOnNode(ctx, f, targetNode)
+			waitForCSINodePodReady(ctx, f, targetNode)
+			waitForCSINodePodStable(ctx, f, targetNode)
+
+			// Delete pod 0 and pod 1 — refcount should decrement correctly from recovered state
+			ginkgo.By("Deleting first two pods after restart")
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pods[0]))
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pods[1]))
+
+			// Pod 2 should still have a working mount (source not torn down because refcount > 0)
+			ginkgo.By("Verifying surviving pod still has access after two siblings unmounted post-restart")
+			checkReadFromPathSucceedEventually(ctx, f, pods[2], sharedFile, toWrite, seed)
+
+			// Clean up pod 2
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pods[2]))
+		})
+
+		ginkgo.It("should persist meta file on disk for mounted volumes", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			targetNode, pods := createPodsOnSameNode(ctx, f, 1, resource)
+			defer deletePodsInOrder(ctx, f, pods)
+
+			// Verify .meta.json file exists on the node by exec'ing into CSI node pod
+			pvName := resource.Pv.Name
+			ginkgo.By(fmt.Sprintf("Verifying .meta.json exists for volume %s", pvName))
+			metaExists := checkMetaFileExists(ctx, f, targetNode, pvName)
+			gomega.Expect(metaExists).To(gomega.BeTrue(),
+				"expected .meta.json file to exist for volume %s", pvName)
+		})
+
+		ginkgo.It("should clean up meta file and source mount after last consumer unmounts", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			targetNode, pods := createPodsOnSameNode(ctx, f, 1, resource)
+			pvName := resource.Pv.Name
+			bucketName := resource.Pv.Spec.CSI.VolumeHandle
+
+			// Meta file should exist while pod is running
+			ginkgo.By("Verifying meta file exists while pod is mounted")
+			metaExists := checkMetaFileExists(ctx, f, targetNode, pvName)
+			gomega.Expect(metaExists).To(gomega.BeTrue())
+
+			// FUSE source should exist in mount table
+			ginkgo.By("Verifying FUSE source mount exists while pod is mounted")
+			dumpMountTable(ctx, f, targetNode, "while pod mounted")
+			fuseCount := countFuseMountsForVolume(ctx, f, targetNode, pvName)
+			gomega.Expect(fuseCount).To(gomega.BeNumerically(">=", 1))
+
+			// mount-s3 process should be running while pod is mounted
+			ginkgo.By("Verifying mount-s3 process exists while pod is mounted")
+			dumpMountpointProcesses(ctx, f, targetNode, "while pod mounted")
+			mpProcessCountBefore := countMountpointProcessesForVolume(ctx, f, targetNode, bucketName)
+			gomega.Expect(mpProcessCountBefore).To(gomega.Equal(1),
+				"expected exactly 1 mount-s3 process for bucket %s while pod is mounted, got %d", bucketName, mpProcessCountBefore)
+
+			// Delete the pod — last consumer, should clean up meta AND source mount
+			ginkgo.By("Deleting the last pod and verifying meta file and source mount are removed")
+			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pods[0]))
+
+			// Give a moment for unmount to complete
+			time.Sleep(5 * time.Second)
+
+			metaExists = checkMetaFileExists(ctx, f, targetNode, pvName)
+			gomega.Expect(metaExists).To(gomega.BeFalse(),
+				"expected .meta.json file to be removed after last consumer unmounts")
+
+			// Source mount should be gone from mount table
+			ginkgo.By("Verifying FUSE source mount is removed from mount table after last consumer unmounts")
+			dumpMountTable(ctx, f, targetNode, "after last consumer unmounts")
+			fuseCountAfter := countFuseMountsForVolume(ctx, f, targetNode, pvName)
+			gomega.Expect(fuseCountAfter).To(gomega.Equal(0),
+				"expected 0 FUSE source mounts after last consumer unmounts, got %d", fuseCountAfter)
+
+			// Verify mount-s3 process for this volume has terminated in the mounter pod
+			ginkgo.By("Verifying mount-s3 process terminated after last consumer unmounts")
+			dumpMountpointProcesses(ctx, f, targetNode, "after last consumer unmounts")
+			mpProcessCountAfter := countMountpointProcessesForVolume(ctx, f, targetNode, bucketName)
+			gomega.Expect(mpProcessCountAfter).To(gomega.Equal(0),
+				"expected 0 mount-s3 processes for bucket %s after last consumer unmounts, got %d", bucketName, mpProcessCountAfter)
+		})
+
+		ginkgo.It("should recover from mounter pod crash with fresh source mount for new pods", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// Create 2 pods sharing the volume and write data
+			targetNode, pods := createPodsOnSameNode(ctx, f, 2, resource)
+			defer deletePodsInOrder(ctx, f, pods)
+
+			toWrite := 1024
+			sharedFile := "/mnt/volume1/pre-crash-shared.txt"
+			seed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+			checkReadFromPathSucceed(ctx, f, pods[1], sharedFile, toWrite, seed)
+
+			pvName := resource.Pv.Name
+
+			// Capture device ID and meta mtime BEFORE crash for comparison after recovery
+			ginkgo.By("Capturing FUSE source device ID and meta mtime before crash")
+			dumpMountTable(ctx, f, targetNode, "BEFORE MOUNTER CRASH")
+			fuseDeviceBefore := getFuseSourceDeviceID(ctx, f, targetNode, pvName)
+			framework.Logf("FUSE device ID before crash: %s", fuseDeviceBefore)
+			gomega.Expect(fuseDeviceBefore).ToNot(gomega.BeEmpty(), "FUSE source should exist before crash")
+			metaMtimeBefore := getMetaFileMtime(ctx, f, targetNode, pvName)
+			framework.Logf("Meta mtime before crash: %s", metaMtimeBefore)
+
+			// Kill the mounter pod — all FUSE mounts die
+			ginkgo.By(fmt.Sprintf("Killing mounter pod on node %s to crash all Mountpoint processes", targetNode))
+			killMounterPodOnNode(ctx, f, targetNode)
+			waitForMounterPodReady(ctx, f, targetNode)
+
+			// Give the CSI node pod time to re-discover the comm dir after mounter pod recovery.
+			// The comm dir re-discovery and mount handshake needs a few seconds.
+			time.Sleep(15 * time.Second)
+
+			// Existing pods have dead mounts
+			ginkgo.By("Verifying existing pods have dead mounts after mounter crash")
+			dumpMountTable(ctx, f, targetNode, "AFTER MOUNTER CRASH")
+			assertPodIOFails(ctx, f, pods[0], "/mnt/volume1/")
+			assertPodIOFails(ctx, f, pods[1], "/mnt/volume1/")
+
+			// Create 3 new pods on the same node using the same PV — without deleting old pods.
+			// This simulates scaling up new replicas while old broken pods still exist.
+			// The CSI driver should detect dead source, create a fresh FUSE mount, and
+			// bind-mount to each new pod's target.
+			ginkgo.By("Creating 3 new pods after mounter crash (old pods still running with dead mounts)")
+			var newPods []*v1.Pod
+			for i := range 3 {
+				pod := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+				pod, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+				framework.ExpectNoError(err, "failed to create new pod %d after mounter crash", i)
+				newPods = append(newPods, pod)
+			}
+			defer func() {
+				for _, p := range newPods {
+					e2epod.DeletePodWithWait(ctx, f.ClientSet, p)
+				}
+			}()
+
+			// All new pods should have healthy I/O
+			ginkgo.By("Verifying all new pods can write and read data")
+			for i, pod := range newPods {
+				writeFile := fmt.Sprintf("/mnt/volume1/new-pod-%d.txt", i)
+				writeSeed := time.Now().UTC().UnixNano() + int64(i)
+				checkWriteToPathSucceed(ctx, f, pod, writeFile, toWrite, writeSeed)
+				checkReadFromPathSucceed(ctx, f, pod, writeFile, toWrite, writeSeed)
+			}
+
+			// Cross-pod sharing should work: pod 0 writes, pod 1 and pod 2 read
+			ginkgo.By("Verifying cross-pod sharing works among new pods")
+			crossFile := "/mnt/volume1/cross-pod-after-crash.txt"
+			crossSeed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, newPods[0], crossFile, toWrite, crossSeed)
+			checkReadFromPathSucceed(ctx, f, newPods[1], crossFile, toWrite, crossSeed)
+			checkReadFromPathSucceed(ctx, f, newPods[2], crossFile, toWrite, crossSeed)
+
+			// Old data written before crash (persisted in S3) should be readable
+			ginkgo.By("Verifying new pods can read data written before mounter crash")
+			checkReadFromPathSucceed(ctx, f, newPods[0], sharedFile, toWrite, seed)
+
+			// Verify only 1 FUSE source mount exists (all 3 pods share the same source)
+			ginkgo.By("Verifying only one FUSE source mount exists for all new pods")
+			dumpMountTable(ctx, f, targetNode, "AFTER RECOVERY (3 new pods)")
+			fuseCount := countFuseMountsForVolume(ctx, f, targetNode, pvName)
+			gomega.Expect(fuseCount).To(gomega.Equal(1),
+				"expected exactly 1 FUSE source mount for volume %s after recovery with 3 pods, got %d", pvName, fuseCount)
+
+			// Verify the new source mount has a different device ID (fresh FUSE mount, not the dead one)
+			ginkgo.By("Verifying fresh source mount has a new device ID")
+			fuseDeviceAfter := getFuseSourceDeviceID(ctx, f, targetNode, pvName)
+			framework.Logf("FUSE device ID — before crash: %s, after recovery: %s", fuseDeviceBefore, fuseDeviceAfter)
+			gomega.Expect(fuseDeviceAfter).ToNot(gomega.BeEmpty(), "expected FUSE source to have a device ID after recovery")
+			gomega.Expect(fuseDeviceAfter).ToNot(gomega.Equal(fuseDeviceBefore),
+				"new source mount should have a different device ID than the crashed one (old=%s, new=%s)", fuseDeviceBefore, fuseDeviceAfter)
+
+			// Verify the old device ID no longer serves the source path
+			ginkgo.By("Verifying old device ID is no longer at the source path")
+			oldDeviceStillAtSource := checkDeviceIDAtSourcePath(ctx, f, targetNode, pvName, fuseDeviceBefore)
+			gomega.Expect(oldDeviceStillAtSource).To(gomega.BeFalse(),
+				"old device ID %s should not be the active source mount anymore", fuseDeviceBefore)
+
+			// Verify meta file was overwritten (mtime changed)
+			ginkgo.By("Verifying meta file was overwritten after recovery")
+			metaMtimeAfter := getMetaFileMtime(ctx, f, targetNode, pvName)
+			framework.Logf("Meta mtime — before: %s, after: %s", metaMtimeBefore, metaMtimeAfter)
+			gomega.Expect(metaMtimeAfter).ToNot(gomega.Equal(metaMtimeBefore),
+				"meta file mtime should change after fresh mount overwrites it")
+		})
+	})
+}
+
+// createPodsOnSameNode creates n pods on the same node using the given volume resource.
+// Returns the target node name and slice of created pods.
+func createPodsOnSameNode(ctx context.Context, f *framework.Framework, n int, resource *storageframework.VolumeResource) (string, []*v1.Pod) {
+	var pods []*v1.Pod
+	var targetNode string
+
+	for i := range n {
+		var nodeSelector map[string]string
+		if i > 0 && targetNode != "" {
+			nodeSelector = map[string]string{"kubernetes.io/hostname": targetNode}
+		}
+
+		ginkgo.By(fmt.Sprintf("Creating pod %d with volume", i+1))
+		pod := e2epod.MakePod(f.Namespace.Name, nodeSelector, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+		pod, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+		framework.ExpectNoError(err)
+
+		if i == 0 {
+			targetNode = pod.Spec.NodeName
+		} else {
+			gomega.Expect(pod.Spec.NodeName).To(gomega.Equal(targetNode))
+		}
+		pods = append(pods, pod)
+	}
+	return targetNode, pods
+}
+
+// deletePodsInOrder deletes pods sequentially in the order they appear in the slice.
+func deletePodsInOrder(ctx context.Context, f *framework.Framework, pods []*v1.Pod) {
+	for _, pod := range pods {
+		e2epod.DeletePodWithWait(ctx, f.ClientSet, pod)
+	}
+}
+
+// checkCrossReadWriteDaemonset verifies that two pods sharing a mount can see each other's writes.
+func checkCrossReadWriteDaemonset(ctx context.Context, f *framework.Framework, pod1, pod2 *v1.Pod) {
+	toWrite := 1024
+	basePath := "/mnt/volume1"
+
+	// Pod1 writes, pod2 reads
+	file1 := filepath.Join(basePath, "ds-cross-file1.txt")
+	seed1 := time.Now().UTC().UnixNano()
+	checkWriteToPathSucceed(ctx, f, pod1, file1, toWrite, seed1)
+	checkReadFromPathSucceed(ctx, f, pod2, file1, toWrite, seed1)
+
+	// Pod2 writes, pod1 reads
+	file2 := filepath.Join(basePath, "ds-cross-file2.txt")
+	seed2 := time.Now().UTC().UnixNano()
+	checkWriteToPathSucceed(ctx, f, pod2, file2, toWrite, seed2)
+	checkReadFromPathSucceed(ctx, f, pod1, file2, toWrite, seed2)
+}
+
+// verifyCSINodeLogs checks the CSI node pod logs for expected sharing messages.
+// This is a helper that can be used to verify that mount sharing is actually happening
+// at the CSI driver level (FUSE source + bind mount) rather than separate mounts.
+func verifyCSINodeLogs(ctx context.Context, f *framework.Framework, nodeName string, expectedSubstring string) bool {
+	pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=s3-csi-node",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil || len(pods.Items) == 0 {
+		return false
+	}
+
+	logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, csiDriverDaemonSetNamespace, pods.Items[0].Name, "s3-plugin")
+	if err != nil {
+		return false
+	}
+
+	return containsSubstring(logs, expectedSubstring)
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// ptrInt64 returns a pointer to the given int64 value.
+func ptrInt64(v int64) *int64 {
+	return &v
+}
+
+// assertPodFailsToMount waits for a pod to have a mount failure event containing the given substring.
+// The pod should be stuck in ContainerCreating due to volume mount failure.
+func assertPodFailsToMount(ctx context.Context, f *framework.Framework, pod *v1.Pod, errorSubstring string) {
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (bool, error) {
+		events, err := f.ClientSet.CoreV1().Events(pod.Namespace).List(ctx, metav1.ListOptions{
+			FieldSelector: "involvedObject.name=" + pod.Name,
+		})
+		if err != nil {
+			return false, err
+		}
+		for _, event := range events.Items {
+			if event.Reason == "FailedMount" && strings.Contains(event.Message, errorSubstring) {
+				framework.Logf("Found expected FailedMount event: %s", event.Message)
+				return true, nil
+			}
+		}
+		return false, nil
+	}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(gomega.BeTrue())
+}
+
+// countFuseMountsForVolume execs into the CSI node pod on the given node and checks
+// /proc/self/mountinfo for FUSE mounts matching the volume ID's source path.
+// The source mount path is: /var/lib/kubelet/plugins/s3.csi.aws.com/mnt/<volumeID>
+// Returns the count of FUSE source mounts for that volume (should be exactly 1 for shared volumes).
+// Retries on transient exec errors (container restarting, etc.) for up to 1 minute.
+func countFuseMountsForVolume(ctx context.Context, f *framework.Framework, nodeName, volumeID string) int {
+	var result int
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (int, error) {
+		// Find the CSI node pod on this node
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-node",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			framework.Logf("Failed to find CSI node pod on node %s (retrying): %v", nodeName, err)
+			return -1, fmt.Errorf("CSI node pod not found on node %s", nodeName)
+		}
+
+		csiPod := &pods.Items[0]
+
+		// Count FUSE source mounts for this specific volume
+		cmd := fmt.Sprintf("cat /proc/self/mountinfo | grep 's3.csi.aws.com/mnt/%s' | grep fuse | wc -l", volumeID)
+		stdout, stderr, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, csiPod.Name, "s3-plugin", []string{"/bin/sh", "-c", cmd})
+		if err != nil {
+			framework.Logf("Failed to exec in CSI node pod (retrying) (stdout=%s, stderr=%s): %v", stdout, stderr, err)
+			return -1, fmt.Errorf("exec failed: %w", err)
+		}
+
+		count := 0
+		fmt.Sscanf(strings.TrimSpace(stdout), "%d", &count)
+		framework.Logf("Found %d FUSE source mount(s) for volume %s on node %s", count, volumeID, nodeName)
+		result = count
+		return count, nil
+	}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(gomega.BeNumerically(">=", 0))
+	return result
+}
+
+// execInPodWithNamespace executes a command in a specific pod/container/namespace using
+// the SPDY executor, bypassing the e2e framework's namespace restriction.
+func execInPodWithNamespace(ctx context.Context, f *framework.Framework, namespace, podName, containerName string, cmd []string) (string, string, error) {
+	config, err := framework.LoadConfig()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to load kube config: %w", err)
+	}
+
+	req := f.ClientSet.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", containerName).
+		Param("stdout", "true").
+		Param("stderr", "true")
+	for _, c := range cmd {
+		req = req.Param("command", c)
+	}
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create SPDY executor: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	return stdout.String(), stderr.String(), err
+}
+
+// killCSINodePodOnNode kills only the CSI node pod (s3-csi-node) on the specified node.
+// This simulates a CSI node pod restart which loses the in-memory mount map.
+// The mounter pod (s3-csi-daemonset-mounter) is NOT killed — FUSE mounts stay alive.
+func killCSINodePodOnNode(ctx context.Context, f *framework.Framework, nodeName string) {
+	pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=s3-csi-node",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	framework.ExpectNoError(err)
+	gomega.Expect(len(pods.Items)).To(gomega.BeNumerically(">", 0),
+		"expected at least one CSI node pod on node %s", nodeName)
+
+	for i := range pods.Items {
+		framework.Logf("Killing CSI node pod %s on node %s", pods.Items[i].Name, nodeName)
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, &pods.Items[i]))
+	}
+}
+
+// waitForCSINodePodReady waits for the CSI node pod on the given node to be Running and Ready.
+func waitForCSINodePodReady(ctx context.Context, f *framework.Framework, nodeName string) {
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (bool, error) {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-node",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil {
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == v1.PodRunning && isPodReady(&pod) {
+				framework.Logf("CSI node pod %s is ready on node %s", pod.Name, nodeName)
+				return true, nil
+			}
+		}
+		return false, nil
+	}).WithTimeout(3 * time.Minute).WithPolling(5 * time.Second).Should(gomega.BeTrue())
+}
+
+// isPodReady checks if all containers in a pod have Ready condition.
+func isPodReady(pod *v1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// checkMetaFileExists execs into the CSI node pod and checks if the .meta.json file
+// exists for the given volume ID.
+// Retries on transient exec errors (container restarting, etc.) for up to 1 minute.
+// Only retries when exec fails; if exec succeeds and file is MISSING, that's a real result.
+func checkMetaFileExists(ctx context.Context, f *framework.Framework, nodeName, volumeID string) bool {
+	var result bool
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-node",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			framework.Logf("Failed to find CSI node pod on node %s (retrying): %v", nodeName, err)
+			return "", fmt.Errorf("CSI node pod not found on node %s", nodeName)
+		}
+
+		csiPod := &pods.Items[0]
+		metaPath := fmt.Sprintf("/var/lib/kubelet/plugins/s3.csi.aws.com/mnt/%s.meta.json", volumeID)
+		cmd := fmt.Sprintf("test -f %s && echo EXISTS || echo MISSING", metaPath)
+
+		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, csiPod.Name, "s3-plugin", []string{"/bin/sh", "-c", cmd})
+		if err != nil {
+			framework.Logf("Failed to check meta file (retrying): %v", err)
+			return "", fmt.Errorf("exec failed: %w", err)
+		}
+
+		output := strings.TrimSpace(stdout)
+		framework.Logf("Meta file check for %s on node %s: %s", volumeID, nodeName, output)
+		result = output == "EXISTS"
+		return output, nil
+	}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).ShouldNot(gomega.BeEmpty())
+	return result
+}
+
+// killMounterPodOnNode kills the s3-csi-daemonset-mounter pod on the specified node.
+// This kills all mount-s3 processes, making existing FUSE mounts dead.
+func killMounterPodOnNode(ctx context.Context, f *framework.Framework, nodeName string) {
+	pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=s3-csi-daemonset-mounter",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	framework.ExpectNoError(err)
+	gomega.Expect(len(pods.Items)).To(gomega.BeNumerically(">", 0),
+		"expected at least one mounter pod on node %s", nodeName)
+
+	for i := range pods.Items {
+		framework.Logf("Killing mounter pod %s on node %s", pods.Items[i].Name, nodeName)
+		framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, &pods.Items[i]))
+	}
+}
+
+// waitForMounterPodReady waits for the mounter pod on the given node to be Running and Ready.
+func waitForMounterPodReady(ctx context.Context, f *framework.Framework, nodeName string) {
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (bool, error) {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-daemonset-mounter",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil {
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == v1.PodRunning && isPodReady(&pod) {
+				framework.Logf("Mounter pod %s is ready on node %s", pod.Name, nodeName)
+				return true, nil
+			}
+		}
+		return false, nil
+	}).WithTimeout(3 * time.Minute).WithPolling(5 * time.Second).Should(gomega.BeTrue())
+}
+
+// assertPodIOFails verifies that I/O to the given path inside the pod fails.
+// After a mounter crash, FUSE mounts become dead and any I/O returns an error.
+func assertPodIOFails(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string) {
+	// Try to list files — should fail with "Transport endpoint is not connected" or similar
+	cmd := fmt.Sprintf("ls %s 2>&1 || true", path)
+	stdout, stderr, err := e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, pod.Spec.Containers[0].Name, "/bin/sh", "-c", cmd)
+	framework.Logf("Pod %s I/O check: stdout=%q stderr=%q err=%v", pod.Name, stdout, stderr, err)
+
+	// The command itself should succeed (we use || true) but output should indicate mount failure
+	combinedOutput := stdout + stderr
+	mountFailed := strings.Contains(combinedOutput, "Transport endpoint is not connected") ||
+		strings.Contains(combinedOutput, "No such device") ||
+		strings.Contains(combinedOutput, "Input/output error")
+	gomega.Expect(mountFailed).To(gomega.BeTrue(),
+		"expected I/O failure after mounter crash, got: %s", combinedOutput)
+}
+
+// readMetaFileContent reads the .meta.json file content for a given volume from the CSI node pod.
+// Returns the raw JSON string, or empty string if the file doesn't exist.
+// Retries on transient exec errors for up to 30 seconds.
+func readMetaFileContent(ctx context.Context, f *framework.Framework, nodeName, volumeID string) string {
+	var result string
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-node",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			framework.Logf("Failed to find CSI node pod on node %s (retrying): %v", nodeName, err)
+			return "", fmt.Errorf("CSI node pod not found on node %s", nodeName)
+		}
+
+		csiPod := &pods.Items[0]
+		metaPath := fmt.Sprintf("/var/lib/kubelet/plugins/s3.csi.aws.com/mnt/%s.meta.json", volumeID)
+		cmd := fmt.Sprintf("cat %s 2>/dev/null || echo ''", metaPath)
+
+		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, csiPod.Name, "s3-plugin", []string{"/bin/sh", "-c", cmd})
+		if err != nil {
+			framework.Logf("Failed to read meta file (retrying): %v", err)
+			return "", fmt.Errorf("exec failed: %w", err)
+		}
+
+		result = strings.TrimSpace(stdout)
+		// Return a sentinel so Eventually knows exec succeeded
+		return "exec-ok", nil
+	}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(gomega.Equal("exec-ok"))
+	return result
+}
+
+// checkDeviceIDAtSourcePath checks if the given device ID is the active (topmost) FUSE mount
+// at the source path for the volume. Returns true if the device ID is still serving.
+// Retries on transient exec errors for up to 30 seconds.
+func checkDeviceIDAtSourcePath(ctx context.Context, f *framework.Framework, nodeName, volumeID, deviceID string) bool {
+	var result bool
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-node",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return "", fmt.Errorf("CSI node pod not found on node %s: %v", nodeName, err)
+		}
+
+		csiPod := &pods.Items[0]
+		// Get the topmost (last) mount entry at the source path and check its device ID
+		cmd := fmt.Sprintf("cat /proc/self/mountinfo | grep 's3.csi.aws.com/mnt/%s ' | grep fuse | tail -1 | awk '{print $3}'", volumeID)
+		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, csiPod.Name, "s3-plugin", []string{"/bin/sh", "-c", cmd})
+		if err != nil {
+			framework.Logf("Failed to check device ID at source path (retrying): %v", err)
+			return "", fmt.Errorf("exec failed: %w", err)
+		}
+
+		topDeviceID := strings.TrimSpace(stdout)
+		framework.Logf("Topmost device ID at source path for %s: %s (checking against old: %s)", volumeID, topDeviceID, deviceID)
+		result = topDeviceID == deviceID
+		// Return a non-empty sentinel so Eventually knows exec succeeded
+		return "done", nil
+	}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(gomega.Equal("done"))
+	return result
+}
+
+// getMetaFileMtime returns the modification time of the .meta.json file for the given volume.
+// Uses stat to get the mtime. Returns empty string if file doesn't exist.
+// Retries on transient exec errors for up to 30 seconds.
+func getMetaFileMtime(ctx context.Context, f *framework.Framework, nodeName, volumeID string) string {
+	var result string
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-node",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return "", fmt.Errorf("CSI node pod not found on node %s: %v", nodeName, err)
+		}
+
+		csiPod := &pods.Items[0]
+		metaPath := fmt.Sprintf("/var/lib/kubelet/plugins/s3.csi.aws.com/mnt/%s.meta.json", volumeID)
+		cmd := fmt.Sprintf("stat -c '%%Y' %s 2>/dev/null || echo ''", metaPath)
+
+		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, csiPod.Name, "s3-plugin", []string{"/bin/sh", "-c", cmd})
+		if err != nil {
+			framework.Logf("Failed to get meta file mtime (retrying): %v", err)
+			return "", fmt.Errorf("exec failed: %w", err)
+		}
+		result = strings.TrimSpace(stdout)
+		return result, nil
+	}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).ShouldNot(gomega.BeEmpty())
+	return result
+}
+
+// getFuseSourceDeviceID execs into the CSI node pod and extracts the device ID (major:minor)
+// of the FUSE source mount for the given volume. Returns empty string if not found.
+// Retries on transient exec errors for up to 30 seconds.
+func getFuseSourceDeviceID(ctx context.Context, f *framework.Framework, nodeName, volumeID string) string {
+	var result string
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-node",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return "", fmt.Errorf("CSI node pod not found on node %s: %v", nodeName, err)
+		}
+
+		csiPod := &pods.Items[0]
+		cmd := fmt.Sprintf("cat /proc/self/mountinfo | grep 's3.csi.aws.com/mnt/%s ' | grep fuse | awk '{print $3}' | tail -1", volumeID)
+		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, csiPod.Name, "s3-plugin", []string{"/bin/sh", "-c", cmd})
+		if err != nil {
+			framework.Logf("Failed to get FUSE source device ID (retrying): %v", err)
+			return "", fmt.Errorf("exec failed: %w", err)
+		}
+		result = strings.TrimSpace(stdout)
+		// Return a sentinel so Eventually knows we succeeded even if device ID is empty (no mount)
+		return "exec-ok", nil
+	}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(gomega.Equal("exec-ok"))
+	return result
+}
+
+// dumpMountTable logs mountinfo entries relevant to S3 CSI (source mounts, bind mounts, mountpoint-s3 FUSE).
+// Filters for lines containing s3.csi.aws.com or mountpoint-s3.
+// Retries a few times on transient exec errors since it's useful for debugging, but is non-fatal.
+func dumpMountTable(ctx context.Context, f *framework.Framework, nodeName, label string) {
+	var dumped bool
+	// Short retry — non-critical, best-effort debugging helper.
+	// We don't use Should() here because failure to dump is non-fatal.
+	for attempts := 0; attempts < 5; attempts++ {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-node",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			framework.Logf("[%s] Failed to find CSI node pod on node %s (attempt %d): %v", label, nodeName, attempts+1, err)
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		csiPod := &pods.Items[0]
+		cmd := "cat /proc/self/mountinfo | grep -E 's3\\.csi\\.aws\\.com|mountpoint-s3'"
+		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, csiPod.Name, "s3-plugin",
+			[]string{"/bin/sh", "-c", cmd})
+		if err != nil {
+			framework.Logf("[%s] Failed to dump mount table (attempt %d): %v", label, attempts+1, err)
+			time.Sleep(3 * time.Second)
+			continue
+		}
+		if stdout == "" {
+			framework.Logf("[%s] Mount table on node %s: (no s3/mountpoint entries)", label, nodeName)
+		} else {
+			framework.Logf("[%s] Mount table on node %s:\n%s", label, nodeName, stdout)
+		}
+		dumped = true
+		break
+	}
+	if !dumped {
+		framework.Logf("[%s] Could not dump mount table on node %s after retries (non-fatal)", label, nodeName)
+	}
+}
+
+// checkReadFromPathSucceedEventually retries reading from a path in a pod, tolerating
+// transient errors like "Transport endpoint is not connected" that can occur briefly
+// after a CSI node pod restart while FUSE mounts re-stabilize.
+// Timeout: 30 seconds, polling: 5 seconds.
+func checkReadFromPathSucceedEventually(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
+	sum := sha256.Sum256(genBinDataFromSeed(toWrite, seed))
+	cmd := fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum | grep -Fq %x", path, toWrite, sum)
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) error {
+		return e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(gomega.Succeed())
+}
+
+// checkWriteToPathSucceedEventually retries writing to a path in a pod, tolerating
+// transient errors that can occur briefly after a CSI node pod or mounter pod restart.
+// Timeout: 30 seconds, polling: 5 seconds.
+func checkWriteToPathSucceedEventually(ctx context.Context, f *framework.Framework, pod *v1.Pod, path string, toWrite int, seed int64) {
+	data := genBinDataFromSeed(toWrite, seed)
+	encoded := base64.StdEncoding.EncodeToString(data)
+	cmd := fmt.Sprintf("echo %s | base64 -d | dd conv=fsync of=%s bs=%d count=1", encoded, path, toWrite)
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) error {
+		return e2epod.VerifyExecInPodSucceed(ctx, f, pod, cmd)
+	}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(gomega.Succeed())
+}
+
+// waitForCSINodePodStable waits for the CSI node pod to have been Running continuously
+// for at least 5 seconds. This prevents race conditions where we exec into a pod that
+// just started but hasn't fully initialized (e.g., RebuildMountMap + DiscoverCommDir).
+func waitForCSINodePodStable(ctx context.Context, f *framework.Framework, nodeName string) {
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (bool, error) {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-node",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return false, nil
+		}
+		pod := &pods.Items[0]
+		if pod.Status.Phase != v1.PodRunning || !isPodReady(pod) {
+			return false, nil
+		}
+		// Check that the s3-plugin container has been running for at least 5 seconds
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name == "s3-plugin" {
+				if cs.State.Running == nil {
+					return false, nil
+				}
+				runningFor := time.Since(cs.State.Running.StartedAt.Time)
+				if runningFor < 5*time.Second {
+					framework.Logf("CSI node pod s3-plugin container running for only %v, waiting for stability", runningFor)
+					return false, nil
+				}
+				return true, nil
+			}
+		}
+		return false, nil
+	}).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(gomega.BeTrue())
+	framework.Logf("CSI node pod on node %s is stable (running for >5s)", nodeName)
+}
+
+// countMountpointProcessesForVolume execs into the mounter pod on the given node and counts
+// mount-s3 processes for the specific bucket. Uses /proc/*/cmdline
+// mount-s3's first arg is the bucket name.
+func countMountpointProcessesForVolume(ctx context.Context, f *framework.Framework, nodeName, bucketName string) int {
+	var result int
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (int, error) {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-daemonset-mounter",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return -1, fmt.Errorf("mounter pod not found on node %s", nodeName)
+		}
+
+		mounterPod := &pods.Items[0]
+		// Count mount-s3 processes for this specific bucket using case pattern match (no grep, avoids self-match)
+		cmd := fmt.Sprintf("count=0; for p in /proc/[0-9]*/cmdline; do line=$(cat $p 2>/dev/null | tr '\\0' ' '); case \"$line\" in '/mountpoint-s3/bin/mount-s3 %s '*) count=$((count+1));; esac; done; echo $count", bucketName)
+		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, mounterPod.Name, "mounter", []string{"/bin/sh", "-c", cmd})
+		if err != nil {
+			return -1, fmt.Errorf("exec failed: %w", err)
+		}
+
+		count := 0
+		fmt.Sscanf(strings.TrimSpace(stdout), "%d", &count)
+		framework.Logf("mount-s3 process count for bucket %s on node %s: %d", bucketName, nodeName, count)
+		result = count
+		return count, nil
+	}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(gomega.BeNumerically(">=", 0))
+	return result
+}
+
+// dumpMountpointProcesses logs all mount-s3 processes running in the mounter pod on the given node.
+// This is a debugging helper — non-fatal on failure.
+func dumpMountpointProcesses(ctx context.Context, f *framework.Framework, nodeName, label string) {
+	pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=s3-csi-daemonset-mounter",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil || len(pods.Items) == 0 {
+		framework.Logf("[%s] Failed to find mounter pod on node %s: %v", label, nodeName, err)
+		return
+	}
+
+	mounterPod := &pods.Items[0]
+	cmd := "for p in /proc/[0-9]*/cmdline; do printf '%s: ' $p; cat $p | tr '\\0' ' '; echo; done 2>/dev/null || true"
+	stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, mounterPod.Name, "mounter", []string{"/bin/sh", "-c", cmd})
+	if err != nil {
+		framework.Logf("[%s] Failed to list mount-s3 processes (non-fatal): %v", label, err)
+		return
+	}
+	if stdout == "" {
+		framework.Logf("[%s] mount-s3 processes on node %s: (none)", label, nodeName)
+	} else {
+		framework.Logf("[%s] mount-s3 processes on node %s:\n%s", label, nodeName, stdout)
+	}
+}

--- a/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
@@ -99,8 +99,8 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			toWrite := 1024
 			path := "/mnt/volume1/after-pod1-delete.txt"
 			seed := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, pods[1], path, toWrite, seed)
-			checkReadFromPathSucceed(ctx, f, pods[1], path, toWrite, seed)
+			checkWriteToPathSucceedEventually(ctx, f, pods[1], path, toWrite, seed)
+			checkReadFromPathSucceedEventually(ctx, f, pods[1], path, toWrite, seed)
 		})
 
 		ginkgo.It("should use only a single mount-s3 process for pods sharing the same PV", func(ctx context.Context) {
@@ -137,7 +137,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, pod1) }()
 
 			// Verify first pod works
-			checkWriteToPathSucceed(ctx, f, pod1, "/mnt/volume1/from-pod1.txt", 512, time.Now().UTC().UnixNano())
+			checkWriteToPathSucceedEventually(ctx, f, pod1, "/mnt/volume1/from-pod1.txt", 512, time.Now().UTC().UnixNano())
 
 			// Second pod with different fsGroup 2000 — should fail to mount
 			ginkgo.By("Creating second pod with fsGroup 2000 on the same node (should fail)")
@@ -165,7 +165,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			targetNode := pod1.Spec.NodeName
 
 			// Verify first pod works
-			checkWriteToPathSucceed(ctx, f, pod1, "/mnt/volume1/from-fsgroup-1000.txt", 512, time.Now().UTC().UnixNano())
+			checkWriteToPathSucceedEventually(ctx, f, pod1, "/mnt/volume1/from-fsgroup-1000.txt", 512, time.Now().UTC().UnixNano())
 
 			// Delete the first pod — entry should reset
 			ginkgo.By("Deleting first pod to release the mount")
@@ -181,7 +181,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 
 			// Verify the new pod can read/write
 			ginkgo.By("Verifying second pod with different fsGroup can read and write")
-			checkWriteToPathSucceed(ctx, f, pod2, "/mnt/volume1/from-fsgroup-2000.txt", 512, time.Now().UTC().UnixNano())
+			checkWriteToPathSucceedEventually(ctx, f, pod2, "/mnt/volume1/from-fsgroup-2000.txt", 512, time.Now().UTC().UnixNano())
 		})
 
 		ginkgo.It("should allow pods with different service accounts to share mount with driver auth", func(ctx context.Context) {
@@ -208,7 +208,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, pod1) }()
 
 			// Verify first pod works
-			checkWriteToPathSucceed(ctx, f, pod1, "/mnt/volume1/from-sa-default.txt", 512, time.Now().UTC().UnixNano())
+			checkWriteToPathSucceedEventually(ctx, f, pod1, "/mnt/volume1/from-sa-default.txt", 512, time.Now().UTC().UnixNano())
 
 			// Second pod with different SA — should succeed because driver auth doesn't enforce SA match
 			ginkgo.By("Creating second pod with different service account on the same node (should succeed with driver auth)")
@@ -221,8 +221,8 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			// Both pods should be able to read/write
 			ginkgo.By("Verifying both pods can read and write to shared volume")
 			seed := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, pod2, "/mnt/volume1/from-sa-different.txt", 512, seed)
-			checkReadFromPathSucceed(ctx, f, pod1, "/mnt/volume1/from-sa-different.txt", 512, seed)
+			checkWriteToPathSucceedEventually(ctx, f, pod2, "/mnt/volume1/from-sa-different.txt", 512, seed)
+			checkReadFromPathSucceedEventually(ctx, f, pod1, "/mnt/volume1/from-sa-different.txt", 512, seed)
 		})
 
 		ginkgo.It("should handle concurrent pod creation on the same node sharing same volume", func(ctx context.Context) {
@@ -279,11 +279,11 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			toWrite := 1024
 			sharedFile := "/mnt/volume1/concurrent-shared.txt"
 			seed := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, pod1, sharedFile, toWrite, seed)
+			checkWriteToPathSucceedEventually(ctx, f, pod1, sharedFile, toWrite, seed)
 
 			for i, pod := range concPods {
 				ginkgo.By(fmt.Sprintf("Verifying concurrent pod %d can read shared file", i))
-				checkReadFromPathSucceed(ctx, f, pod, sharedFile, toWrite, seed)
+				checkReadFromPathSucceedEventually(ctx, f, pod, sharedFile, toWrite, seed)
 			}
 		})
 
@@ -299,7 +299,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			toWrite := 1024
 			sharedFile := "/mnt/volume1/churn-test.txt"
 			seed := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+			checkWriteToPathSucceedEventually(ctx, f, pods[0], sharedFile, toWrite, seed)
 
 			// Delete pod 0 and pod 1 while simultaneously creating 2 new pods
 			ginkgo.By("Concurrently deleting 2 pods and creating 2 new pods")
@@ -353,12 +353,12 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 
 			// pod 2 (never deleted) should still have access
 			ginkgo.By("Verifying surviving pod still has access")
-			checkReadFromPathSucceed(ctx, f, pods[2], sharedFile, toWrite, seed)
+			checkReadFromPathSucceedEventually(ctx, f, pods[2], sharedFile, toWrite, seed)
 
 			// New pods should also have access
 			for i, pod := range newPods {
 				ginkgo.By(fmt.Sprintf("Verifying new pod %d can read shared file", i))
-				checkReadFromPathSucceed(ctx, f, pod, sharedFile, toWrite, seed)
+				checkReadFromPathSucceedEventually(ctx, f, pod, sharedFile, toWrite, seed)
 			}
 
 			// Clean up pod 2
@@ -390,7 +390,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 				// Write a unique file
 				path := fmt.Sprintf("/mnt/volume1/churn-%d.txt", i)
 				seed := time.Now().UTC().UnixNano() + int64(i)
-				checkWriteToPathSucceed(ctx, f, pod, path, 512, seed)
+				checkWriteToPathSucceedEventually(ctx, f, pod, path, 512, seed)
 
 				ginkgo.By(fmt.Sprintf("Churn iteration %d: deleting pod", i+1))
 				framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
@@ -430,7 +430,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 					defer ginkgo.GinkgoRecover()
 					defer wg.Done()
 					path := fmt.Sprintf("/mnt/volume1/pod%d-file.txt", idx)
-					checkWriteToPathSucceed(ctx, f, pods[idx], path, toWrite, seeds[idx])
+					checkWriteToPathSucceedEventually(ctx, f, pods[idx], path, toWrite, seeds[idx])
 				}(i)
 			}
 			wg.Wait()
@@ -440,7 +440,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			for reader := range podCount {
 				for writer := range podCount {
 					path := fmt.Sprintf("/mnt/volume1/pod%d-file.txt", writer)
-					checkReadFromPathSucceed(ctx, f, pods[reader], path, toWrite, seeds[writer])
+					checkReadFromPathSucceedEventually(ctx, f, pods[reader], path, toWrite, seeds[writer])
 				}
 			}
 		})
@@ -456,7 +456,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			toWrite := 1024
 			sharedFile := "/mnt/volume1/reverse-delete.txt"
 			seed := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+			checkWriteToPathSucceedEventually(ctx, f, pods[0], sharedFile, toWrite, seed)
 
 			// Delete pods in reverse order (last created first), verifying remaining pods still work
 			for i := podCount - 1; i > 0; i-- {
@@ -465,7 +465,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 
 				// Verify pod 0 (first pod) still has access
 				ginkgo.By(fmt.Sprintf("Verifying pod 0 still has access after deleting pod %d", i))
-				checkReadFromPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+				checkReadFromPathSucceedEventually(ctx, f, pods[0], sharedFile, toWrite, seed)
 			}
 
 			// Finally delete pod 0
@@ -482,8 +482,8 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			toWrite := 1024
 			file1 := "/mnt/volume1/gen1-file.txt"
 			seed1 := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, pods[0], file1, toWrite, seed1)
-			checkReadFromPathSucceed(ctx, f, pods[1], file1, toWrite, seed1)
+			checkWriteToPathSucceedEventually(ctx, f, pods[0], file1, toWrite, seed1)
+			checkReadFromPathSucceedEventually(ctx, f, pods[1], file1, toWrite, seed1)
 
 			ginkgo.By("Deleting all first-generation pods")
 			for _, pod := range pods {
@@ -505,14 +505,14 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			ginkgo.By("Verifying second-generation pods can read first-generation data")
 			for i, pod := range gen2Pods {
 				ginkgo.By(fmt.Sprintf("Gen2 pod %d reading gen1 file", i))
-				checkReadFromPathSucceed(ctx, f, pod, file1, toWrite, seed1)
+				checkReadFromPathSucceedEventually(ctx, f, pod, file1, toWrite, seed1)
 			}
 
 			// Gen2 pods should share with each other
 			file2 := "/mnt/volume1/gen2-file.txt"
 			seed2 := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, gen2Pods[0], file2, toWrite, seed2)
-			checkReadFromPathSucceed(ctx, f, gen2Pods[1], file2, toWrite, seed2)
+			checkWriteToPathSucceedEventually(ctx, f, gen2Pods[0], file2, toWrite, seed2)
+			checkReadFromPathSucceedEventually(ctx, f, gen2Pods[1], file2, toWrite, seed2)
 		})
 
 		ginkgo.It("should recover mount map after CSI node pod restart and existing pods keep working", func(ctx context.Context) {
@@ -527,8 +527,8 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			toWrite := 1024
 			sharedFile := "/mnt/volume1/pre-restart.txt"
 			seed := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
-			checkReadFromPathSucceed(ctx, f, pods[1], sharedFile, toWrite, seed)
+			checkWriteToPathSucceedEventually(ctx, f, pods[0], sharedFile, toWrite, seed)
+			checkReadFromPathSucceedEventually(ctx, f, pods[1], sharedFile, toWrite, seed)
 
 			// Kill the CSI node pod on this node (only the node pod, not the mounter)
 			ginkgo.By(fmt.Sprintf("Killing CSI node pod on node %s to lose in-memory mount map", targetNode))
@@ -564,7 +564,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			toWrite := 1024
 			sharedFile := "/mnt/volume1/before-restart.txt"
 			seed := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+			checkWriteToPathSucceedEventually(ctx, f, pods[0], sharedFile, toWrite, seed)
 
 			// Kill CSI node pod
 			ginkgo.By(fmt.Sprintf("Killing CSI node pod on node %s", targetNode))
@@ -582,7 +582,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 
 			// New pod should read data written before the restart
 			ginkgo.By("Verifying new pod can read data written before CSI node restart")
-			checkReadFromPathSucceed(ctx, f, pod2, sharedFile, toWrite, seed)
+			checkReadFromPathSucceedEventually(ctx, f, pod2, sharedFile, toWrite, seed)
 
 			// Verify still only 1 FUSE mount (sharing, not a new one)
 			ginkgo.By("Verifying only one FUSE source mount exists (mount was shared, not duplicated)")
@@ -602,7 +602,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			toWrite := 1024
 			sharedFile := "/mnt/volume1/refcount-test.txt"
 			seed := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
+			checkWriteToPathSucceedEventually(ctx, f, pods[0], sharedFile, toWrite, seed)
 
 			// Kill CSI node pod — refcount lost from memory
 			ginkgo.By(fmt.Sprintf("Killing CSI node pod on node %s", targetNode))
@@ -715,8 +715,8 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			toWrite := 1024
 			sharedFile := "/mnt/volume1/pre-crash-shared.txt"
 			seed := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, pods[0], sharedFile, toWrite, seed)
-			checkReadFromPathSucceed(ctx, f, pods[1], sharedFile, toWrite, seed)
+			checkWriteToPathSucceedEventually(ctx, f, pods[0], sharedFile, toWrite, seed)
+			checkReadFromPathSucceedEventually(ctx, f, pods[1], sharedFile, toWrite, seed)
 
 			pvName := resource.Pv.Name
 
@@ -767,21 +767,21 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			for i, pod := range newPods {
 				writeFile := fmt.Sprintf("/mnt/volume1/new-pod-%d.txt", i)
 				writeSeed := time.Now().UTC().UnixNano() + int64(i)
-				checkWriteToPathSucceed(ctx, f, pod, writeFile, toWrite, writeSeed)
-				checkReadFromPathSucceed(ctx, f, pod, writeFile, toWrite, writeSeed)
+				checkWriteToPathSucceedEventually(ctx, f, pod, writeFile, toWrite, writeSeed)
+				checkReadFromPathSucceedEventually(ctx, f, pod, writeFile, toWrite, writeSeed)
 			}
 
 			// Cross-pod sharing should work: pod 0 writes, pod 1 and pod 2 read
 			ginkgo.By("Verifying cross-pod sharing works among new pods")
 			crossFile := "/mnt/volume1/cross-pod-after-crash.txt"
 			crossSeed := time.Now().UTC().UnixNano()
-			checkWriteToPathSucceed(ctx, f, newPods[0], crossFile, toWrite, crossSeed)
-			checkReadFromPathSucceed(ctx, f, newPods[1], crossFile, toWrite, crossSeed)
-			checkReadFromPathSucceed(ctx, f, newPods[2], crossFile, toWrite, crossSeed)
+			checkWriteToPathSucceedEventually(ctx, f, newPods[0], crossFile, toWrite, crossSeed)
+			checkReadFromPathSucceedEventually(ctx, f, newPods[1], crossFile, toWrite, crossSeed)
+			checkReadFromPathSucceedEventually(ctx, f, newPods[2], crossFile, toWrite, crossSeed)
 
 			// Old data written before crash (persisted in S3) should be readable
 			ginkgo.By("Verifying new pods can read data written before mounter crash")
-			checkReadFromPathSucceed(ctx, f, newPods[0], sharedFile, toWrite, seed)
+			checkReadFromPathSucceedEventually(ctx, f, newPods[0], sharedFile, toWrite, seed)
 
 			// Verify only 1 FUSE source mount exists (all 3 pods share the same source)
 			ginkgo.By("Verifying only one FUSE source mount exists for all new pods")
@@ -856,14 +856,14 @@ func checkCrossReadWriteDaemonset(ctx context.Context, f *framework.Framework, p
 	// Pod1 writes, pod2 reads
 	file1 := filepath.Join(basePath, "ds-cross-file1.txt")
 	seed1 := time.Now().UTC().UnixNano()
-	checkWriteToPathSucceed(ctx, f, pod1, file1, toWrite, seed1)
-	checkReadFromPathSucceed(ctx, f, pod2, file1, toWrite, seed1)
+	checkWriteToPathSucceedEventually(ctx, f, pod1, file1, toWrite, seed1)
+	checkReadFromPathSucceedEventually(ctx, f, pod2, file1, toWrite, seed1)
 
 	// Pod2 writes, pod1 reads
 	file2 := filepath.Join(basePath, "ds-cross-file2.txt")
 	seed2 := time.Now().UTC().UnixNano()
-	checkWriteToPathSucceed(ctx, f, pod2, file2, toWrite, seed2)
-	checkReadFromPathSucceed(ctx, f, pod1, file2, toWrite, seed2)
+	checkWriteToPathSucceedEventually(ctx, f, pod2, file2, toWrite, seed2)
+	checkReadFromPathSucceedEventually(ctx, f, pod1, file2, toWrite, seed2)
 }
 
 // verifyCSINodeLogs checks the CSI node pod logs for expected sharing messages.
@@ -1406,7 +1406,7 @@ func dumpMountpointProcesses(ctx context.Context, f *framework.Framework, nodeNa
 
 // checkCredentialDirExists checks if the per-mount credential directory exists in the mounter pod's comm volume.
 // The credential directory lives at <commDir>/<volumeID>/ inside the mounter pod.
-// Retries on transient exec errors for up to 1 minute.
+// Retries on transient exec errors and MISSING results for up to 1 minute.
 func checkCredentialDirExists(ctx context.Context, f *framework.Framework, nodeName, volumeID string) bool {
 	var result bool
 	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
@@ -1433,8 +1433,11 @@ func checkCredentialDirExists(ctx context.Context, f *framework.Framework, nodeN
 
 		output := strings.TrimSpace(stdout)
 		framework.Logf("Credential dir check for %s on node %s: %s", volumeID, nodeName, output)
-		result = output == "EXISTS"
+		if output != "EXISTS" {
+			return output, fmt.Errorf("credential dir not yet present (got %s)", output)
+		}
+		result = true
 		return output, nil
-	}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).ShouldNot(gomega.BeEmpty())
+	}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Equal("EXISTS"))
 	return result
 }

--- a/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
@@ -184,6 +184,47 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			checkWriteToPathSucceed(ctx, f, pod2, "/mnt/volume1/from-fsgroup-2000.txt", 512, time.Now().UTC().UnixNano())
 		})
 
+		ginkgo.It("should allow pods with different service accounts to share mount with driver auth", func(ctx context.Context) {
+			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, resource)
+
+			// Create a second service account in the namespace
+			ginkgo.By("Creating a second service account")
+			sa2 := &v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "s3-e2e-sa-different",
+					Namespace: f.Namespace.Name,
+				},
+			}
+			sa2, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Create(ctx, sa2, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+
+			// First pod with default SA
+			ginkgo.By("Creating first pod with default service account")
+			pod1 := e2epod.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			pod1, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod1)
+			framework.ExpectNoError(err)
+			targetNode := pod1.Spec.NodeName
+			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, pod1) }()
+
+			// Verify first pod works
+			checkWriteToPathSucceed(ctx, f, pod1, "/mnt/volume1/from-sa-default.txt", 512, time.Now().UTC().UnixNano())
+
+			// Second pod with different SA — should succeed because driver auth doesn't enforce SA match
+			ginkgo.By("Creating second pod with different service account on the same node (should succeed with driver auth)")
+			pod2 := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+			pod2.Spec.ServiceAccountName = sa2.Name
+			pod2, err = createPod(ctx, f.ClientSet, f.Namespace.Name, pod2)
+			framework.ExpectNoError(err)
+			defer func() { e2epod.DeletePodWithWait(ctx, f.ClientSet, pod2) }()
+
+			// Both pods should be able to read/write
+			ginkgo.By("Verifying both pods can read and write to shared volume")
+			seed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceed(ctx, f, pod2, "/mnt/volume1/from-sa-different.txt", 512, seed)
+			checkReadFromPathSucceed(ctx, f, pod1, "/mnt/volume1/from-sa-different.txt", 512, seed)
+		})
+
 		ginkgo.It("should handle concurrent pod creation on the same node sharing same volume", func(ctx context.Context) {
 			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
 			l.resources = append(l.resources, resource)
@@ -597,7 +638,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 				"expected .meta.json file to exist for volume %s", pvName)
 		})
 
-		ginkgo.It("should clean up meta file and source mount after last consumer unmounts", func(ctx context.Context) {
+		ginkgo.It("should clean up meta file, credentials, and source mount after last consumer unmounts", func(ctx context.Context) {
 			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
 			l.resources = append(l.resources, resource)
 
@@ -609,6 +650,12 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			ginkgo.By("Verifying meta file exists while pod is mounted")
 			metaExists := checkMetaFileExists(ctx, f, targetNode, pvName)
 			gomega.Expect(metaExists).To(gomega.BeTrue())
+
+			// Credential directory should exist while pod is mounted
+			ginkgo.By("Verifying credential directory exists in mounter pod while pod is mounted")
+			credDirExists := checkCredentialDirExists(ctx, f, targetNode, pvName)
+			gomega.Expect(credDirExists).To(gomega.BeTrue(),
+				"expected credential directory for volume %s to exist while pod is mounted", pvName)
 
 			// FUSE source should exist in mount table
 			ginkgo.By("Verifying FUSE source mount exists while pod is mounted")
@@ -649,6 +696,12 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 				count := countMountpointProcessesForVolume(ctx, f, targetNode, bucketName)
 				return count, nil
 			}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(gomega.Equal(0))
+
+			// Verify credential directory is cleaned up from mounter pod's comm volume
+			ginkgo.By("Verifying credential directory is removed from mounter pod after last consumer unmounts")
+			credDirExists = checkCredentialDirExists(ctx, f, targetNode, pvName)
+			gomega.Expect(credDirExists).To(gomega.BeFalse(),
+				"expected credential directory for volume %s to be removed after last consumer unmounts", pvName)
 		})
 
 		ginkgo.It("should recover from mounter pod crash with fresh source mount for new pods", func(ctx context.Context) {
@@ -1349,4 +1402,39 @@ func dumpMountpointProcesses(ctx context.Context, f *framework.Framework, nodeNa
 	} else {
 		framework.Logf("[%s] mount-s3 processes on node %s:\n%s", label, nodeName, stdout)
 	}
+}
+
+// checkCredentialDirExists checks if the per-mount credential directory exists in the mounter pod's comm volume.
+// The credential directory lives at <commDir>/<volumeID>/ inside the mounter pod.
+// Retries on transient exec errors for up to 1 minute.
+func checkCredentialDirExists(ctx context.Context, f *framework.Framework, nodeName, volumeID string) bool {
+	var result bool
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=s3-csi-daemonset-mounter",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			framework.Logf("Failed to find mounter pod on node %s (retrying): %v", nodeName, err)
+			return "", fmt.Errorf("mounter pod not found on node %s", nodeName)
+		}
+
+		mounterPod := &pods.Items[0]
+		// The comm volume is mounted at /comm in the mounter container.
+		// Credential directory is /comm/<volumeID>/
+		credDir := fmt.Sprintf("/comm/%s", volumeID)
+		cmd := fmt.Sprintf("test -d %s && echo EXISTS || echo MISSING", credDir)
+
+		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, mounterPod.Name, "mounter", []string{"/bin/sh", "-c", cmd})
+		if err != nil {
+			framework.Logf("Failed to check credential dir (retrying): %v", err)
+			return "", fmt.Errorf("exec failed: %w", err)
+		}
+
+		output := strings.TrimSpace(stdout)
+		framework.Logf("Credential dir check for %s on node %s: %s", volumeID, nodeName, output)
+		result = output == "EXISTS"
+		return output, nil
+	}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).ShouldNot(gomega.BeEmpty())
+	return result
 }

--- a/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
@@ -810,6 +810,52 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			gomega.Expect(metaMtimeAfter).ToNot(gomega.Equal(metaMtimeBefore),
 				"meta file mtime should change after fresh mount overwrites it")
 		})
+		ginkgo.It("should recover from mounter pod crash with fresh source mount for new pods with different params", func(ctx context.Context) {
+			// Create PV with --read-only mount option
+			readOnlyResource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, []string{"--read-only"})
+			l.resources = append(l.resources, readOnlyResource)
+
+			// Mount pod 1 with read-only params
+			ginkgo.By("Creating pod 1 with read-only mount")
+			targetNode, pods := createPodsOnSameNode(ctx, f, 1, readOnlyResource)
+			defer deletePodsInOrder(ctx, f, pods)
+
+			// Verify pod 1 can read but not write (read-only mount)
+			ginkgo.By("Verifying pod 1 has a working read-only mount (read succeeds, write fails)")
+			toWrite := 1024
+			seed := time.Now().UTC().UnixNano()
+			checkListingPathSucceed(ctx, f, pods[0], "/mnt/volume1/")
+			checkWriteToPathFails(ctx, f, pods[0], "/mnt/volume1/should-fail.txt", toWrite, seed)
+
+			// Kill mounter pod
+			ginkgo.By(fmt.Sprintf("Killing mounter pod on node %s", targetNode))
+			killMounterPodOnNode(ctx, f, targetNode)
+			waitForMounterPodReady(ctx, f, targetNode)
+			time.Sleep(15 * time.Second)
+
+			// Verify pod 1 now has transport errors (dead FUSE mount)
+			ginkgo.By("Verifying pod 1 has transport errors after mounter crash")
+			assertPodIOFails(ctx, f, pods[0], "/mnt/volume1/")
+
+			// Create a new PV/PVC without --read-only for the new pod (same bucket, different params)
+			ginkgo.By("Creating new volume resource without --read-only for new pod")
+			writableResource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+			l.resources = append(l.resources, writableResource)
+
+			// Create pod 2 on the same node with writable PV
+			ginkgo.By("Creating pod 2 with writable mount on same node after mounter crash")
+			pod2 := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": targetNode}, []*v1.PersistentVolumeClaim{writableResource.Pvc}, admissionapi.LevelBaseline, "")
+			pod2, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod2)
+			framework.ExpectNoError(err, "failed to create pod 2 with writable mount")
+			defer e2epod.DeletePodWithWait(ctx, f.ClientSet, pod2)
+
+			// Pod 2 should be able to write (proves fresh mount with new params, not stale read-only)
+			ginkgo.By("Verifying pod 2 can write (fresh mount without --read-only)")
+			writeFile := "/mnt/volume1/after-crash-writable.txt"
+			writeSeed := time.Now().UTC().UnixNano()
+			checkWriteToPathSucceedEventually(ctx, f, pod2, writeFile, toWrite, writeSeed)
+			checkReadFromPathSucceedEventually(ctx, f, pod2, writeFile, toWrite, writeSeed)
+		})
 	})
 }
 

--- a/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
@@ -653,6 +653,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 
 			// Credential directory should exist while pod is mounted
 			ginkgo.By("Verifying credential directory exists in mounter pod while pod is mounted")
+			listCommDirContents(ctx, f, targetNode, pvName)
 			credDirExists := checkCredentialDirExists(ctx, f, targetNode, pvName)
 			gomega.Expect(credDirExists).To(gomega.BeTrue(),
 				"expected credential directory for volume %s to exist while pod is mounted", pvName)
@@ -699,9 +700,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 
 			// Verify credential directory is cleaned up from mounter pod's comm volume
 			ginkgo.By("Verifying credential directory is removed from mounter pod after last consumer unmounts")
-			credDirExists = checkCredentialDirExists(ctx, f, targetNode, pvName)
-			gomega.Expect(credDirExists).To(gomega.BeFalse(),
-				"expected credential directory for volume %s to be removed after last consumer unmounts", pvName)
+			checkCredentialDirRemoved(ctx, f, targetNode, pvName)
 		})
 
 		ginkgo.It("should recover from mounter pod crash with fresh source mount for new pods", func(ctx context.Context) {
@@ -1404,40 +1403,82 @@ func dumpMountpointProcesses(ctx context.Context, f *framework.Framework, nodeNa
 	}
 }
 
-// checkCredentialDirExists checks if the per-mount credential directory exists in the mounter pod's comm volume.
-// The credential directory lives at <commDir>/<volumeID>/ inside the mounter pod.
-// Retries on transient exec errors and MISSING results for up to 1 minute.
+// listCommDirContents dumps the contents of /comm/ inside the mounter pod for debugging.
+func listCommDirContents(ctx context.Context, f *framework.Framework, nodeName, volumeID string) {
+	pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=s3-csi-daemonset-mounter",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil || len(pods.Items) == 0 {
+		framework.Logf("DEBUG: Could not find mounter pod for listing: %v", err)
+		return
+	}
+	cmd := fmt.Sprintf("echo '--- /comm/ top-level ---'; ls -la /comm/ 2>&1; echo '--- /comm/%s/ ---'; ls -la /comm/%s/ 2>&1 || true", volumeID, volumeID)
+	stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, pods.Items[0].Name, "mounter", []string{"/bin/sh", "-c", cmd})
+	if err != nil {
+		framework.Logf("DEBUG: listing /comm/ failed: %v", err)
+		return
+	}
+	framework.Logf("DEBUG /comm/ contents on node %s (looking for %s):\n%s", nodeName, volumeID, stdout)
+}
+
+// queryCredentialDirStatus execs into the mounter pod and returns "EXISTS" or "MISSING" for the credential directory.
+// Returns an error if the exec fails or the mounter pod is not found.
+func queryCredentialDirStatus(ctx context.Context, f *framework.Framework, nodeName, volumeID string) (string, error) {
+	pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=s3-csi-daemonset-mounter",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil || len(pods.Items) == 0 {
+		return "", fmt.Errorf("mounter pod not found on node %s: %v", nodeName, err)
+	}
+
+	mounterPod := &pods.Items[0]
+	credDir := fmt.Sprintf("/comm/%s", volumeID)
+	cmd := fmt.Sprintf("test -d %s && echo EXISTS || echo MISSING", credDir)
+
+	stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, mounterPod.Name, "mounter", []string{"/bin/sh", "-c", cmd})
+	if err != nil {
+		return "", fmt.Errorf("exec failed: %w", err)
+	}
+
+	output := strings.TrimSpace(stdout)
+	framework.Logf("Credential dir check for %s on node %s: %s", volumeID, nodeName, output)
+	return output, nil
+}
+
+// checkCredentialDirExists polls until the credential directory EXISTS in the mounter pod (up to 1 minute).
 func checkCredentialDirExists(ctx context.Context, f *framework.Framework, nodeName, volumeID string) bool {
 	var result bool
 	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
-		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
-			LabelSelector: "app=s3-csi-daemonset-mounter",
-			FieldSelector: "spec.nodeName=" + nodeName,
-		})
-		if err != nil || len(pods.Items) == 0 {
-			framework.Logf("Failed to find mounter pod on node %s (retrying): %v", nodeName, err)
-			return "", fmt.Errorf("mounter pod not found on node %s", nodeName)
-		}
-
-		mounterPod := &pods.Items[0]
-		// The comm volume is mounted at /comm in the mounter container.
-		// Credential directory is /comm/<volumeID>/
-		credDir := fmt.Sprintf("/comm/%s", volumeID)
-		cmd := fmt.Sprintf("test -d %s && echo EXISTS || echo MISSING", credDir)
-
-		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, mounterPod.Name, "mounter", []string{"/bin/sh", "-c", cmd})
+		status, err := queryCredentialDirStatus(ctx, f, nodeName, volumeID)
 		if err != nil {
 			framework.Logf("Failed to check credential dir (retrying): %v", err)
-			return "", fmt.Errorf("exec failed: %w", err)
+			return "", err
 		}
-
-		output := strings.TrimSpace(stdout)
-		framework.Logf("Credential dir check for %s on node %s: %s", volumeID, nodeName, output)
-		if output != "EXISTS" {
-			return output, fmt.Errorf("credential dir not yet present (got %s)", output)
+		if status != "EXISTS" {
+			return status, fmt.Errorf("credential dir not yet present (got %s)", status)
 		}
 		result = true
-		return output, nil
+		return status, nil
 	}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Equal("EXISTS"))
+	return result
+}
+
+// checkCredentialDirRemoved polls until the credential directory is MISSING from the mounter pod (up to 1 minute).
+func checkCredentialDirRemoved(ctx context.Context, f *framework.Framework, nodeName, volumeID string) bool {
+	var result bool
+	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+		status, err := queryCredentialDirStatus(ctx, f, nodeName, volumeID)
+		if err != nil {
+			framework.Logf("Failed to check credential dir removal (retrying): %v", err)
+			return "", err
+		}
+		if status != "MISSING" {
+			return status, fmt.Errorf("credential dir still present (got %s)", status)
+		}
+		result = true
+		return status, nil
+	}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Equal("MISSING"))
 	return result
 }

--- a/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
@@ -1058,7 +1058,7 @@ func checkMetaFileExists(ctx context.Context, f *framework.Framework, nodeName, 
 		}
 
 		csiPod := &pods.Items[0]
-		metaPath := fmt.Sprintf("/var/lib/kubelet/plugins/s3.csi.aws.com/mnt/%s.meta.json", volumeID)
+		metaPath := fmt.Sprintf("/var/lib/kubelet/plugins/s3.csi.aws.com/meta/%s.meta.json", volumeID)
 		cmd := fmt.Sprintf("test -f %s && echo EXISTS || echo MISSING", metaPath)
 
 		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, csiPod.Name, "s3-plugin", []string{"/bin/sh", "-c", cmd})
@@ -1145,7 +1145,7 @@ func readMetaFileContent(ctx context.Context, f *framework.Framework, nodeName, 
 		}
 
 		csiPod := &pods.Items[0]
-		metaPath := fmt.Sprintf("/var/lib/kubelet/plugins/s3.csi.aws.com/mnt/%s.meta.json", volumeID)
+		metaPath := fmt.Sprintf("/var/lib/kubelet/plugins/s3.csi.aws.com/meta/%s.meta.json", volumeID)
 		cmd := fmt.Sprintf("cat %s 2>/dev/null || echo ''", metaPath)
 
 		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, csiPod.Name, "s3-plugin", []string{"/bin/sh", "-c", cmd})
@@ -1208,7 +1208,7 @@ func getMetaFileMtime(ctx context.Context, f *framework.Framework, nodeName, vol
 		}
 
 		csiPod := &pods.Items[0]
-		metaPath := fmt.Sprintf("/var/lib/kubelet/plugins/s3.csi.aws.com/mnt/%s.meta.json", volumeID)
+		metaPath := fmt.Sprintf("/var/lib/kubelet/plugins/s3.csi.aws.com/meta/%s.meta.json", volumeID)
 		cmd := fmt.Sprintf("stat -c '%%Y' %s 2>/dev/null || echo ''", metaPath)
 
 		stdout, _, err := execInPodWithNamespace(ctx, f, csiDriverDaemonSetNamespace, csiPod.Name, "s3-plugin", []string{"/bin/sh", "-c", cmd})

--- a/tests/e2e-kubernetes/testsuites/util.go
+++ b/tests/e2e-kubernetes/testsuites/util.go
@@ -383,3 +383,9 @@ func findMountpointPods(ctx context.Context, cs clientset.Interface, volumeName 
 
 	return matchingPods, nil
 }
+
+// isDaemonsetMounterMode returns true if the MOUNTER_MODE environment variable is set to "daemonset",
+// indicating the driver is deployed in daemonset architecture mode.
+func isDaemonsetMounterMode(_ context.Context, _ *framework.Framework) bool {
+	return os.Getenv("MOUNTER_MODE") == "daemonset"
+}

--- a/tests/e2e-kubernetes/testsuites/util.go
+++ b/tests/e2e-kubernetes/testsuites/util.go
@@ -384,8 +384,14 @@ func findMountpointPods(ctx context.Context, cs clientset.Interface, volumeName 
 	return matchingPods, nil
 }
 
-// isDaemonsetMounterMode returns true if the MOUNTER_MODE environment variable is set to "daemonset",
+// isDaemonsetMounterMode returns true if the cluster has daemonset mounter pods running,
 // indicating the driver is deployed in daemonset architecture mode.
-func isDaemonsetMounterMode(_ context.Context, _ *framework.Framework) bool {
-	return os.Getenv("MOUNTER_MODE") == "daemonset"
+func isDaemonsetMounterMode(ctx context.Context, f *framework.Framework) bool {
+	pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=s3-csi-daemonset-mounter",
+	})
+	if err != nil {
+		return false
+	}
+	return len(pods.Items) > 0
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Multiple pods on the same node using the same PV now share a single mount-s3 FUSE process via bind mounts instead of each getting a separate one
2 First pod triggers a FUSE mount at a stable source path (/var/lib/kubelet/plugins/s3.csi.aws.com/mnt/<volumeID>), subsequent pods get bind mounts from that source
3. Reference-counted MountMap (lock-free sync.Map with per-volume mutex) tracks active consumers; last unmount tears down the FUSE source
4. Sharing is validated: pods must have matching mount options, auth source, service account, EKS role ARN, namespace, and fsGroup — mismatches are rejected
5. .meta.json files persisted alongside source mounts enable state recovery after CSI node pod restart via RebuildMountMap() (scans meta files + /proc/self/mountinfo to reconstruct refcounts)
6. After mounter pod crash: existing pods have dead mounts (require recreation), but new pods automatically get a fresh FUSE source
7. E2E test suite covers: basic sharing, refcount correctness, parameter validation, concurrent mount/unmount, pod churn, CSI node restart recovery, persistence lifecycle, mounter crash recovery

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
