### PR TITLE
Return mount success, when target is mounted and mountpoint pod can not be found

### DIFF
--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -135,6 +136,15 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 	if err != nil {
 		klog.Errorf("Failed to find corresponding MountpointS3PodAttachment custom resource for %q: %v. %s", target, err, pm.helpMessageForGettingControllerLogs())
 		return fmt.Errorf("Failed to find corresponding MountpointS3PodAttachment custom resource: %w. %s", err, pm.helpMessageForGettingControllerLogs())
+	}
+
+	// If target is already mounted (republish) but the MP pod is gone, return success to avoid
+	// kubelet exponential backoff that would block NodePublishVolume for all other pods on this volume.
+	if isTargetMountPoint {
+		if _, err := pm.podWatcher.Get(mpPodName); apierrors.IsNotFound(err) {
+			klog.Errorf("Mountpoint Pod %q for %q not found, credentials not updated. %s", mpPodName, target, pm.helpMessageForGettingMountpointPodStatus(err, mpPodName))
+			return nil
+		}
 	}
 
 	pod, podPath, err := pm.waitForMountpointPod(ctx, mpPodName)

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -104,10 +104,12 @@ func NewPodMounter(
 // If Mountpoint is already mounted at `target`, it will return early at step 3 to ensure credentials are up-to-date.
 // If Mountpoint is already mounted at `source`, it will skip steps 4-7 and only perform bind mount to `target`.
 func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target string, credentialCtx credentialprovider.ProvideContext, args mountpoint.Args, fsGroup string, userEnv envprovider.Environment) error {
-	volumeName, err := pm.volumeNameFromTargetPath(target)
+	tp, err := targetpath.Parse(target)
 	if err != nil {
 		return fmt.Errorf("Failed to extract volume name from %q: %w", target, err)
 	}
+	volumeName := tp.VolumeID
+	workloadPodID := tp.PodID
 
 	isTargetMountPoint, err := pm.IsMountPoint(target)
 	if err != nil {
@@ -142,7 +144,7 @@ func (pm *PodMounter) Mount(ctx context.Context, bucketName string, target strin
 	// kubelet exponential backoff that would block NodePublishVolume for all other pods on this volume.
 	if isTargetMountPoint {
 		if _, err := pm.podWatcher.Get(mpPodName); apierrors.IsNotFound(err) {
-			klog.Errorf("Mountpoint Pod %q for %q not found, credentials not updated. %s", mpPodName, target, pm.helpMessageForGettingMountpointPodStatus(err, mpPodName))
+			klog.Errorf("Mountpoint Pod %q for %q not found, credentials not updated. Mount will not recover — restart the workload %q to get a fresh mount.", mpPodName, target, workloadPodID)
 			return nil
 		}
 	}
@@ -514,15 +516,6 @@ func (pm *PodMounter) bindMountSyscallWithDefault(source, target string) error {
 // unmountTarget calls `unmount` syscall on `target`.
 func (pm *PodMounter) unmountTarget(target string) error {
 	return pm.mount.Unmount(target)
-}
-
-// volumeNameFromTargetPath tries to extract PersistentVolume's name from `target` path.
-func (pm *PodMounter) volumeNameFromTargetPath(target string) (string, error) {
-	tp, err := targetpath.Parse(target)
-	if err != nil {
-		return "", err
-	}
-	return tp.VolumeID, nil
 }
 
 // helpMessageForGettingMountpointLogs returns a help message to troubleshoot Mountpoint failures.

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -582,6 +582,31 @@ func TestPodMounter(t *testing.T) {
 				t.Errorf("it should unmount the target path if Mountpoint fails to start")
 			}
 		})
+
+		t.Run("Returns success when target is already mounted but Mountpoint Pod is gone", func(t *testing.T) {
+			testCtx := setup(t)
+
+			// Create target directory and simulate a previously successful mount at target
+			err := os.MkdirAll(testCtx.targetPath, 0750)
+			assert.NoError(t, err)
+			testCtx.mount.Mount("mountpoint-s3", testCtx.targetPath, "fuse", []string{"bind"})
+
+			// Do NOT create the Mountpoint Pod — it has been deleted.
+			// The S3PA still references it, but the pod no longer exists in the cluster.
+
+			err = testCtx.podMounter.Mount(testCtx.ctx, testCtx.bucketName, testCtx.targetPath, credentialprovider.ProvideContext{
+				VolumeID:      testCtx.volumeID,
+				WorkloadPodID: testCtx.podUID,
+			}, mountpoint.ParseArgs(nil), testCtx.fsGroup, envprovider.Environment{})
+			assert.NoError(t, err)
+
+			// Target should still be mounted (not unmounted by the driver)
+			ok, err := testCtx.mount.IsMountPoint(testCtx.targetPath)
+			assert.NoError(t, err)
+			if !ok {
+				t.Errorf("target should remain mounted when returning success for deleted Mountpoint Pod")
+			}
+		})
 	})
 
 	t.Run("Checking if target is a mount point", func(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

When `NodePublishVolume` is called for a volume that is already published at the target (credential refresh via `requiresRepublish`), but the backing Mountpoint Pod no longer exists, the driver currently waits 15s then returns an error. This triggers kubelet's per-volume exponential backoff (max 2m2s). Since kubelet serializes all `NodePublishVolume` calls for the same volume behind a single backoff timer, orphaned workloads (whose MP pod was deleted) repeatedly consume the slot and delay new workloads with healthy MP pods from mounting. With ~20 orphaned workloads contending, a new workload has a ~1/21 chance of being picked each cycle, with a 2m+ delay between attempts.

This change returns success when the target is already a mountpoint and the MP pod is not found — the mount is unrecoverable regardless (FUSE session is gone), but returning an error only causes collateral damage to other workloads. This also aligns with the [CSI spec](https://github.com/container-storage-interface/spec/blob/master/spec.md#nodepublishvolume): "This operation MUST be idempotent. If the volume corresponding to the `volume_id` has already been published at the specified `target_path` [...] the Plugin MUST reply `0 OK`."

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
