### PR TITLE
fix: Sync Kustomize manifests with Helm chart

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -44,3 +44,5 @@ spec:
               value: mount-s3
             - name: MOUNTPOINT_PRIORITY_CLASS_NAME
               value: mount-s3-critical
+            - name: MOUNTPOINT_POD_LABELS
+              value: "{}"

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -121,7 +121,7 @@ spec:
               cpu: 10m
               memory: 40Mi
         - name: node-driver-registrar
-          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.10.0-eks-1-29-7
+          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.3
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true
@@ -159,7 +159,7 @@ spec:
               cpu: 10m
               memory: 40Mi
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.12.0-eks-1-29-7
+          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.3
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true

--- a/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
+++ b/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
@@ -73,3 +73,39 @@ roleRef:
   kind: Role
   name: s3-csi-driver-controller-role
   apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-controller-leader-election-role
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/component: csi-driver
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["aws-s3-csi-controller"]
+    verbs: ["get", "update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-controller-leader-election-role-binding
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/component: csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: s3-csi-driver-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: s3-csi-driver-controller-leader-election-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
*Issue #, if available: *N/A

*Description of changes:*

The Kustomize manifests had drifted behind several Helm chart changes. Bring them back in line:

- Add leader-election RBAC (Role + RoleBinding granting access to the `aws-s3-csi-controller` lease) for the controller
- Add the `MOUNTPOINT_POD_LABELS` env var to the controller
- Update the node-driver-registrar and livenessprobe sidecar images to the csi-components registry versions

Verified by rendering `helm template --release-name kustomize` and `kubectl kustomize deploy/kubernetes/overlays/stable` and confirming the only remaining differences are the intentional Kustomize-specific deltas (`INSTALLATION_TYPE=kustomize`, `hostPID=false`, image placeholders). Manually run e2e tests against Kustomize.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
