### PR TITLE
Drop support for Kubernetes 1.30

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -11,7 +11,7 @@ matrix:
       "Ubuntu2404",
     ]
   kubernetes-version:
-    ["1.30.4", "1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0", "1.36.1"]
+    ["1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0", "1.36.1"]
   include:
     # Enable enforcing mode for SELinux in AL2023, it's easier to list it in "include"
     # field rather than trying to exclude all other variants.
@@ -20,9 +20,6 @@ matrix:
   exclude:
     # Ubuntu2404 is only supported on EKS >= 1.33.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
-    - cluster-type: "eksctl"
-      family: "Ubuntu2404"
-      kubernetes-version: "1.30.4"
     - cluster-type: "eksctl"
       family: "Ubuntu2404"
       kubernetes-version: "1.31.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Notable changes
 * Removed support for AL2, and Ubuntu 22.04.
+* Drop support for Kubernetes 1.30.
 
 # v2.7.0
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This policy is non-binding and subject to change.
 
 ## Compatibility
 
-The Mountpoint for S3 CSI Driver is compatible with Kubernetes versions v1.30+ and implements the CSI Specification v1.9.0. The driver supports **x86-64** and **arm64** architectures.
+The Mountpoint for S3 CSI Driver is compatible with Kubernetes versions v1.31+ and implements the CSI Specification v1.9.0. The driver supports **x86-64** and **arm64** architectures.
 
 ## Distros Support Matrix
 
@@ -105,11 +105,11 @@ The following table provides the support status for various distros with regards
 | Distro               | Stable     | Removed | Currently Supported EKS Versions |
 |----------------------|-----------:|--------:|----------------------------------|
 | Amazon Linux 2       |      1.0.0 |   2.8.0 | —                                |
-| Amazon Linux 2023    |      1.0.0 |       — | 1.30 – 1.36                      |
+| Amazon Linux 2023    |      1.0.0 |       — | 1.31 – 1.36                      |
 | Ubuntu 20.04         |      1.0.0 |   2.5.0 | —                                |
 | Ubuntu 22.04         |      1.0.0 |   2.8.0 | —                                |
 | Ubuntu 24.04         |      2.0.0 |       — | 1.33 – 1.36                      |
-| Bottlerocket >1.19.2 |      1.4.0 |       — | 1.30 – 1.36                      |
+| Bottlerocket >1.19.2 |      1.4.0 |       — | 1.31 – 1.36                      |
 
 ## Documentation
 

--- a/charts/aws-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aws-mountpoint-s3-csi-driver
 description: A Helm chart for installing the Mountpoint for Amazon S3 CSI Driver. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface. Install via the Helm repository at https://awslabs.github.io/mountpoint-s3-csi-driver — do not install directly from a GitHub branch.
 version: 2.7.0
-kubeVersion: ">=1.30.0-0"
+kubeVersion: ">=1.31.0-0"
 home: https://github.com/awslabs/mountpoint-s3-csi-driver
 sources:
   - https://github.com/awslabs/mountpoint-s3-csi-driver

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -5,7 +5,7 @@
 
 ## Prerequisites
 
-* Kubernetes Version >= 1.30
+* Kubernetes Version >= 1.31
 * A [supported Operating System (OS)](/README.md#distros-support-matrix) with **x86-64** or **arm64** architectures.
 
 ## Installation

--- a/tests/e2e-kubernetes/README.md
+++ b/tests/e2e-kubernetes/README.md
@@ -9,7 +9,7 @@ export AWS_REGION=us-east-1
 export TAG=20cb9d919704522d93ac40914b760dbd0487bcf3 # CSI Driver image tag to install
 export IMAGE_NAME="s3-csi-driver" # repository is inferred from current AWS account and region
 export SSH_KEY=/home/csiuser/.ssh/k8s.private.pub # optional
-export K8S_VERSION="1.30.0" # optional, must be a full version
+export K8S_VERSION="1.31.0" # optional, must be a full version
 
 ACTION=install_tools tests/e2e-kubernetes/scripts/run.sh
 ACTION=create_cluster tests/e2e-kubernetes/scripts/run.sh
@@ -19,7 +19,7 @@ ACTION=install_driver  tests/e2e-kubernetes/scripts/run.sh
 # option 1: kubeconfig inferred from CLUSTER_TYPE and ARCH
 ACTION=run_tests tests/e2e-kubernetes/scripts/run.sh
 # option 2: kubeconfig set explicitly
-export KUBECONFIG=/local/home/vlaad/local/aws-s3-csi-driver/tests/e2e-kubernetes/csi-test-artifacts/s3-csi-cluster.eksctl.1.30.0.k8s.local.kubeconfig
+export KUBECONFIG=/local/home/vlaad/local/aws-s3-csi-driver/tests/e2e-kubernetes/csi-test-artifacts/s3-csi-cluster.eksctl.1.31.0.k8s.local.kubeconfig
 ACTION=run_tests tests/e2e-kubernetes/scripts/run.sh
 
 ACTION=uninstall_driver tests/e2e-kubernetes/scripts/run.sh

--- a/tests/e2e-kubernetes/scripts/run.sh
+++ b/tests/e2e-kubernetes/scripts/run.sh
@@ -35,7 +35,7 @@ SELINUX_MODE=${SELINUX_MODE:-}
 
 # eksctl: mustn't include patch version (e.g. 1.19)
 # 'K8S_VERSION' variable must be a full version (e.g. 1.19.1)
-K8S_VERSION=${K8S_VERSION:-1.30.4}
+K8S_VERSION=${K8S_VERSION:-1.31.0}
 K8S_VERSION_EKSCTL=${K8S_VERSION_EKSCTL:-${K8S_VERSION%.*}}
 
 # We need to ensure that we're using all testing matrix variables in the cluster name


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

EKS drops extended support for Kubernetes 1.30 on 2026-07-23 (https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html), so this PR removes testing and support for the driver on Kubernetes v1.30 or lower.

Changes:
- Remove 1.30.4 from the CI test matrix (`.github/matrix.yaml`)
- Bump Helm chart `kubeVersion` floor to `>=1.31.0-0`
- Update docs: README compatibility line + Distros Support Matrix, docs/INSTALL.md prerequisite, tests/e2e-kubernetes/README.md, and the default K8S_VERSION in the e2e run script
- Add CHANGELOG entry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.