### PR TITLE
feat: support Mountpoint Pod annotations

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
@@ -73,6 +73,8 @@ spec:
               value: {{ .Values.mountpointPod.priorityClassName }}
             - name: MOUNTPOINT_POD_LABELS
               value: {{ toJson .Values.mountpointPod.podLabels | quote }}
+            - name: MOUNTPOINT_POD_ANNOTATIONS
+              value: {{ toJson .Values.mountpointPod.podAnnotations | quote }}
             {{- if .Values.experimental.reserveHeadroomForMountpointPods }}
             - name: MOUNTPOINT_HEADROOM_POD_LABELS
               value: {{ toJson .Values.experimental.headroomPodLabels | quote }}

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -108,6 +108,7 @@ mountpointPod:
   preemptingPriorityClassName: mount-s3-preempting-critical
   headroomPriorityClassName: mount-s3-headroom
   podLabels: {}
+  podAnnotations: {}
 
 nameOverride: ""
 fullnameOverride: ""

--- a/cmd/aws-s3-csi-controller/main.go
+++ b/cmd/aws-s3-csi-controller/main.go
@@ -38,6 +38,7 @@ var headroomImage = flag.String("headroom-image", os.Getenv("MOUNTPOINT_HEADROOM
 var mountpointImagePullPolicy = flag.String("mountpoint-image-pull-policy", os.Getenv("MOUNTPOINT_IMAGE_PULL_POLICY"), "Pull policy of Mountpoint images.")
 var mountpointContainerCommand = flag.String("mountpoint-container-command", "/bin/aws-s3-csi-mounter", "Entrypoint command of the Mountpoint Pods.")
 var mountpointPodLabels = flag.String("mountpoint-pod-labels", os.Getenv("MOUNTPOINT_POD_LABELS"), "Pod labels to apply to Mountpoint Pods (JSON format).")
+var mountpointPodAnnotations = flag.String("mountpoint-pod-annotations", os.Getenv("MOUNTPOINT_POD_ANNOTATIONS"), "Pod annotations to apply to Mountpoint Pods (JSON format).")
 var mountpointHeadroomPodLabels = flag.String("mountpoint-headroom-pod-labels", os.Getenv("MOUNTPOINT_HEADROOM_POD_LABELS"), "Pod labels to apply to Headroom Pods (JSON format).")
 
 var (
@@ -75,6 +76,7 @@ func main() {
 	}
 
 	podLabels := util.ParseLabels(*mountpointPodLabels, log)
+	podAnnotations := util.ParseAnnotations(*mountpointPodAnnotations, log)
 	headroomPodLabels := util.ParseLabels(*mountpointHeadroomPodLabels, log)
 
 	reconciler := csicontroller.NewReconciler(mgr.GetClient(), mppod.Config{
@@ -92,6 +94,7 @@ func main() {
 		CSIDriverVersion:  version.GetVersion().DriverVersion,
 		ClusterVariant:    cluster.DetectVariant(conf, log),
 		PodLabels:         podLabels,
+		PodAnnotations:    podAnnotations,
 		HeadroomPodLabels: headroomPodLabels,
 	}, log)
 

--- a/pkg/podmounter/mppod/creator.go
+++ b/pkg/podmounter/mppod/creator.go
@@ -86,6 +86,7 @@ type Config struct {
 	Container                   ContainerConfig
 	CSIDriverVersion            string
 	PodLabels                   map[string]string
+	PodAnnotations              map[string]string
 	HeadroomPodLabels           map[string]string
 }
 
@@ -112,17 +113,20 @@ func (c *Creator) MountpointPod(node string, pv *corev1.PersistentVolume, priori
 	labels := maps.Clone(c.config.PodLabels)
 	labels[LabelMountpointVersion] = c.config.MountpointVersion
 	labels[LabelCSIDriverVersion] = c.config.CSIDriverVersion
+	annotations := maps.Clone(c.config.PodAnnotations)
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[AnnotationVolumeName] = pv.Name
+	annotations[AnnotationVolumeId] = pv.Spec.CSI.VolumeHandle
+	annotations[AnnotationClusterAutoscalerDaemonsetPod] = "true"
 
 	mpPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "mp-",
 			Namespace:    c.config.Namespace,
 			Labels:       labels,
-			Annotations: map[string]string{
-				AnnotationVolumeName:                    pv.Name,
-				AnnotationVolumeId:                      pv.Spec.CSI.VolumeHandle,
-				AnnotationClusterAutoscalerDaemonsetPod: "true",
-			},
+			Annotations:  annotations,
 		},
 		Spec: corev1.PodSpec{
 			NodeSelector: map[string]string{

--- a/pkg/podmounter/mppod/creator_test.go
+++ b/pkg/podmounter/mppod/creator_test.go
@@ -270,6 +270,7 @@ func createTestConfig(clusterVariant cluster.Variant) mppod.Config {
 		CSIDriverVersion:  csiDriverVersion,
 		ClusterVariant:    clusterVariant,
 		PodLabels:         map[string]string{},
+		PodAnnotations:    map[string]string{},
 		HeadroomPodLabels: map[string]string{},
 	}
 }
@@ -1007,5 +1008,53 @@ func TestPodLabels(t *testing.T) {
 		assert.Equals(t, string(workloadPod.UID), hrPod.Labels[mppod.LabelHeadroomForPod])
 		assert.Equals(t, testVolName, hrPod.Labels[mppod.LabelHeadroomForVolume])
 		assert.Equals(t, 2, len(hrPod.Labels))
+	})
+}
+
+func TestPodAnnotations(t *testing.T) {
+	t.Run("Configured annotations", func(t *testing.T) {
+		config := createTestConfig(cluster.DefaultKubernetes)
+		config.PodAnnotations = map[string]string{
+			"example.com/exclude":                         "true",
+			mppod.AnnotationVolumeName:                    "should-be-overridden",
+			mppod.AnnotationClusterAutoscalerDaemonsetPod: "false",
+		}
+		creator := mppod.NewCreator(config, testr.New(t))
+
+		pv := &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: testVolName},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{VolumeHandle: testVolID},
+				},
+			},
+		}
+
+		mpPod, err := creator.MountpointPod(testNode, pv, mppod.DefaultPriorityClass)
+		assert.NoError(t, err)
+
+		assert.Equals(t, "true", mpPod.Annotations["example.com/exclude"])
+		assert.Equals(t, testVolName, mpPod.Annotations[mppod.AnnotationVolumeName])
+		assert.Equals(t, testVolID, mpPod.Annotations[mppod.AnnotationVolumeId])
+		assert.Equals(t, "true", mpPod.Annotations[mppod.AnnotationClusterAutoscalerDaemonsetPod])
+	})
+
+	t.Run("Nil annotations", func(t *testing.T) {
+		config := createTestConfig(cluster.DefaultKubernetes)
+		config.PodAnnotations = nil
+		creator := mppod.NewCreator(config, testr.New(t))
+
+		pv := &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: testVolName},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{VolumeHandle: testVolID},
+				},
+			},
+		}
+
+		mpPod, err := creator.MountpointPod(testNode, pv, mppod.DefaultPriorityClass)
+		assert.NoError(t, err)
+		assert.Equals(t, 3, len(mpPod.Annotations))
 	})
 }

