### PR TITLE
Add Dockerfile for EKS addon e2e tests

### DIFF
--- a/tests/e2e-kubernetes/scripts/eks-addon/Dockerfile
+++ b/tests/e2e-kubernetes/scripts/eks-addon/Dockerfile
@@ -1,0 +1,87 @@
+# Note that all dependencies are compiled here, since isolated regions
+# won't be able to pull dependencies over internet at run time.
+
+ARG GO_VERSION
+
+FROM public.ecr.aws/eks-distro-build-tooling/golang:${GO_VERSION}-al23 AS builder
+ARG GINKGO_VERSION
+
+ENV GOPROXY=direct
+
+WORKDIR /src
+COPY . .
+
+# Compile the e2e test binary
+RUN cd tests/e2e-kubernetes && go test -c -o /e2e.test .
+
+# Install ginkgo CLI
+RUN GOBIN=/usr/local/bin go install github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}
+
+# --- Runtime stage ---
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+# Install AWS CLI and basic utilities
+RUN dnf install -y aws-cli && \
+    dnf clean all
+
+# Install kubectl
+ARG KUBECTL_VERSION=1.33.3
+RUN curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl && mv kubectl /usr/local/bin/
+
+# Copy pre-compiled binaries from builder
+COPY --from=builder /e2e.test /usr/local/bin/e2e.test
+COPY --from=builder /usr/local/bin/ginkgo /usr/local/bin/ginkgo
+
+COPY <<'EOF' /entrypoint.sh
+#!/bin/bash
+set -euo pipefail
+
+# Use service-specific endpoint env var for EKS beta/gamma endpoint override.
+# This avoids --endpoint-url CLI flag which is unreliable across AWS CLI versions.
+# AWS_ENDPOINT_URL_EKS only affects EKS calls, not S3/STS/CloudWatch/etc.
+if [[ -n "${EKS_ENDPOINT:-}" ]]; then
+    export AWS_ENDPOINT_URL_EKS="${EKS_ENDPOINT}"
+    echo "EKS Endpoint: ${EKS_ENDPOINT} (via AWS_ENDPOINT_URL_EKS)"
+fi
+if [[ -n "${EKS_AUTH_ENDPOINT:-}" ]]; then
+    export AWS_ENDPOINT_URL_EKS_AUTH="${EKS_AUTH_ENDPOINT}"
+    echo "EKS Auth Endpoint: ${AWS_ENDPOINT_URL_EKS_AUTH} (via AWS_ENDPOINT_URL_EKS_AUTH)"
+fi
+if [[ -n "${TEST_IMAGE_URI:-}" ]]; then
+    export TEST_POD_IMAGE="${TEST_IMAGE_URI}"
+    echo "TEST_POD_IMAGE: ${TEST_POD_IMAGE}"
+fi
+
+export KUBECONFIG="/tmp/kubeconfig"
+echo "${KUBECONFIG_BASE64}" | base64 -d > "${KUBECONFIG}"
+
+aws eks create-addon --addon-name aws-mountpoint-s3-csi-driver \
+	    --cluster-name "$CLUSTER_NAME" --region "$REGION" \
+	    --addon-version "$ADDON_VERSION"
+
+# Wait for addons to become active
+echo "Waiting for aws-mountpoint-s3-csi-driver addon to become active..."
+if ! aws eks wait addon-active --addon-name aws-mountpoint-s3-csi-driver \
+    --cluster-name "$CLUSTER_NAME" --region "$REGION"; then
+  echo "ERROR: aws-mountpoint-s3-csi-driver addon did not become active"
+  aws eks describe-addon --addon-name aws-mountpoint-s3-csi-driver \
+      --cluster-name "$CLUSTER_NAME" --region "$REGION" 2>&1 || true
+  kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-mountpoint-s3-csi-driver -o wide 2>&1 || true
+  exit 1
+fi
+
+exec ginkgo -vv -timeout 60m \
+    /usr/local/bin/e2e.test \
+    -- \
+    --bucket-region="${REGION}" \
+    --commit-id=latest \
+    --bucket-prefix="${CLUSTER_NAME}" \
+    --imds-available=true \
+    --cluster-name="${CLUSTER_NAME}" \
+    --cluster-type=eksctl
+
+EOF
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tests/e2e-kubernetes/scripts/eks-addon/build_and_push.sh
+++ b/tests/e2e-kubernetes/scripts/eks-addon/build_and_push.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Builds the e2e test image and pushes it to ECR
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --account) AWS_ACCOUNT="$2"; shift 2 ;;
+        --region)  AWS_REGION="$2"; shift 2 ;;
+        --repo)    ECR_REPO="$2"; shift 2 ;;
+        --tag)     IMAGE_TAG="$2"; shift 2 ;;
+        --help)
+            echo "Usage: $0 [--account ID] [--region REGION] [--repo NAME] [--tag TAG]"
+            echo ""
+            echo "Options:"
+            echo "  --account   AWS account ID"
+            echo "  --region    AWS region"
+            echo "  --repo      ECR repository name"
+            echo "  --tag       Image tag"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+ECR_URI="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+FULL_IMAGE="${ECR_URI}/${ECR_REPO}:${IMAGE_TAG}"
+LOCAL_IMAGE="mp-s3-csi-e2e:${IMAGE_TAG}"
+
+echo "=== Configuration ==="
+echo "  Account:  ${AWS_ACCOUNT}"
+echo "  Region:   ${AWS_REGION}"
+echo "  Image:    ${FULL_IMAGE}"
+echo ""
+
+# Authenticate to ECR
+echo "=== Logging in to ECR ==="
+aws ecr get-login-password --region "${AWS_REGION}" | \
+    docker login --username AWS --password-stdin "${ECR_URI}"
+
+# Build
+echo "=== Building image ==="
+"${SCRIPT_DIR}/build_test_image.sh" --output "type=docker,name=${LOCAL_IMAGE}"
+
+# Tag and push
+echo "=== Pushing to ECR ==="
+docker tag "${LOCAL_IMAGE}" "${FULL_IMAGE}"
+docker push "${FULL_IMAGE}"
+
+echo ""
+echo "=== Done ==="
+echo "Image pushed: ${FULL_IMAGE}"
+echo ""
+echo "To use locally, set testImageUris in your run definition:"
+echo "  \"testImageUris\": \"{\\\"${IMAGE_TAG}\\\":\\\"${FULL_IMAGE}\\\"}\""

