### PR TITLE
Backport CI matrix updates to v1 (drop k8s 1.30, remove AL2/Ubuntu 22.04, add Helm image verification)

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -6,10 +6,8 @@ matrix:
   arch: ["x86", "arm"]
   family:
     [
-      "AmazonLinux2",
       "AmazonLinux2023",
       "Bottlerocket",
-      "Ubuntu2204",
       "Ubuntu2404",
     ]
   kubernetes-version:
@@ -20,26 +18,11 @@ matrix:
     - family: "AmazonLinux2023"
       selinux-mode: "enforcing"
   exclude:
-    # AL2 is not supported by Kubernetes 1.33.
-    - cluster-type: "eksctl"
-      family: "AmazonLinux2"
-      kubernetes-version: "1.33.2"
-    # AL2 is not supported by Kubernetes 1.34.
-    - cluster-type: "eksctl"
-      family: "AmazonLinux2"
-      kubernetes-version: "1.34.1"
-    # AL2 is not supported by Kubernetes 1.35.
-    - cluster-type: "eksctl"
-      family: "AmazonLinux2"
-      kubernetes-version: "1.35.0"
-    # Ubuntu2204 is only supported on EKS >= 1.29 && EKS < 1.33.
+    # Ubuntu2404 is only supported on EKS >= 1.33.
     # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
     - cluster-type: "eksctl"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.33.2"
+      family: "Ubuntu2404"
+      kubernetes-version: "1.31.0"
     - cluster-type: "eksctl"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.34.1"
-    - cluster-type: "eksctl"
-      family: "Ubuntu2204"
-      kubernetes-version: "1.35.0"
+      family: "Ubuntu2404"
+      kubernetes-version: "1.32.1"

--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -13,7 +13,7 @@ matrix:
       "Ubuntu2404",
     ]
   kubernetes-version:
-    ["1.30.4", "1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0"]
+    ["1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0"]
   include:
     # Enable enforcing mode for SELinux in AL2023, it's easier to list it in "include"
     # field rather than trying to exclude all other variants.
@@ -43,8 +43,3 @@ matrix:
     - cluster-type: "eksctl"
       family: "Ubuntu2204"
       kubernetes-version: "1.35.0"
-    # Ubuntu2404 is only supported on EKS >= 1.31.
-    # See https://eksctl.io/usage/custom-ami-support/?h=ubuntu#setting-the-node-ami-family.
-    - cluster-type: "eksctl"
-      family: "Ubuntu2404"
-      kubernetes-version: "1.30.4"

--- a/.github/workflows/verify-helm-images.yaml
+++ b/.github/workflows/verify-helm-images.yaml
@@ -1,0 +1,28 @@
+name: "Verify Helm Images"
+
+on:
+  push:
+    branches: [ "main", "feature/*" ]
+  pull_request:
+  merge_group:
+    types: [ "checks_requested" ]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify chart images exist in public ECR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install crane
+        run: |
+          cd /tmp
+          curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" > crane.tar.gz
+          tar -xzf crane.tar.gz crane
+          sudo mv crane /usr/local/bin/crane
+          sudo chmod +x /usr/local/bin/crane
+          crane version
+      - name: Verify public ECR images referenced in chart
+        run: ./scripts/verify-helm-images.sh --public-only

--- a/charts/aws-mountpoint-s3-csi-driver/Chart.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aws-mountpoint-s3-csi-driver
 description: A Helm chart for installing the Mountpoint for Amazon S3 CSI Driver. This CSI driver allows your Kubernetes applications to access S3 objects through a file system interface.
 version: 1.15.0
-kubeVersion: ">=1.30.0-0"
+kubeVersion: ">=1.31.0-0"
 home: https://github.com/awslabs/mountpoint-s3-csi-driver
 sources:
   - https://github.com/awslabs/mountpoint-s3-csi-driver

--- a/scripts/verify-helm-images.sh
+++ b/scripts/verify-helm-images.sh
@@ -11,11 +11,24 @@ set -euo pipefail
 #   - Node driver registrar sidecar
 #   - Liveness probe sidecar
 #
+# Usage:
+#   ./verify-helm-images.sh                # Full verification (incl. EKS-addon private ECR repo; needs AWS creds)
+#   ./verify-helm-images.sh --public-only  # Verify only public ECR images (no AWS creds needed)
+#
 # Prerequisites:
 #   - yq: YAML processor (https://github.com/mikefarah/yq)
 #   - crane: Container registry tool (https://github.com/google/go-containerregistry/tree/main/cmd/crane)
 #
-# Note: AWS credentials are required with ecr:GetAuthorizationToken and ecr:BatchGetImage permissions to access EKS add-on repositories.
+# Note: For the default (full) mode, AWS credentials with ecr:GetAuthorizationToken and
+# ecr:BatchGetImage permissions are required to access EKS add-on repositories.
+
+PUBLIC_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --public-only) PUBLIC_ONLY=1 ;;
+    *) echo "ERROR: Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
 
 CHART_DIR="charts/aws-mountpoint-s3-csi-driver"
 VALUES_FILE="${CHART_DIR}/values.yaml"
@@ -53,9 +66,11 @@ fi
 echo "Verifying all images referenced in ${VALUES_FILE}..."
 echo ""
 
-if ! aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${EKS_REGISTRY}"; then
-  echo "ERROR: Failed to authenticate with ECR"
-  exit 1
+if [[ ${PUBLIC_ONLY} -eq 0 ]]; then
+  if ! aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${EKS_REGISTRY}"; then
+    echo "ERROR: Failed to authenticate with ECR"
+    exit 1
+  fi
 fi
 
 FAILED=0
@@ -108,8 +123,10 @@ verify_sidecar_images_in_chart() {
 echo "== Verifying standard images =="
 verify_sidecar_images_in_chart "helm template $CHART_DIR"
 
-echo "== Verifying EKS Addon images =="
-verify_sidecar_images_in_chart "helm template $CHART_DIR --set isEKSAddon=true --set sidecars.livenessProbe.image.containerRegistry=$EKS_REGISTRY --set sidecars.nodeDriverRegistrar.image.containerRegistry=$EKS_REGISTRY"
+if [[ ${PUBLIC_ONLY} -eq 0 ]]; then
+  echo "== Verifying EKS Addon images =="
+  verify_sidecar_images_in_chart "helm template $CHART_DIR --set isEKSAddon=true --set sidecars.livenessProbe.image.containerRegistry=$EKS_REGISTRY --set sidecars.nodeDriverRegistrar.image.containerRegistry=$EKS_REGISTRY"
+fi
 
 # Summary
 echo "========================================"


### PR DESCRIPTION
Backports two main-branch CI changes to the `v1` branch:
- #870 — Drop support for Kubernetes 1.30
- #841 — Remove unsupported OSes (AL2, Ubuntu 22.04)
- #832 — Add the "Verify Helm Images" workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.