### PR TITLE
ci: add warning to use merge commit for merge to feature branch workflow

### DIFF
--- a/.github/workflows/merge-main-to-feature-daemonset.yaml
+++ b/.github/workflows/merge-main-to-feature-daemonset.yaml
@@ -75,7 +75,11 @@ jobs:
 
           This is an automated bi-weekly merge of \`main\` into \`feature/daemonset-architecture\`.
 
-          No conflicts detected. Please review and merge.
+          No conflicts detected. Please review and merge via 'Create a merge commit' option.
+
+          > [!WARNING]
+          > This PR must be merged via 'Create a merge commit', not 'Squash and merge'.
+          > This preserves the history of the main branch commits.
 
           > **Note:** Please delete the \`${MERGE_BRANCH}\` branch after merging this PR.
 


### PR DESCRIPTION
*Description of changes:*

I forgot to use merge commit for the [merge to daemonset architecture branch workflow](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/.github/workflows/merge-main-to-feature-daemonset.yaml) and instead used Squash and merge. Now added a warning so we don't forget to do that. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
