### PR TITLE
fix: grant leader election event permissions

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -92,6 +92,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
+++ b/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
@@ -91,6 +91,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
## Summary

- grant the controller leader-election Role permission to create and patch core Events
- keep the existing Lease permissions unchanged

## Root cause

Leader election was added in v2.7.0, but its namespaced Role only permits access to `coordination.k8s.io/leases`. The client-go event recorder also creates and patches core Events, so the controller logs `events is forbidden` whenever it records leadership changes.

## Validation

- `helm lint charts/aws-mountpoint-s3-csi-driver`
- rendered the default chart and asserted the leader-election Role contains the Events rule
- rendered with `isEKSAddon=true` and asserted the Events rule is present
- `git diff --check`

Closes #886

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.