### PR TITLE
fix(test): make some process sharing e2e tests serial

### DIFF
--- a/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
@@ -515,7 +515,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			checkReadFromPathSucceedEventually(ctx, f, gen2Pods[1], file2, toWrite, seed2)
 		})
 
-		ginkgo.It("should recover mount map after CSI node pod restart and existing pods keep working", func(ctx context.Context) {
+		ginkgo.It("should recover mount map after CSI node pod restart and existing pods keep working", ginkgo.Serial, func(ctx context.Context) {
 			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
 			l.resources = append(l.resources, resource)
 
@@ -553,7 +553,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			checkReadFromPathSucceedEventually(ctx, f, pods[1], postRestartFile, toWrite, postSeed)
 		})
 
-		ginkgo.It("should allow new pod to join shared mount after CSI node pod restart", func(ctx context.Context) {
+		ginkgo.It("should allow new pod to join shared mount after CSI node pod restart", ginkgo.Serial, func(ctx context.Context) {
 			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
 			l.resources = append(l.resources, resource)
 
@@ -592,7 +592,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 				"expected exactly 1 FUSE source mount for volume %s after restart, got %d", pvName, fuseCount)
 		})
 
-		ginkgo.It("should correctly unmount after CSI node pod restart with recovered refcount", func(ctx context.Context) {
+		ginkgo.It("should correctly unmount after CSI node pod restart with recovered refcount", ginkgo.Serial, func(ctx context.Context) {
 			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
 			l.resources = append(l.resources, resource)
 
@@ -703,7 +703,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			checkCredentialDirRemoved(ctx, f, targetNode, pvName)
 		})
 
-		ginkgo.It("should recover from mounter pod crash with fresh source mount for new pods", func(ctx context.Context) {
+		ginkgo.It("should recover from mounter pod crash with fresh source mount for new pods", ginkgo.Serial, func(ctx context.Context) {
 			resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
 			l.resources = append(l.resources, resource)
 
@@ -810,7 +810,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			gomega.Expect(metaMtimeAfter).ToNot(gomega.Equal(metaMtimeBefore),
 				"meta file mtime should change after fresh mount overwrites it")
 		})
-		ginkgo.It("should recover from mounter pod crash with fresh source mount for new pods with different params", func(ctx context.Context) {
+		ginkgo.It("should recover from mounter pod crash with fresh source mount for new pods with different params", ginkgo.Serial, func(ctx context.Context) {
 			// Create PV with --read-only mount option
 			readOnlyResource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, []string{"--read-only"})
 			l.resources = append(l.resources, readOnlyResource)


### PR DESCRIPTION
## Description of changes

Noticed this [CI error](https://github.com/awslabs/mountpoint-s3-csi-driver/actions/runs/30904535264/job/92837283210?pr=851#step:17:7454) for test `[It] should clean up meta file, credentials, and source mount after last consumer unmounts`:
```
[FAILED] expected credential directory for volume s3-e2e-pv-xxxxx to exist while pod is mounted
```

I suspect tests with `killCSINodePodOnNode` or `killMounterPodOnNode` would break the other tests that are running in parallel with them which causes this issue.

Added ginkgo.Serial to tests with `killCSINodePodOnNode` or `killMounterPodOnNode` in this file which should hopefully fix this problem.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
