### PR TITLE
Expose controller replica count in Helm configuration

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,6 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
+    - name: Verify Helm controller replicas
+      run: |
+        helm template standard charts/aws-mountpoint-s3-csi-driver --set controller.replicaCount=3 --show-only templates/controller.yaml | grep -q '^  replicas: 3$'
+        helm template addon charts/aws-mountpoint-s3-csi-driver --set isEKSAddon=true --set controller.replicaCount=3 --show-only templates/controller.yaml | grep -q '^  replicas: 3$'
+
     - name: Set up Go
       uses: actions/setup-go@v7
       with:

--- a/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/controller.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "aws-mountpoint-s3-csi-driver.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.controller.replicaCount }}
   selector:
     matchLabels:
       app: s3-csi-controller

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -87,6 +87,7 @@ sidecars:
     resources: {}
 
 controller:
+  replicaCount: 1
   # Consider deploying the controller component to special nodes for controller components.
   # See https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md#configuring-nodeSelector-for-the-controller-component for more details.
   # For example:


### PR DESCRIPTION
*Issue #, if available:* #885

*Description of changes:*
- add controller.replicaCount with a default of 1
- use the configured value for the controller Deployment replica count
- add CI regression coverage for standard Helm and EKS add-on rendering

*Testing:*
- helm lint charts/aws-mountpoint-s3-csi-driver
- verified the default chart renders one controller replica
- verified standard Helm and EKS add-on rendering honor controller.replicaCount=3
- rendered the complete chart in standard and EKS add-on modes
- make check_style
- git diff --check

Closes #885

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.