### PR TITLE
Bump net, text, mod, and grpc gomod deps

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         description: "Only used if `run_upgrade_tests` is true, specifies the new version to test upgrade to."
+      upgrade_tests_is_major_version_upgrade:
+        required: false
+        type: boolean
+        description: "Only used if `run_upgrade_tests` is true. Set true when the upgrade crosses a major version boundary; terminates new-version workloads (Set D) before rollback since they can't survive a rollback to the previous major version."
 
 concurrency:
   group: e2e-cluster-${{ inputs.environment }}
@@ -96,6 +100,7 @@ jobs:
       SELINUX_MODE: "${{ matrix.selinux-mode }}"
       MOUNTPOINT_CSI_DRIVER_PREVIOUS_VERSION: "${{ inputs.upgrade_tests_old_version }}"
       MOUNTPOINT_CSI_DRIVER_NEW_VERSION: "${{ inputs.upgrade_tests_new_version }}"
+      MOUNTPOINT_CSI_DRIVER_IS_MAJOR_VERSION_UPGRADE: "${{ inputs.upgrade_tests_is_major_version_upgrade }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/e2e-upgrade-test.yaml
+++ b/.github/workflows/e2e-upgrade-test.yaml
@@ -7,6 +7,10 @@ on:
         description: "Previous version to upgrade from (e.g., 1.14.1)"
       new_version:
         description: "New version to upgrade to (e.g., 2.0.0-beta)"
+      is_major_version_upgrade:
+        description: "Set true when the upgrade crosses a major version boundary (e.g. 1.x -> 2.x). Terminates new-version workloads before rollback instead of keeping them, since they can't survive a rollback to the previous major version."
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -22,4 +26,5 @@ jobs:
       run_upgrade_tests: true
       upgrade_tests_old_version: "${{ inputs.old_version }}"
       upgrade_tests_new_version: "${{ inputs.new_version }}"
+      upgrade_tests_is_major_version_upgrade: ${{ inputs.is_major_version_upgrade }}
     secrets: inherit

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -77,6 +77,13 @@ var helmChartNewVersion = os.Getenv("MOUNTPOINT_CSI_DRIVER_NEW_VERSION")
 var helmChartContainerRepository = os.Getenv("REPOSITORY")
 var helmChartContainerTag = os.Getenv("TAG")
 