--- a/tests/e2e-kubernetes/scripts/eks-addon/build_test_image.sh
+++ b/tests/e2e-kubernetes/scripts/eks-addon/build_test_image.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# build_test_image.sh --output <buildx output spec>
+# Builds the e2e test container image.
+# Go and Ginkgo versions are auto-discovered from the source.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output) OUTPUT="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+if [ -z "$OUTPUT" ]; then
+  echo "Usage: $0 --output <buildx output spec>]"
+  echo "Example: $0 --output 'type=oci,dest=out.tar'"
+  echo "         $0 --output 'type=docker'"
+  exit 1
+fi
+
+# Discover versions from source
+GO_VERSION=$(grep '^go ' "$REPO_ROOT/go.mod" | awk '{print $2}')
+GINKGO_VERSION=$(grep 'github.com/onsi/ginkgo/v' "$REPO_ROOT/tests/e2e-kubernetes/go.mod" | awk '{print $2}')
+
+echo "Discovered GO_VERSION=${GO_VERSION}, GINKGO_VERSION=${GINKGO_VERSION}"
+
+docker buildx create --use --driver docker-container
+docker buildx build --platform "linux/amd64" \
+  --build-arg "GO_VERSION=${GO_VERSION}" \
+  --build-arg "GINKGO_VERSION=${GINKGO_VERSION}" \
+  --output "$OUTPUT" \
+  -f "$REPO_ROOT/tests/e2e-kubernetes/scripts/eks-addon/Dockerfile" \
+  "$REPO_ROOT"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Adds a new `Dockerfile` to build the e2e test suite which can be ran inside a k8s cluster.
- Adds `build_test_image.sh` which is used for building the image, collecting various version numbers from source so they don't need to be updated in multiple places
- Adds `build_and_push.sh` which can be used for testing building the image and deploying it to ECR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
