### PR TITLE
ci: Restrict verify helm images workflow to PRs targeting main

### DIFF
--- a/.github/workflows/verify-helm-images.yaml
+++ b/.github/workflows/verify-helm-images.yaml
@@ -14,6 +14,7 @@ jobs:
   verify:
     name: Verify chart images exist in public ECR
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.base_ref == 'main'
     steps:
       - uses: actions/checkout@v7
       - name: Install crane


### PR DESCRIPTION
*Description of changes:*
The verify helm images workflow currently runs on all pull requests, including release branch PRs where the image intentionally doesn't exist yet (it gets built after tagging). This restricts the verify helm images check to only run on PRs targeting main, preventing false failures on release branch PRs where the image has not yet been published.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