+// isMajorVersionUpgrade indicates the upgrade crosses a major version boundary, so rolling
+// the driver back to the previous major version cannot serve mounts created by the new major
+// version. In that case, workloads created on the new version (Set D) cannot survive the
+// rollback and must be terminated before it. Defaults to false (same-major upgrade), where
+// Set D is kept through the rollback and monitored to verify existing workloads survive.
+var isMajorVersionUpgrade = os.Getenv("MOUNTPOINT_CSI_DRIVER_IS_MAJOR_VERSION_UPGRADE") == "true"
+
 // tokenExpirationPostRenderer patches CSIDriver and ServiceAccount to use shorter token expiration for tests
 type tokenExpirationPostRenderer struct {
 	expirationSeconds int64
@@ -378,7 +385,18 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 		for _, pod := range slices.Concat(fullAccessPodsSetB, readOnlyAccessPodsSetB, fullAccessPodsSetC, readOnlyAccessPodsSetC) {
 			e2epod.DeletePodWithWait(ctx, f.ClientSet, pod)
 		}
-		framework.Logf("Set B and Set C terminated successfully. Set A and Set D remain running.")
+		framework.Logf("Set B and Set C terminated successfully.")
+		// Set D was created on the new version. On a MAJOR version upgrade, rolling the driver
+		// back to the previous major version cannot serve mounts created by the new major
+		// version, so Set D must be terminated before rollback.
+		if isMajorVersionUpgrade {
+			framework.Logf("Major version upgrade: Set A remains running, terminating Set D workloads before rollback (new-version workloads can't survive rollback to the previous major)...")
+			for _, pod := range slices.Concat(fullAccessPodsSetD, readOnlyAccessPodsSetD) {
+				e2epod.DeletePodWithWait(ctx, f.ClientSet, pod)
+			}
+		} else {
+			framework.Logf("Set A and Set D remain running.")
+		}
 
 		framework.Logf("Upgrade phase completed successfully, proceeding to rollback test...")
 
@@ -406,20 +424,28 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 			testFile, testWriteSize, seed = writeAndVerifyTestFile(ctx, fullAccessPodsSetE)
 			verifyReadOnlyAccess(ctx, readOnlyAccessPodsSetE, testFile, testWriteSize, seed)
 
-			// Monitor Set A + D + E for 150 minutes after rollback
-			framework.Logf("Monitoring workloads (Set A + D + E) for %d minutes after rollback...", ROLLBACK_TEST_DURATION_IN_MINUTES)
-
-			allFullAccessAfterRollback := slices.Concat(fullAccessPodsSetA, fullAccessPodsSetD, fullAccessPodsSetE)
-			allReadOnlyAfterRollback := slices.Concat(readOnlyAccessPodsSetA, readOnlyAccessPodsSetD, readOnlyAccessPodsSetE)
+			// Monitor Set A + E (+ Set D on non-major version upgrade runs) after rollback.
+			allFullAccessAfterRollback := slices.Concat(fullAccessPodsSetA, fullAccessPodsSetE)
+			allReadOnlyAfterRollback := slices.Concat(readOnlyAccessPodsSetA, readOnlyAccessPodsSetE)
+			if !isMajorVersionUpgrade {
+				allFullAccessAfterRollback = slices.Concat(allFullAccessAfterRollback, fullAccessPodsSetD)
+				allReadOnlyAfterRollback = slices.Concat(allReadOnlyAfterRollback, readOnlyAccessPodsSetD)
+			}
+			framework.Logf("Monitoring workloads (Set A + E%s) for %d minutes after rollback...",
+				map[bool]string{true: "", false: " + D"}[isMajorVersionUpgrade], ROLLBACK_TEST_DURATION_IN_MINUTES)
 
 			monitorWorkloadsForDuration(ctx, allFullAccessAfterRollback, allReadOnlyAfterRollback, testFile, testWriteSize, seed, ROLLBACK_TEST_DURATION_IN_MINUTES*time.Minute, "rollback", verifyWorkloadHealth)
 
-			// Terminate Set A + D + E (test termination after rollback)
-			framework.Logf("Terminating Set A, Set D, and Set E workloads to test termination after rollback...")
-			for _, pod := range slices.Concat(fullAccessPodsSetA, readOnlyAccessPodsSetA, fullAccessPodsSetD, readOnlyAccessPodsSetD, fullAccessPodsSetE, readOnlyAccessPodsSetE) {
+			// Terminate the monitored workloads (Set A + E, plus Set D on non-downgrade runs).
+			framework.Logf("Terminating post-rollback workloads to test termination after rollback...")
+			podsToTerminate := slices.Concat(fullAccessPodsSetA, readOnlyAccessPodsSetA, fullAccessPodsSetE, readOnlyAccessPodsSetE)
+			if !isMajorVersionUpgrade {
+				podsToTerminate = slices.Concat(podsToTerminate, fullAccessPodsSetD, readOnlyAccessPodsSetD)
+			}
+			for _, pod := range podsToTerminate {
 				e2epod.DeletePodWithWait(ctx, f.ClientSet, pod)
 			}
-			framework.Logf("Set A, Set D, and Set E terminated successfully")
+			framework.Logf("Post-rollback workloads terminated successfully")
 		}()
 
 		// Log rollback outcome with GitHub Actions annotation if failed


### PR DESCRIPTION
*Description of changes:*

```
go get golang.org/x/net@latest golang.org/x/text@latest golang.org/x/mod@latest google.golang.org/grpc@latest
go mod tidy

cd tests/e2e-kubernetes
go get golang.org/x/net@latest golang.org/x/text@latest golang.org/x/mod@latest google.golang.org/grpc@latest
go mod tidy
```

TODO: Cherry pick to release 2.8 branch. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
