### PR TITLE
fix: add OS selector to Mountpoint pods

### DIFF
--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -125,6 +125,9 @@ func (c *Creator) MountpointPod(node string, pv *corev1.PersistentVolume, priori
 			},
 		},
 		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				corev1.LabelOSStable: "linux",
+			},
 			// Mountpoint terminates with zero exit code on a successful termination,
 			// and in turn `/bin/aws-s3-csi-mounter` also exits with Mountpoint process' exit code,
 			// here `restartPolicy: OnFailure` allows Pod to only restart on non-zero exit codes (i.e. some failures)

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -281,6 +281,7 @@ func createAndVerifyPod(t *testing.T, clusterVariant cluster.Variant, expectedRu
 		assert.Equals(t, "mp-", mpPod.GenerateName)
 		assert.Equals(t, "", mpPod.Name)
 		assert.Equals(t, namespace, mpPod.Namespace)
+		assert.Equals(t, map[string]string{corev1.LabelOSStable: "linux"}, mpPod.Spec.NodeSelector)
 		assert.Equals(t, map[string]string{
 			mppod.LabelMountpointVersion: mountpointVersion,
 			mppod.LabelCSIDriverVersion:  csiDriverVersion,
@@ -933,7 +934,6 @@ func TestPodLabels(t *testing.T) {
 		// Verify driver labels take priority (cannot be overridden)
 		assert.Equals(t, mountpointVersion, mpPod.Labels[mppod.LabelMountpointVersion])
 		assert.Equals(t, csiDriverVersion, mpPod.Labels[mppod.LabelCSIDriverVersion])
-		assert.Equals(t, map[string]string{corev1.LabelOSStable: "linux"}, mpPod.Spec.NodeSelector)
 	})
 
 	t.Run("Headroom Pod", func(t *testing.T) {
@@ -965,6 +965,7 @@ func TestPodLabels(t *testing.T) {
 		// Verify driver labels take priority (cannot be overridden)
 		assert.Equals(t, string(workloadPod.UID), hrPod.Labels[mppod.LabelHeadroomForPod])
 		assert.Equals(t, testVolName, hrPod.Labels[mppod.LabelHeadroomForVolume])
+		assert.Equals(t, map[string]string{corev1.LabelOSStable: "linux"}, hrPod.Spec.NodeSelector)
 	})
 
 	t.Run("Empty Labels", func(t *testing.T) {

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -933,6 +933,7 @@ func TestPodLabels(t *testing.T) {
 		// Verify driver labels take priority (cannot be overridden)
 		assert.Equals(t, mountpointVersion, mpPod.Labels[mppod.LabelMountpointVersion])
 		assert.Equals(t, csiDriverVersion, mpPod.Labels[mppod.LabelCSIDriverVersion])
+		assert.Equals(t, map[string]string{corev1.LabelOSStable: "linux"}, mpPod.Spec.NodeSelector)
 	})
 
 	t.Run("Headroom Pod", func(t *testing.T) {

--- a/pkg/podmounter/mppod/headroom.go
+++ b/pkg/podmounter/mppod/headroom.go
@@ -50,6 +50,9 @@ func (c *Creator) HeadroomPod(workloadPod *corev1.Pod, pv *corev1.PersistentVolu
 			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				corev1.LabelOSStable: "linux",
+			},
 			PriorityClassName: c.config.HeadroomPriorityClassName,
 			Affinity: &corev1.Affinity{
 				// Specify inter-pod affinity rule to Workload Pod to

--- a/tests/controller/controller_test.go
+++ b/tests/controller/controller_test.go
@@ -1976,6 +1976,7 @@ func verifyMountpointPodFor(pod *testPod, vol *testVolume, mountpointPod *testPo
 	Expect(mountpointPod.ObjectMeta.Annotations).To(HaveKeyWithValue(mppod.AnnotationVolumeId, vol.pv.Spec.CSI.VolumeHandle))
 
 	Expect(mountpointPod.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
+	Expect(mountpointPod.Spec.NodeSelector).To(Equal(map[string]string{corev1.LabelOSStable: "linux"}))
 
 	Expect(mountpointPod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(Equal([]corev1.NodeSelectorTerm{
 		{


### PR DESCRIPTION
## Summary

- add the stable `kubernetes.io/os: linux` node selector to controller-created Mountpoint pods
- add the same selector to Headroom pods
- verify the selector in Mountpoint, Headroom, and controller pod checks

## Root cause

Mountpoint pods are pinned to the workload node through node affinity, but they do not declare an OS node selector. Admission policies that require `kubernetes.io/os` therefore reject these pods before scheduling.

Adding the stable Linux selector makes the generated pod spec explicit and compatible with those policies without changing the existing exact-node affinity.

## Validation

- `go test ./pkg/podmounter/mppod -run 'TestPodLabels|TestPodDefaults'`
- `git diff --check`

The controller compile smoke (`go test ./tests/controller -run '^$'`) was attempted on Windows, but dependency download from `proxy.golang.org` timed out before package compilation.

Closes #763

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.