### PR TITLE
Backport docker e2e tests to v1

### DIFF
--- a/.github/workflows/e2e-test-trusted.yaml
+++ b/.github/workflows/e2e-test-trusted.yaml
@@ -22,7 +22,7 @@ jobs:
     secrets: inherit
   outcome:
     name: All E2E Tests Passed
-    if: always()
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id) }}
     runs-on: ubuntu-latest
     needs:
       - e2e

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,9 @@ test:
 	# skipping controller test cases because we don't implement controller for static provisioning,
 	# this is a known limitation of sanity testing package: https://github.com/kubernetes-csi/csi-test/issues/214
 	go test -v ./tests/sanity/... -ginkgo.skip="ControllerGetCapabilities" -ginkgo.skip="ValidateVolumeCapabilities"
+	# Run unit tests in e2e-kubernetes (image override, parsing, etc.) without requiring a cluster.
+	# TestE2E is the Ginkgo e2e suite entry point which requires a live cluster, so we skip it.
+	cd tests/e2e-kubernetes && go test -v -skip TestE2E ./...
 
 .PHONY: cover
 cover:

--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -2,10 +2,13 @@ package e2e
 
 import (
 	"flag"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/awslabs/mountpoint-s3-csi-driver/tests/e2e-kubernetes/s3client"
 	custom_testsuites "github.com/awslabs/mountpoint-s3-csi-driver/tests/e2e-kubernetes/testsuites"
+	"github.com/distribution/reference"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -13,6 +16,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 func init() {
@@ -35,6 +39,40 @@ func init() {
 	custom_testsuites.ClusterName = ClusterName
 	custom_testsuites.IMDSAvailable = IMDSAvailable
 	custom_testsuites.IsPodMounter = IsPodMounter
+
+	// Override the upstream K8s e2e framework's default test image (BusyBox) with
+	// our TEST_POD_IMAGE so that tests like InitVolumesTestSuite use an image
+	// accessible from all regions instead of registry.k8s.io.
+	overrideUpstreamTestImage()
+}
+
+func overrideUpstreamTestImage() {
+	img := os.Getenv("TEST_POD_IMAGE")
+	if img == "" {
+		img = "public.ecr.aws/amazonlinux/amazonlinux:2023"
+	}
+
+	ref, err := reference.Parse(img)
+	if err != nil {
+		panic(fmt.Sprintf("overrideUpstreamTestImage: invalid image reference %q: %v", img, err))
+	}
+
+	named, ok := ref.(reference.Named)
+	if !ok {
+		panic(fmt.Sprintf("overrideUpstreamTestImage: image reference %q has no name", img))
+	}
+
+	version := "latest"
+	if tagged, ok := ref.(reference.Tagged); ok {
+		version = tagged.Tag()
+	}
+
+	configs := imageutils.GetImageConfigs()
+	cfg := configs[imageutils.BusyBox]
+	cfg.SetRegistry(reference.Domain(named))
+	cfg.SetName(reference.Path(named))
+	cfg.SetVersion(version)
+	configs[imageutils.BusyBox] = cfg
 }
 
 func TestE2E(t *testing.T) {

--- a/tests/e2e-kubernetes/go.mod
+++ b/tests/e2e-kubernetes/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
+	github.com/distribution/reference v0.6.0
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/tests/e2e-kubernetes/image_override_test.go
+++ b/tests/e2e-kubernetes/image_override_test.go
@@ -1,0 +1,35 @@
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+func TestOverrideUpstreamTestImage(t *testing.T) {
+	// init() has already called overrideUpstreamTestImage(), so verify that the
+	// upstream BusyBox image config reflects our TEST_POD_IMAGE (or the default).
+	expectedImage := os.Getenv("TEST_POD_IMAGE")
+	if expectedImage == "" {
+		expectedImage = "public.ecr.aws/amazonlinux/amazonlinux:2023"
+	}
+
+	t.Run("imageutils returns overridden image", func(t *testing.T) {
+		got := imageutils.GetE2EImage(imageutils.BusyBox)
+		if got != expectedImage {
+			t.Errorf("GetE2EImage(BusyBox) = %q, want %q", got, expectedImage)
+		}
+	})
+
+	t.Run("e2epod.MakePod uses overridden image", func(t *testing.T) {
+		pod := e2epod.MakePod("default", nil, nil, admissionapi.LevelBaseline, "")
+		for _, container := range pod.Spec.Containers {
+			if container.Image != expectedImage {
+				t.Errorf("e2epod.MakePod() container image = %q, want %q", container.Image, expectedImage)
+			}
+		}
+	})
+}

--- a/tests/e2e-kubernetes/s3client/client.go
+++ b/tests/e2e-kubernetes/s3client/client.go
@@ -4,6 +4,7 @@ package s3client
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
 // DefaultRegion is the default AWS region to use if unspecified.
@@ -78,12 +80,22 @@ func (c *Client) CreateStandardBucket(ctx context.Context) (string, DeleteBucket
 	return bucketName, c.create(ctx, input)
 }
 
+// expressAZ returns the S3 Express availability zone for the client's region.
+// It checks the S3_EXPRESS_AZ environment variable first, allowing callers to override
+// the built-in map for regions not yet in the hardcoded list.
+func (c *Client) expressAZ() string {
+	if az := os.Getenv("S3_EXPRESS_AZ"); az != "" {
+		return az
+	}
+	return expressAZs[c.region]
+}
+
 // CreateDirectoryBucket creates a new directory S3 bucket with a random name (by following
 // "Directory bucket naming rules") and returns the bucket name and a clean up function.
 func (c *Client) CreateDirectoryBucket(ctx context.Context) (string, DeleteBucketFunc) {
-	regionAz := expressAZs[c.region]
+	regionAz := c.expressAZ()
 	if regionAz == "" {
-		framework.Failf("Unknown S3 Express region %s\n", c.region)
+		e2eskipper.Skipf("Unknown S3 Express region %s\n", c.region)
 	}
 
 	// refer to s3 express bucket naming conventions

--- a/tests/e2e-kubernetes/scripts/eks-addon/Dockerfile
+++ b/tests/e2e-kubernetes/scripts/eks-addon/Dockerfile
@@ -1,0 +1,87 @@
+# Note that all dependencies are compiled here, since isolated regions
+# won't be able to pull dependencies over internet at run time.
+
+ARG GO_VERSION
+
+FROM public.ecr.aws/eks-distro-build-tooling/golang:${GO_VERSION}-al23 AS builder
+ARG GINKGO_VERSION
+
+ENV GOPROXY=direct
+
+WORKDIR /src
+COPY . .
+
+# Compile the e2e test binary
+RUN cd tests/e2e-kubernetes && go test -c -o /e2e.test .
+
+# Install ginkgo CLI
+RUN GOBIN=/usr/local/bin go install github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}
+
+# --- Runtime stage ---
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+# Install AWS CLI and basic utilities
+RUN dnf install -y aws-cli && \
+    dnf clean all
+
+# Install kubectl
+ARG KUBECTL_VERSION=1.33.3
+RUN curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl && mv kubectl /usr/local/bin/
+
+# Copy pre-compiled binaries from builder
+COPY --from=builder /e2e.test /usr/local/bin/e2e.test
+COPY --from=builder /usr/local/bin/ginkgo /usr/local/bin/ginkgo
+
+COPY <<'EOF' /entrypoint.sh
+#!/bin/bash
+set -euo pipefail
+
+# Use service-specific endpoint env var for EKS beta/gamma endpoint override.
+# This avoids --endpoint-url CLI flag which is unreliable across AWS CLI versions.
+# AWS_ENDPOINT_URL_EKS only affects EKS calls, not S3/STS/CloudWatch/etc.
+if [[ -n "${EKS_ENDPOINT:-}" ]]; then
+    export AWS_ENDPOINT_URL_EKS="${EKS_ENDPOINT}"
+    echo "EKS Endpoint: ${EKS_ENDPOINT} (via AWS_ENDPOINT_URL_EKS)"
+fi
+if [[ -n "${EKS_AUTH_ENDPOINT:-}" ]]; then
+    export AWS_ENDPOINT_URL_EKS_AUTH="${EKS_AUTH_ENDPOINT}"
+    echo "EKS Auth Endpoint: ${AWS_ENDPOINT_URL_EKS_AUTH} (via AWS_ENDPOINT_URL_EKS_AUTH)"
+fi
+if [[ -n "${TEST_IMAGE_URI:-}" ]]; then
+    export TEST_POD_IMAGE="${TEST_IMAGE_URI}"
+    echo "TEST_POD_IMAGE: ${TEST_POD_IMAGE}"
+fi
+
+export KUBECONFIG="/tmp/kubeconfig"
+echo "${KUBECONFIG_BASE64}" | base64 -d > "${KUBECONFIG}"
+
+aws eks create-addon --addon-name aws-mountpoint-s3-csi-driver \
+	    --cluster-name "$CLUSTER_NAME" --region "$REGION" \
+	    --addon-version "$ADDON_VERSION"
+
+# Wait for addons to become active
+echo "Waiting for aws-mountpoint-s3-csi-driver addon to become active..."
+if ! aws eks wait addon-active --addon-name aws-mountpoint-s3-csi-driver \
+    --cluster-name "$CLUSTER_NAME" --region "$REGION"; then
+  echo "ERROR: aws-mountpoint-s3-csi-driver addon did not become active"
+  aws eks describe-addon --addon-name aws-mountpoint-s3-csi-driver \
+      --cluster-name "$CLUSTER_NAME" --region "$REGION" 2>&1 || true
+  kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-mountpoint-s3-csi-driver -o wide 2>&1 || true
+  exit 1
+fi
+
+exec ginkgo -vv -timeout 60m \
+    /usr/local/bin/e2e.test \
+    -- \
+    --bucket-region="${REGION}" \
+    --commit-id=latest \
+    --bucket-prefix="${CLUSTER_NAME}" \
+    --imds-available=true \
+    --cluster-name="${CLUSTER_NAME}" \
+    --cluster-type=eksctl
+
+EOF
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tests/e2e-kubernetes/scripts/eks-addon/Dockerfile
+++ b/tests/e2e-kubernetes/scripts/eks-addon/Dockerfile
@@ -79,7 +79,7 @@ exec ginkgo -vv -timeout 60m \
     --bucket-prefix="${CLUSTER_NAME}" \
     --imds-available=true \
     --cluster-name="${CLUSTER_NAME}" \
-    --cluster-type=eksctl
+    --pod-mounter=false
 
 EOF
 RUN chmod +x /entrypoint.sh

--- a/tests/e2e-kubernetes/scripts/eks-addon/build_and_push.sh
+++ b/tests/e2e-kubernetes/scripts/eks-addon/build_and_push.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Builds the e2e test image and pushes it to ECR
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --account) AWS_ACCOUNT="$2"; shift 2 ;;
+        --region)  AWS_REGION="$2"; shift 2 ;;
+        --repo)    ECR_REPO="$2"; shift 2 ;;
+        --tag)     IMAGE_TAG="$2"; shift 2 ;;
+        --help)
+            echo "Usage: $0 [--account ID] [--region REGION] [--repo NAME] [--tag TAG]"
+            echo ""
+            echo "Options:"
+            echo "  --account   AWS account ID"
+            echo "  --region    AWS region"
+            echo "  --repo      ECR repository name"
+            echo "  --tag       Image tag"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+ECR_URI="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+FULL_IMAGE="${ECR_URI}/${ECR_REPO}:${IMAGE_TAG}"
+LOCAL_IMAGE="mp-s3-csi-e2e:${IMAGE_TAG}"
+
+echo "=== Configuration ==="
+echo "  Account:  ${AWS_ACCOUNT}"
+echo "  Region:   ${AWS_REGION}"
+echo "  Image:    ${FULL_IMAGE}"
+echo ""
+
+# Authenticate to ECR
+echo "=== Logging in to ECR ==="
+aws ecr get-login-password --region "${AWS_REGION}" | \
+    docker login --username AWS --password-stdin "${ECR_URI}"
+
+# Build
+echo "=== Building image ==="
+"${SCRIPT_DIR}/build_test_image.sh" --output "type=docker,name=${LOCAL_IMAGE}"
+
+# Tag and push
+echo "=== Pushing to ECR ==="
+docker tag "${LOCAL_IMAGE}" "${FULL_IMAGE}"
+docker push "${FULL_IMAGE}"
+
+echo ""
+echo "=== Done ==="
+echo "Image pushed: ${FULL_IMAGE}"
+echo ""
+echo "To use locally, set testImageUris in your run definition:"
+echo "  \"testImageUris\": \"{\\\"${IMAGE_TAG}\\\":\\\"${FULL_IMAGE}\\\"}\""

