### PR TITLE
Add `Client.expressAZ` to get the S3 Express AZ used in the test

### DIFF
--- a/tests/e2e-kubernetes/s3client/client.go
+++ b/tests/e2e-kubernetes/s3client/client.go
@@ -4,6 +4,7 @@ package s3client
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
 // DefaultRegion is the default AWS region to use if unspecified.
@@ -78,12 +80,22 @@ func (c *Client) CreateStandardBucket(ctx context.Context) (string, DeleteBucket
 	return bucketName, c.create(ctx, input)
 }
 
+// expressAZ returns the S3 Express availability zone for the client's region.
+// It checks the S3_EXPRESS_AZ environment variable first, allowing callers to override
+// the built-in map for regions not yet in the hardcoded list.
+func (c *Client) expressAZ() string {
+	if az := os.Getenv("S3_EXPRESS_AZ"); az != "" {
+		return az
+	}
+	return expressAZs[c.region]
+}
+
 // CreateDirectoryBucket creates a new directory S3 bucket with a random name (by following
 // "Directory bucket naming rules") and returns the bucket name and a clean up function.
 func (c *Client) CreateDirectoryBucket(ctx context.Context) (string, DeleteBucketFunc) {
-	regionAz := expressAZs[c.region]
+	regionAz := c.expressAZ()
 	if regionAz == "" {
-		framework.Failf("Unknown S3 Express region %s\n", c.region)
+		e2eskipper.Skipf("Unknown S3 Express region %s\n", c.region)
 	}
 
 	// refer to s3 express bucket naming conventions


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- Do not fail if S3 Express is not present.
- Add new environment variable `S3_EXPRESS_AZ` which can be set to override the Express AZ

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