--- a/pkg/util/annotations.go
+++ b/pkg/util/annotations.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// ParseAnnotations parses a JSON string into a map of annotations and validates their keys.
+// Returns an empty map if the input is empty or invalid JSON.
+func ParseAnnotations(annotationsJSON string, log logr.Logger) map[string]string {
+	if annotationsJSON == "" || annotationsJSON == "{}" || annotationsJSON == "null" {
+		return map[string]string{}
+	}
+
+	var annotations map[string]string
+	if err := json.Unmarshal([]byte(annotationsJSON), &annotations); err != nil {
+		log.Error(err, "Failed to parse annotations JSON, ignoring", "json", annotationsJSON)
+		return map[string]string{}
+	}
+
+	validAnnotations := make(map[string]string)
+	for key, value := range annotations {
+		if strings.HasPrefix(key, ReservedLabelPrefix) {
+			log.Info("Skipping annotation with reserved prefix", "key", key, "prefix", ReservedLabelPrefix)
+			continue
+		}
+
+		if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+			log.Info("Skipping annotation with invalid key", "key", key, "errors", strings.Join(errs, "; "))
+			continue
+		}
+
+		validAnnotations[key] = value
+	}
+
+	return validAnnotations
+}

--- a/pkg/util/annotations_test.go
+++ b/pkg/util/annotations_test.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/util/testutil/assert"
+	"github.com/go-logr/logr/testr"
+)
+
+func TestParseAnnotations(t *testing.T) {
+	t.Run("Valid annotations", func(t *testing.T) {
+		longValue := strings.Repeat("a", 128)
+		annotationsJSON := `{"example.com/exclude":"true","description":"` + longValue + `"}`
+
+		annotations := ParseAnnotations(annotationsJSON, testr.New(t))
+
+		assert.Equals(t, 2, len(annotations))
+		assert.Equals(t, "true", annotations["example.com/exclude"])
+		assert.Equals(t, longValue, annotations["description"])
+	})
+
+	t.Run("Reserved prefix is rejected", func(t *testing.T) {
+		annotationsJSON := `{"example.com/exclude":"true","s3.csi.aws.com/volume-name":"override"}`
+
+		annotations := ParseAnnotations(annotationsJSON, testr.New(t))
+
+		assert.Equals(t, 1, len(annotations))
+		assert.Equals(t, "true", annotations["example.com/exclude"])
+	})
+
+	t.Run("Invalid keys are filtered out", func(t *testing.T) {
+		annotationsJSON := `{"example.com/exclude":"true","invalid key with spaces":"value"}`
+
+		annotations := ParseAnnotations(annotationsJSON, testr.New(t))
+
+		assert.Equals(t, 1, len(annotations))
+		assert.Equals(t, "true", annotations["example.com/exclude"])
+	})
+
+	t.Run("Invalid JSON is ignored", func(t *testing.T) {
+		annotations := ParseAnnotations(`{"example.com/exclude":`, testr.New(t))
+
+		assert.Equals(t, 0, len(annotations))
+	})
+}


### PR DESCRIPTION
*Issue #, if available:*

#804

*Description of changes:*

Mountpoint Pods are created dynamically by the controller, so the Helm chart's existing pod metadata options cannot annotate them. This prevents operators from excluding Mountpoint Pods from third-party controllers or attaching other integration metadata.

This change:

- adds `mountpointPod.podAnnotations` to the Helm values
- forwards the map to the controller as JSON and validates annotation keys
- applies configured annotations to dynamically created Mountpoint Pods
- keeps driver-managed annotations authoritative when keys conflict
- covers parsing, nil configuration, user annotations, and reserved-key precedence with unit tests

Validation:

- `go test ./pkg/util -run '^TestParseAnnotations$' -count=1`
- `go test ./pkg/podmounter/mppod -run '^(TestPodAnnotations|TestPodLabels)$' -count=1`
- `helm lint charts/aws-mountpoint-s3-csi-driver --set isHelmRepo=true`
- rendered the chart with `mountpointPod.podAnnotations.example.com/exclude=true` and asserted the controller receives the expected `MOUNTPOINT_POD_ANNOTATIONS` JSON
- `git diff --check`

Closes #804

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
