### PR TITLE
Use TEST_POD_IMAGE environment variable for defining the test image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,9 @@ test:
 	# skipping controller test cases because we don't implement controller for static provisioning,
 	# this is a known limitation of sanity testing package: https://github.com/kubernetes-csi/csi-test/issues/214
 	go test -v ./tests/sanity/... -ginkgo.skip="ControllerGetCapabilities" -ginkgo.skip="ValidateVolumeCapabilities" -ginkgo.skip="should remove target path"
+	# Run unit tests in e2e-kubernetes (image override, parsing, etc.) without requiring a cluster.
+	# TestE2E is the Ginkgo e2e suite entry point which requires a live cluster, so we skip it.
+	cd tests/e2e-kubernetes && go test -v -skip TestE2E ./...
 
 .PHONY: cover
 cover:

--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -3,11 +3,14 @@ package e2e
 import (
 	"context"
 	"flag"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/awslabs/mountpoint-s3-csi-driver/tests/e2e-kubernetes/s3client"
 	custom_testsuites "github.com/awslabs/mountpoint-s3-csi-driver/tests/e2e-kubernetes/testsuites"
+	"github.com/distribution/reference"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -16,6 +19,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 func init() {
@@ -39,6 +43,40 @@ func init() {
 	custom_testsuites.ClusterName = ClusterName
 	custom_testsuites.ClusterType = ClusterType
 	custom_testsuites.IMDSAvailable = IMDSAvailable
+
+	// Override the upstream K8s e2e framework's default test image (BusyBox) with
+	// our TEST_POD_IMAGE so that tests like InitVolumesTestSuite use an image
+	// accessible from all regions instead of registry.k8s.io.
+	overrideUpstreamTestImage()
+}
+
+func overrideUpstreamTestImage() {
+	img := os.Getenv("TEST_POD_IMAGE")
+	if img == "" {
+		img = "public.ecr.aws/amazonlinux/amazonlinux:2023"
+	}
+
+	ref, err := reference.Parse(img)
+	if err != nil {
+		panic(fmt.Sprintf("overrideUpstreamTestImage: invalid image reference %q: %v", img, err))
+	}
+
+	named, ok := ref.(reference.Named)
+	if !ok {
+		panic(fmt.Sprintf("overrideUpstreamTestImage: image reference %q has no name", img))
+	}
+
+	version := "latest"
+	if tagged, ok := ref.(reference.Tagged); ok {
+		version = tagged.Tag()
+	}
+
+	configs := imageutils.GetImageConfigs()
+	cfg := configs[imageutils.BusyBox]
+	cfg.SetRegistry(reference.Domain(named))
+	cfg.SetName(reference.Path(named))
+	cfg.SetVersion(version)
+	configs[imageutils.BusyBox] = cfg
 }
 
 func TestE2E(t *testing.T) {

--- a/tests/e2e-kubernetes/go.mod
+++ b/tests/e2e-kubernetes/go.mod
@@ -144,7 +144,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
+	github.com/distribution/reference v0.6.0
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/tests/e2e-kubernetes/image_override_test.go
+++ b/tests/e2e-kubernetes/image_override_test.go
@@ -1,0 +1,35 @@
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+func TestOverrideUpstreamTestImage(t *testing.T) {
+	// init() has already called overrideUpstreamTestImage(), so verify that the
+	// upstream BusyBox image config reflects our TEST_POD_IMAGE (or the default).
+	expectedImage := os.Getenv("TEST_POD_IMAGE")
+	if expectedImage == "" {
+		expectedImage = "public.ecr.aws/amazonlinux/amazonlinux:2023"
+	}
+
+	t.Run("imageutils returns overridden image", func(t *testing.T) {
+		got := imageutils.GetE2EImage(imageutils.BusyBox)
+		if got != expectedImage {
+			t.Errorf("GetE2EImage(BusyBox) = %q, want %q", got, expectedImage)
+		}
+	})
+
+	t.Run("e2epod.MakePod uses overridden image", func(t *testing.T) {
+		pod := e2epod.MakePod("default", nil, nil, admissionapi.LevelBaseline, "")
+		for _, container := range pod.Spec.Containers {
+			if container.Image != expectedImage {
+				t.Errorf("e2epod.MakePod() container image = %q, want %q", container.Image, expectedImage)
+			}
+		}
+	})
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- Instead of using `busybox`, use AL2023 as our global test image
- Allow the image to be overridden through an environment variable `TEST_POD_IMAGE`
- Add a test to verify that the new variable works
- Overrides the k8s `busybox` image because then it impacts the normal k8s tests. `KUBE_TEST_REPO_LIST` does not work as we need to override image tag as well as repo & repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
