### PR TITLE
Disallow --ca-bundle mount option (not yet supported in CSI Driver)

### DIFF
--- a/pkg/driver/node/node.go
+++ b/pkg/driver/node/node.go
@@ -132,6 +132,11 @@ func (ns *S3NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 		return nil, status.Error(codes.InvalidArgument, "Running mount-s3 with mount flag -o is not supported in CSI Driver.")
 	}
 
+	// `--ca-bundle` is not supported in CSI Driver yet.
+	if args.Has(mountpoint.ArgCABundle) {
+		return nil, status.Errorf(codes.InvalidArgument, "Running mount-s3 with %s is not supported in CSI Driver.", mountpoint.ArgCABundle)
+	}
+
 	fsGroup := ""
 	if capMount := volCap.GetMount(); capMount != nil {
 		if volumeMountGroup := capMount.GetVolumeMountGroup(); volumeMountGroup != "" {

--- a/pkg/driver/node/node_test.go
+++ b/pkg/driver/node/node_test.go
@@ -198,6 +198,34 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "fail: --ca-bundle option is present",
+			testFunc: func(t *testing.T) {
+				nodeTestEnv := initNodeServerTestEnv(t)
+				ctx := context.Background()
+				req := &csi.NodePublishVolumeRequest{
+					VolumeId: volumeId,
+					VolumeCapability: &csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{
+								MountFlags: []string{"--ca-bundle=/etc/ssl/certs/custom-ca.pem"},
+							},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+					TargetPath:    targetPath,
+					VolumeContext: map[string]string{"bucketName": bucketName},
+				}
+
+				_, err := nodeTestEnv.server.NodePublishVolume(ctx, req)
+				if err == nil {
+					t.Fatalf("NodePublishVolume should fail when --ca-bundle is set")
+				}
+				nodeTestEnv.mockCtl.Finish()
+			},
+		},
+		{
 			name: "success: foreground option is removed",
 			testFunc: func(t *testing.T) {
 				nodeTestEnv := initNodeServerTestEnv(t)

--- a/pkg/mountpoint/args.go
+++ b/pkg/mountpoint/args.go
@@ -24,6 +24,7 @@ const (
 	ArgDebug           = "--debug"
 	ArgDebugCRT        = "--debug-crt"
 	ArgFsTab           = "-o"
+	ArgCABundle        = "--ca-bundle"
 )
 
 // An ArgKey represents the key of an argument.


### PR DESCRIPTION
Mountpoint added `--ca-bundle` / `AWS_CA_BUNDLE` support in awslabs/mountpoint-s3#1834. This flag is not supported in the CSI Driver yet, so this change denylists it in `mountOptions`, returning an `InvalidArgument` error from `NodePublishVolume` (mirroring the existing `-o` handling).

The `AWS_CA_BUNDLE` env var path is already blocked by the user env allowlist.