--- a/tests/e2e-kubernetes/scripts/eks-addon/build_test_image.sh
+++ b/tests/e2e-kubernetes/scripts/eks-addon/build_test_image.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# build_test_image.sh --output <buildx output spec>
+# Builds the e2e test container image.
+# Go and Ginkgo versions are auto-discovered from the source.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output) OUTPUT="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+if [ -z "$OUTPUT" ]; then
+  echo "Usage: $0 --output <buildx output spec>]"
+  echo "Example: $0 --output 'type=oci,dest=out.tar'"
+  echo "         $0 --output 'type=docker'"
+  exit 1
+fi
+
+# Discover versions from source
+GO_VERSION=$(grep '^go ' "$REPO_ROOT/go.mod" | awk '{print $2}')
+GINKGO_VERSION=$(grep 'github.com/onsi/ginkgo/v' "$REPO_ROOT/tests/e2e-kubernetes/go.mod" | awk '{print $2}')
+
+echo "Discovered GO_VERSION=${GO_VERSION}, GINKGO_VERSION=${GINKGO_VERSION}"
+
+docker buildx create --use --driver docker-container
+docker buildx build --platform "linux/amd64" \
+  --build-arg "GO_VERSION=${GO_VERSION}" \
+  --build-arg "GINKGO_VERSION=${GINKGO_VERSION}" \
+  --output "$OUTPUT" \
+  -f "$REPO_ROOT/tests/e2e-kubernetes/scripts/eks-addon/Dockerfile" \
+  "$REPO_ROOT"

--- a/tests/e2e-kubernetes/testsuites/credentials.go
+++ b/tests/e2e-kubernetes/testsuites/credentials.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	goerrors "errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -73,6 +74,9 @@ const credentialSecretName = "aws-secret"
 
 const serviceAccountTokenAudienceEKS = "pods.eks.amazonaws.com"
 
+// AWS Service Principal for EKS Pod Identity
+var eksPodsServicePrincipal = determineEksPodsServicePrincipal()
+
 // DefaultRegion specifies the STS region explicitly.
 var DefaultRegion string
 var ClusterName string
@@ -83,6 +87,16 @@ var IMDSAvailable bool
 
 type s3CSICredentialsTestSuite struct {
 	tsInfo storageframework.TestSuiteInfo
+}
+
+func determineEksPodsServicePrincipal() string {
+	const envVarKey = "POD_IDENTITY_SERVICE_PRINCIPAL"
+	fromEnv := strings.TrimSpace(os.Getenv(envVarKey))
+	if len(fromEnv) == 0 {
+		return "pods.eks.amazonaws.com"
+	} else {
+		return fromEnv
+	}
 }
 
 func InitS3CSICredentialsTestSuite() storageframework.TestSuite {
@@ -1003,7 +1017,7 @@ func eksPodIdentityRoleTrustPolicyDocument() string {
 			{
 				"Effect": "Allow",
 				"Principal": jsonMap{
-					"Service": serviceAccountTokenAudienceEKS,
+					"Service": eksPodsServicePrincipal,
 				},
 				"Action": []string{"sts:AssumeRole", "sts:TagSession"},
 			},
@@ -1021,12 +1035,12 @@ func getARNPartition(arn string) string {
 }
 
 func createRole(ctx context.Context, f *framework.Framework, assumeRolePolicyDocument string, policyNames ...string) (*iamtypes.Role, func(context.Context) error) {
-	framework.Logf("Creating IAM role")
 	identity := stsCallerIdentity(ctx)
 
 	client := iam.NewFromConfig(awsConfig(ctx))
 
 	roleName := fmt.Sprintf("%s-%s", f.BaseName, uuid.NewString())
+	framework.Logf("Creating IAM role '%s' with assumeRolePolicyDocument \"%s\"", roleName, assumeRolePolicyDocument)
 	role, err := client.CreateRole(ctx, &iam.CreateRoleInput{
 		RoleName:                 new(roleName),
 		AssumeRolePolicyDocument: new(assumeRolePolicyDocument),
@@ -1034,7 +1048,7 @@ func createRole(ctx context.Context, f *framework.Framework, assumeRolePolicyDoc
 	framework.ExpectNoError(err)
 
 	deleteRole := func(ctx context.Context) error {
-		framework.Logf("Deleting IAM role")
+		framework.Logf("Deleting IAM role '%s'", roleName)
 		_, err := client.DeleteRole(ctx, &iam.DeleteRoleInput{
 			RoleName: new(roleName),
 		})


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Backport conversion of e2e test suite to being docker compatible to V1. 

We only needed to change how ginkgo is launched compared to v2 as we changed some options.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
