### PR TITLE
Add periodic resource cleanup for daemonset mounter

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -140,6 +140,7 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 			klog.Fatalf("Failed to discover mounter pod: %v", err)
 		}
 		go dm.StartCommDirWatch(stopCh)
+		go dm.StartPeriodicCleanup(stopCh)
 
 		maxVolumesPerNode, err := util.GetEnvAsInt(maxVolumesPerNodeEnvName)
 		if err != nil {

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -64,6 +64,12 @@ const (
 	commDirStaleCheckInterval = 1 * time.Second
 	commDirDiscoveryTimeout   = 60 * time.Second
 	commDirRediscoveryTimeout = 15 * time.Second
+
+	// cleanupInterval is how often the periodic cleanup job runs.
+	cleanupInterval = 2 * time.Minute
+
+	// cleanupHealthCheckTimeout caps the source health probe so a frozen FUSE daemon can't stall cleanup.
+	cleanupHealthCheckTimeout = 10 * time.Second
 )
 
 var mounterNamespace = os.Getenv("MOUNTER_NAMESPACE")
@@ -450,19 +456,28 @@ func (dm *DaemonsetMounter) Unmount(ctx context.Context, target string, credenti
 
 // releaseTarget handles the Unmount flow with MountMap refcounting.
 func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string, credentialCtx credentialprovider.CleanupContext) error {
-	entry := dm.mountMap.Get(volumeID)
-	if entry == nil {
-		// No entry means this volume is not tracked (e.g., after CSI node restart without
-		// successful RebuildMountMap recovery). Best-effort unmount the target in case a
-		// stale bind mount still exists in the kernel mount table.
-		klog.V(4).Infof("DaemonsetMounter: no mount map entry for volume %s, best-effort unmount of %s", volumeID, target)
-		if err := dm.unmountIfMounted(target); err != nil {
-			klog.Errorf("DaemonsetMounter: best-effort unmount of untracked target %s failed: %v", target, err)
+	// The periodic cleanup job also deletes entries from the map, so between our
+	// Get and our Lock the entry could be deleted/replaced. Re-check after locking
+	// that we still hold the map's canonical entry; retry if not.
+	var entry *MountEntry
+	for {
+		entry = dm.mountMap.Get(volumeID)
+		if entry == nil {
+			// No entry means this volume is not tracked (e.g., after CSI node restart without
+			// successful RebuildMountMap recovery). Best-effort unmount the target in case a
+			// stale bind mount still exists in the kernel mount table.
+			klog.V(4).Infof("DaemonsetMounter: no mount map entry for volume %s, best-effort unmount of %s", volumeID, target)
+			if err := dm.unmountIfMounted(target); err != nil {
+				klog.Errorf("DaemonsetMounter: best-effort unmount of untracked target %s failed: %v", target, err)
+			}
+			return nil
 		}
-		return nil
+		entry.mu.Lock()
+		if dm.mountMap.Get(volumeID) == entry {
+			break
+		}
+		entry.mu.Unlock() // orphaned entry (deleted by concurrent unmount/cleanup), retry
 	}
-
-	entry.mu.Lock()
 	defer entry.mu.Unlock()
 
 	// Unmount the bind mount at target.
@@ -495,6 +510,113 @@ func (dm *DaemonsetMounter) releaseTarget(target string, volumeID string, creden
 
 	klog.V(4).Infof("DaemonsetMounter: volume %s unmounted from %s", volumeID, target)
 	return nil
+}
+
+// StartPeriodicCleanup runs CleanupOrphans on a ticker until stopCh is closed.
+//
+// It's a safety net for when inline cleanup and startup cleanup miss resources orphaned while the driver keeps running with no operation touching a volume
+// e.g. a cleanup that failed at refcount 0, or a source mount left dead after a mounter-pod crash.
+func (dm *DaemonsetMounter) StartPeriodicCleanup(stopCh <-chan struct{}) {
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-ticker.C:
+			dm.CleanupOrphans()
+		}
+	}
+}
+
+// For each entry, under the entry's lock:
+//   - if the source mount is unhealthy, tear it down;
+//   - otherwise reconcile the refcount against the live bind mounts, and if it drops
+//     to zero, tear it down.
+func (dm *DaemonsetMounter) CleanupOrphans() {
+	dm.mountMap.Range(func(volumeID string, entry *MountEntry) bool {
+		dm.cleanupEntry(volumeID, entry)
+		return true
+	})
+}
+
+// cleanupEntry reconciles and, if needed, tears down a single mount entry.
+func (dm *DaemonsetMounter) cleanupEntry(volumeID string, entry *MountEntry) {
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+
+	// A concurrent unmount may have deleted this entry between the Range read and
+	// the lock. Confirm the map still points to this exact entry; if not, skip it.
+	if dm.mountMap.Get(volumeID) != entry {
+		return
+	}
+
+	// An empty SourcePath means GetOrCreate inserted a blank entry that has not been
+	// given a mount yet (mid-creation). Nothing to clean, so leave it.
+	if entry.SourcePath == "" {
+		return
+	}
+
+	mountInfos, err := dm.mountInfoProviderWithDefault()
+	if err != nil {
+		klog.Errorf("DaemonsetMounter: cleanup: failed to read mount table for volume %s: %v", volumeID, err)
+		return
+	}
+
+	sourceMI := findMountByPath(mountInfos, entry.SourcePath)
+	if sourceMI == nil {
+		// Source is gone from the mount table — no bind mounts can reference it, so
+		// it's a true orphan (e.g. a crash between writing meta and creating the mount).
+		klog.V(2).Infof("DaemonsetMounter: cleanup: source %s for volume %s not in mount table, cleaning up", entry.SourcePath, volumeID)
+		dm.teardownEntry(volumeID, entry)
+		return
+	}
+
+	// Being in the mount table doesn't mean the source still works — a crashed mounter leaves
+	// a dead FUSE mount that lingers but errors on every I/O. So we probe it (with a timeout so
+	// a frozen daemon can't stall the pass). If it's dead, tear it down and reclaim its resources;
+	// if we can't tell, leave it alone rather than risk destroying a source still serving a workload.
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupHealthCheckTimeout)
+	healthy, healthErr := dm.IsSourceHealthy(ctx, entry.SourcePath)
+	cancel()
+	switch {
+	case healthErr != nil:
+		klog.V(4).Infof("DaemonsetMounter: cleanup: source health unknown for volume %s (%v), leaving intact", volumeID, healthErr)
+		return
+	case !healthy:
+		klog.V(2).Infof("DaemonsetMounter: cleanup: source %s for volume %s is dead, cleaning up", entry.SourcePath, volumeID)
+		dm.teardownEntry(volumeID, entry)
+		return
+	}
+
+	liveTargets := findBindMountTargets(mountInfos, deviceID(sourceMI), entry.SourcePath)
+
+	// Sync targets and refcount to the kernel mount table (the source of truth for who is actually bind-mounted).
+	entry.Targets = liveTargets
+	entry.RefCount = len(liveTargets)
+
+	// If the kernel shows zero bind mounts on this source, nobody's using it — tear it down.
+	if len(liveTargets) == 0 {
+		klog.V(2).Infof("DaemonsetMounter: cleanup: volume %s has no remaining consumers, cleaning up", volumeID)
+		dm.teardownEntry(volumeID, entry)
+		return
+	}
+
+	// Source still in use — leave it. Logged (V4) so a healthy-volume pass is observable.
+	klog.V(4).Infof("DaemonsetMounter: cleanup: volume %s healthy with %d live consumer(s), leaving intact", volumeID, len(liveTargets))
+}
+
+// teardownEntry runs cleanupMount and, only on success, removes the in-memory
+// entry and then its meta file (entry before meta, matching the other teardown
+// paths). On failure both are kept so a later pass retries. Caller must hold entry.mu.
+func (dm *DaemonsetMounter) teardownEntry(volumeID string, entry *MountEntry) {
+	cleanupCtx := credentialprovider.CleanupContext{VolumeID: volumeID}
+	if err := dm.cleanupMount(entry, cleanupCtx); err != nil {
+		klog.Errorf("DaemonsetMounter: cleanup: %v (will retry next tick)", err)
+		return
+	}
+	dm.mountMap.Delete(volumeID)
+	RemoveMeta(dm.kubeletPath, volumeID)
 }
 
 // GetErrorFileName returns the error file name for a given volume ID.

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -581,7 +581,7 @@ func (dm *DaemonsetMounter) cleanupEntry(volumeID string, entry *MountEntry) {
 	cancel()
 	switch {
 	case healthErr != nil:
-		klog.V(4).Infof("DaemonsetMounter: cleanup: source health unknown for volume %s (%v), leaving intact", volumeID, healthErr)
+		klog.Errorf("DaemonsetMounter: cleanup: source health unknown for volume %s (%v), leaving intact", volumeID, healthErr)
 		return
 	case !healthy:
 		klog.V(2).Infof("DaemonsetMounter: cleanup: source %s for volume %s is dead, cleaning up", entry.SourcePath, volumeID)

--- a/pkg/driver/node/mounter/mount_map.go
+++ b/pkg/driver/node/mounter/mount_map.go
@@ -149,6 +149,16 @@ func (m *MountMap) Delete(volumeID string) {
 	m.entries.Delete(volumeID)
 }
 
+// Range iterates every entry in the map, letting the cleanup job loop over every
+// tracked mount. Return false from fn to stop early.
+// Note: the entry pointer may change under a concurrent mount/unmount, so callers
+// must still lock it and re-check before acting.
+func (m *MountMap) Range(fn func(volumeID string, entry *MountEntry) bool) {
+	m.entries.Range(func(k, v any) bool {
+		return fn(k.(string), v.(*MountEntry))
+	})
+}
+
 // SourceMountPath returns the source mount directory for a given volume.
 // This path is stable across pod lifecycles — it's keyed by volume, not pod.
 func SourceMountPath(kubeletPath, volumeID string) string {

--- a/pkg/driver/node/mounter/mount_map_persistence_test.go
+++ b/pkg/driver/node/mounter/mount_map_persistence_test.go
@@ -688,9 +688,10 @@ func TestCleanupOrphans(t *testing.T) {
 		// mountInfo is the fake kernel mount table for this case.
 		mountInfo func(sourcePath, targetA string) []mountutils.MountInfo
 
-		expectEntryGone bool // map entry removed
-		expectMetaGone  bool // meta file removed
-		expectRefCount  int  // asserted when the entry survives
+		expectEntryGone   bool // map entry removed
+		expectMetaGone    bool // meta file removed
+		expectMetaPresent bool // meta file must remain — a surviving entry relies on it to rebuild the map after a CSI node restart
+		expectRefCount    int  // asserted when the entry survives
 	}{
 		{
 			// Dead source (nothing in the mount table): source, creds, error file,
@@ -715,7 +716,8 @@ func TestCleanupOrphans(t *testing.T) {
 			setup: func(t *testing.T, dm *DaemonsetMounter, fakeMounter *mountutils.FakeMounter, kubeletPath, sourcePath, targetA string) {
 				targetB := filepath.Join(kubeletPath, "pods", "wl-b", "mount")
 				registerSourceMount(t, fakeMounter, sourcePath)
-				seedEntry(dm, volumeID, sourcePath, "", []string{targetA, targetB})
+				entry := seedEntry(dm, volumeID, sourcePath, "", []string{targetA, targetB})
+				assert.NoError(t, WriteMeta(kubeletPath, entry))
 			},
 			mountInfo: func(sourcePath, targetA string) []mountutils.MountInfo {
 				return []mountutils.MountInfo{ // targetB is gone from the kernel
@@ -723,7 +725,8 @@ func TestCleanupOrphans(t *testing.T) {
 					{MountPoint: targetA, Major: 0, Minor: 42},
 				}
 			},
-			expectRefCount: 1,
+			expectRefCount:    1,
+			expectMetaPresent: true,
 		},
 		{
 			// Teardown's cleanupMount fails (unmount errors): the entry and meta are
@@ -738,7 +741,8 @@ func TestCleanupOrphans(t *testing.T) {
 			mountInfo: func(sourcePath, _ string) []mountutils.MountInfo {
 				return []mountutils.MountInfo{{MountPoint: sourcePath, Major: 0, Minor: 42}}
 			},
-			expectRefCount: 0, // entry survives (not torn down)
+			expectRefCount:    0, // entry survives (not torn down)
+			expectMetaPresent: true,
 		},
 		{
 			// Healthy source, no bind mounts left in the kernel: torn down.
@@ -758,9 +762,10 @@ func TestCleanupOrphans(t *testing.T) {
 			// The source is healthy and the kernel shows a live bind mount that we are not
 			// tracking. Cleanup adopts it, so the refcount becomes 1 and the source is kept.
 			name: "untracked live bind mount adopted not torn down",
-			setup: func(t *testing.T, dm *DaemonsetMounter, fakeMounter *mountutils.FakeMounter, _, sourcePath, _ string) {
-				registerSourceMount(t, fakeMounter, sourcePath) // source is healthy
-				seedEntry(dm, volumeID, sourcePath, "", nil)    // we track no targets
+			setup: func(t *testing.T, dm *DaemonsetMounter, fakeMounter *mountutils.FakeMounter, kubeletPath, sourcePath, _ string) {
+				registerSourceMount(t, fakeMounter, sourcePath)       // source is healthy
+				entry := seedEntry(dm, volumeID, sourcePath, "", nil) // we track no targets
+				assert.NoError(t, WriteMeta(kubeletPath, entry))
 			},
 			mountInfo: func(sourcePath, targetA string) []mountutils.MountInfo {
 				return []mountutils.MountInfo{
@@ -768,7 +773,8 @@ func TestCleanupOrphans(t *testing.T) {
 					{MountPoint: targetA, Major: 0, Minor: 42}, // untracked but live
 				}
 			},
-			expectRefCount: 1,
+			expectRefCount:    1,
+			expectMetaPresent: true,
 		},
 		{
 			// A dead source still in the mount table with a live tracked target (mounter
@@ -822,6 +828,11 @@ func TestCleanupOrphans(t *testing.T) {
 			}
 			if tt.expectMetaGone {
 				assert.Equals(t, true, os.IsNotExist(statErr(MetaFileName(kubeletPath, volumeID))))
+			}
+			if tt.expectMetaPresent {
+				// A surviving entry must keep its meta file — RebuildMountMap relies on it
+				// to recover this mount after a CSI node restart.
+				assert.NoError(t, statErr(MetaFileName(kubeletPath, volumeID)))
 			}
 		})
 	}

--- a/pkg/driver/node/mounter/mount_map_persistence_test.go
+++ b/pkg/driver/node/mounter/mount_map_persistence_test.go
@@ -46,14 +46,22 @@ func newTestDMWithMountInfo(kubeletPath string, provider mountInfoProviderFunc) 
 // newTestDMWithMountInfoAndCredProvider creates a DaemonsetMounter with a no-op credential
 // provider and fake mounter, suitable for tests that exercise cleanupMount during rebuild.
 func newTestDMWithMountInfoAndCredProvider(kubeletPath string, provider mountInfoProviderFunc) *DaemonsetMounter {
+	dm, _ := newTestDMWithFakeMounter(kubeletPath, provider)
+	return dm
+}
+
+// newTestDMWithFakeMounter is like newTestDMWithMountInfoAndCredProvider but also returns
+// the underlying FakeMounter, so tests can register healthy mounts that CheckMountpoint sees.
+func newTestDMWithFakeMounter(kubeletPath string, provider mountInfoProviderFunc) (*DaemonsetMounter, *mountutils.FakeMounter) {
 	fakeMounter := mountutils.NewFakeMounter(nil)
-	return &DaemonsetMounter{
+	dm := &DaemonsetMounter{
 		kubeletPath:       kubeletPath,
 		mountInfoProvider: provider,
 		mountMap:          NewMountMap(),
 		mount:             mpmounter.NewWithMount(fakeMounter),
 		credProvider:      &noopCredProvider{},
 	}
+	return dm, fakeMounter
 }
 
 func TestWriteMeta_CreatesFile(t *testing.T) {
@@ -641,4 +649,195 @@ func TestRebuildMountMap_DeadSourceCleansCredentials(t *testing.T) {
 	if !os.IsNotExist(err) {
 		t.Fatal("expected meta file to be removed for dead source")
 	}
+}
+
+// seedEntry inserts a source-mounted entry into the map. i.e pretend a mount already exists
+func seedEntry(dm *DaemonsetMounter, volumeID, sourcePath, commDir string, targets []string) *MountEntry {
+	entry, _ := dm.mountMap.GetOrCreate(volumeID)
+	entry.SourcePath = sourcePath
+	entry.CommDir = commDir
+	entry.Params = MountParams{AuthenticationSource: "driver"}
+	entry.Targets = targets
+	entry.RefCount = len(targets)
+	entry.sourceMounted = true
+	return entry
+}
+
+// registerSourceMount registers the source as a mountpoint mount in the fake
+// mounter and creates its dir, so teardown's unmount path (cleanupMount ->
+// unmountIfMounted -> IsMountPoint/Unmount) has a real mount to act on.
+func registerSourceMount(t *testing.T, fakeMounter *mountutils.FakeMounter, sourcePath string) {
+	t.Helper()
+	assert.NoError(t, os.MkdirAll(sourcePath, 0750))
+	assert.NoError(t, fakeMounter.Mount("mountpoint-s3", sourcePath, "fuse", nil))
+}
+
+func statErr(path string) error {
+	_, err := os.Stat(path)
+	return err
+}
+
+// TestCleanupOrphans covers the periodic cleanup job's per-entry reconcile logic.
+func TestCleanupOrphans(t *testing.T) {
+	const volumeID = "vol-1"
+
+	tests := []struct {
+		name string
+		// setup seeds the map and on-host state for this case.
+		setup func(t *testing.T, dm *DaemonsetMounter, fakeMounter *mountutils.FakeMounter, kubeletPath, sourcePath, targetA string)
+		// mountInfo is the fake kernel mount table for this case.
+		mountInfo func(sourcePath, targetA string) []mountutils.MountInfo
+
+		expectEntryGone bool // map entry removed
+		expectMetaGone  bool // meta file removed
+		expectRefCount  int  // asserted when the entry survives
+	}{
+		{
+			// Dead source (nothing in the mount table): source, creds, error file,
+			// meta, and map entry all removed.
+			name: "dead source torn down",
+			setup: func(t *testing.T, dm *DaemonsetMounter, _ *mountutils.FakeMounter, kubeletPath, sourcePath, _ string) {
+				commDir := filepath.Join(kubeletPath, "comm")
+				assert.NoError(t, os.MkdirAll(filepath.Join(commDir, volumeID), 0750))
+				os.WriteFile(filepath.Join(commDir, volumeID+".error"), []byte("boom"), 0600)
+				entry := seedEntry(dm, volumeID, sourcePath, commDir, nil)
+				assert.NoError(t, WriteMeta(kubeletPath, entry))
+			},
+			mountInfo:       func(_, _ string) []mountutils.MountInfo { return nil },
+			expectEntryGone: true,
+			expectMetaGone:  true,
+		},
+		{
+			// Healthy source: a tracked target the kernel no longer shows is dropped
+			// and the refcount fixed, but the source stays because another target is
+			// still live. (Also covers the "healthy mount left alone" path.)
+			name: "reconciles refcount",
+			setup: func(t *testing.T, dm *DaemonsetMounter, fakeMounter *mountutils.FakeMounter, kubeletPath, sourcePath, targetA string) {
+				targetB := filepath.Join(kubeletPath, "pods", "wl-b", "mount")
+				registerSourceMount(t, fakeMounter, sourcePath)
+				seedEntry(dm, volumeID, sourcePath, "", []string{targetA, targetB})
+			},
+			mountInfo: func(sourcePath, targetA string) []mountutils.MountInfo {
+				return []mountutils.MountInfo{ // targetB is gone from the kernel
+					{MountPoint: sourcePath, Major: 0, Minor: 42},
+					{MountPoint: targetA, Major: 0, Minor: 42},
+				}
+			},
+			expectRefCount: 1,
+		},
+		{
+			// Teardown's cleanupMount fails (unmount errors): the entry and meta are
+			// KEPT so a later tick retries — we must not lose bookkeeping on failure.
+			name: "failed cleanup keeps entry and meta",
+			setup: func(t *testing.T, dm *DaemonsetMounter, fakeMounter *mountutils.FakeMounter, kubeletPath, sourcePath, _ string) {
+				registerSourceMount(t, fakeMounter, sourcePath)
+				fakeMounter.UnmountFunc = func(string) error { return fmt.Errorf("unmount failed") }
+				entry := seedEntry(dm, volumeID, sourcePath, "", nil) // no live targets -> teardown attempted
+				assert.NoError(t, WriteMeta(kubeletPath, entry))
+			},
+			mountInfo: func(sourcePath, _ string) []mountutils.MountInfo {
+				return []mountutils.MountInfo{{MountPoint: sourcePath, Major: 0, Minor: 42}}
+			},
+			expectRefCount: 0, // entry survives (not torn down)
+		},
+		{
+			// Healthy source, no bind mounts left in the kernel: torn down.
+			name: "last consumer gone torn down",
+			setup: func(t *testing.T, dm *DaemonsetMounter, fakeMounter *mountutils.FakeMounter, kubeletPath, sourcePath, _ string) {
+				registerSourceMount(t, fakeMounter, sourcePath)
+				entry := seedEntry(dm, volumeID, sourcePath, "", []string{filepath.Join(kubeletPath, "pods", "gone", "mount")})
+				assert.NoError(t, WriteMeta(kubeletPath, entry))
+			},
+			mountInfo: func(sourcePath, _ string) []mountutils.MountInfo {
+				return []mountutils.MountInfo{{MountPoint: sourcePath, Major: 0, Minor: 42}}
+			},
+			expectEntryGone: true,
+			expectMetaGone:  true,
+		},
+		{
+			// The source is healthy and the kernel shows a live bind mount that we are not
+			// tracking. Cleanup adopts it, so the refcount becomes 1 and the source is kept.
+			name: "untracked live bind mount adopted not torn down",
+			setup: func(t *testing.T, dm *DaemonsetMounter, fakeMounter *mountutils.FakeMounter, _, sourcePath, _ string) {
+				registerSourceMount(t, fakeMounter, sourcePath) // source is healthy
+				seedEntry(dm, volumeID, sourcePath, "", nil)    // we track no targets
+			},
+			mountInfo: func(sourcePath, targetA string) []mountutils.MountInfo {
+				return []mountutils.MountInfo{
+					{MountPoint: sourcePath, Major: 0, Minor: 42},
+					{MountPoint: targetA, Major: 0, Minor: 42}, // untracked but live
+				}
+			},
+			expectRefCount: 1,
+		},
+		{
+			// A dead source still in the mount table with a live tracked target (mounter
+			// crashed, workload pod still running) is torn down: teardown is gated on
+			// source health, not on live targets. The stale target's mount is broken
+			// anyway (recreate the pod to recover); the meta/cred churn a republishing
+			// workload would otherwise cause is stopped in Mount, not here.
+			name: "dead source with live target torn down",
+			setup: func(t *testing.T, dm *DaemonsetMounter, _ *mountutils.FakeMounter, kubeletPath, sourcePath, targetA string) {
+				// Source is not registered as healthy, so the health probe reports it dead.
+				entry := seedEntry(dm, volumeID, sourcePath, "", []string{targetA})
+				assert.NoError(t, WriteMeta(kubeletPath, entry))
+			},
+			mountInfo: func(sourcePath, targetA string) []mountutils.MountInfo {
+				return []mountutils.MountInfo{
+					{MountPoint: sourcePath, Major: 0, Minor: 42},
+					{MountPoint: targetA, Major: 0, Minor: 42},
+				}
+			},
+			expectEntryGone: true,
+			expectMetaGone:  true,
+		},
+		{
+			// A mid-creation placeholder (empty SourcePath) is skipped, not deleted.
+			name: "skips placeholder",
+			setup: func(_ *testing.T, dm *DaemonsetMounter, _ *mountutils.FakeMounter, _, _, _ string) {
+				dm.mountMap.GetOrCreate(volumeID)
+			},
+			mountInfo:      func(_, _ string) []mountutils.MountInfo { return nil },
+			expectRefCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeletPath := t.TempDir()
+			sourcePath := SourceMountPath(kubeletPath, volumeID)
+			targetA := filepath.Join(kubeletPath, "pods", "wl-a", "mount")
+
+			dm, fakeMounter := newTestDMWithFakeMounter(kubeletPath, fakeMountInfoProvider(tt.mountInfo(sourcePath, targetA)))
+			tt.setup(t, dm, fakeMounter, kubeletPath, sourcePath, targetA)
+
+			dm.CleanupOrphans()
+
+			entry := dm.mountMap.Get(volumeID)
+			if tt.expectEntryGone {
+				assert.Equals(t, true, entry == nil)
+			} else {
+				assert.Equals(t, true, entry != nil)
+				assert.Equals(t, tt.expectRefCount, entry.RefCount)
+			}
+			if tt.expectMetaGone {
+				assert.Equals(t, true, os.IsNotExist(statErr(MetaFileName(kubeletPath, volumeID))))
+			}
+		})
+	}
+}
+
+// TestCleanupOrphans_MountTableReadError verifies that if reading the mount table
+// fails, the entry is left untouched rather than acted on with a bad view.
+func TestCleanupOrphans_MountTableReadError(t *testing.T) {
+	kubeletPath := t.TempDir()
+	failingProvider := func() ([]mountutils.MountInfo, error) {
+		return nil, fmt.Errorf("read mountinfo failed")
+	}
+	dm, _ := newTestDMWithFakeMounter(kubeletPath, failingProvider)
+	seedEntry(dm, "vol-1", SourceMountPath(kubeletPath, "vol-1"), "", nil)
+
+	dm.CleanupOrphans()
+
+	assert.Equals(t, true, dm.mountMap.Get("vol-1") != nil)
 }

--- a/pkg/driver/node/mounter/mount_map_test.go
+++ b/pkg/driver/node/mounter/mount_map_test.go
@@ -448,3 +448,20 @@ func TestMountMap_ConcurrentDeleteAndGetOrCreate(t *testing.T) {
 
 	// No panic = success. Final state may or may not have an entry depending on ordering.
 }
+
+// MountMap.Range iterates every tracked mount on the node — it's the primitive
+// the periodic cleanup job uses to walk the map and reconcile each entry. Here, we verify that early-stop is honored.
+func TestMountMap_Range_StopsEarlyOnFalse(t *testing.T) {
+	m := NewMountMap()
+	for _, id := range []string{"vol-1", "vol-2", "vol-3"} {
+		m.GetOrCreate(id)
+	}
+
+	count := 0
+	m.Range(func(volumeID string, entry *MountEntry) bool {
+		count++
+		return false
+	})
+
+	assert.Equals(t, 1, count)
+}

--- a/tests/e2e-kubernetes/e2e_test.go
+++ b/tests/e2e-kubernetes/e2e_test.go
@@ -117,6 +117,7 @@ var CSITestSuites = []func() framework.TestSuite{
 	custom_testsuites.InitS3MountOptionsTestSuite,
 	custom_testsuites.InitS3CSICredentialsTestSuite,
 	custom_testsuites.InitS3CSIPodSharingDaemonsetTestSuite,
+	custom_testsuites.InitS3CSIResourceCleanupDaemonsetTestSuite,
 	custom_testsuites.InitS3CSIVolumeLimitsTestSuite,
 	// TODO: reenable or rewrite when credentials / cache / pod sharing are implemented for daemonset mode
 	// custom_testsuites.InitS3CSICacheTestSuite,

--- a/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
@@ -884,6 +884,15 @@ func createPodsOnSameNode(ctx context.Context, f *framework.Framework, n int, re
 	return targetNode, pods
 }
 
+// createPodOnNode creates a pod pinned to nodeName using resource's PVC and waits for it
+// to be running. Returns a slice to match createPodsOnSameNode and plug into deletePodsInOrder.
+func createPodOnNode(ctx context.Context, f *framework.Framework, nodeName string, resource *storageframework.VolumeResource) []*v1.Pod {
+	pod := e2epod.MakePod(f.Namespace.Name, map[string]string{"kubernetes.io/hostname": nodeName}, []*v1.PersistentVolumeClaim{resource.Pvc}, admissionapi.LevelBaseline, "")
+	pod, err := createPod(ctx, f.ClientSet, f.Namespace.Name, pod)
+	framework.ExpectNoError(err)
+	return []*v1.Pod{pod}
+}
+
 // deletePodsInOrder deletes pods sequentially in the order they appear in the slice.
 func deletePodsInOrder(ctx context.Context, f *framework.Framework, pods []*v1.Pod) {
 	for _, pod := range pods {

--- a/tests/e2e-kubernetes/testsuites/resource_cleanup_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/resource_cleanup_daemonset.go
@@ -1,0 +1,131 @@
+package custom_testsuites
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/kubernetes/test/e2e/framework"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+// A cleanup pass runs every 2m (cleanupInterval). We watch for one full cycle plus
+// buffer so at least one pass is guaranteed to run within the window.
+const cleanupObserveTimeout = 3 * time.Minute
+const cleanupObservePoll = 5 * time.Second
+
+type s3CSIResourceCleanupDaemonsetTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+// InitS3CSIResourceCleanupDaemonsetTestSuite tests the periodic cleanup job in
+// daemonset mode. It verifies the job's central safety property: a cleanup pass
+// runs and leaves a healthy, in-use mount completely untouched.
+func InitS3CSIResourceCleanupDaemonsetTestSuite() storageframework.TestSuite {
+	return &s3CSIResourceCleanupDaemonsetTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "resourcecleanupdaemonset",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+func (t *s3CSIResourceCleanupDaemonsetTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *s3CSIResourceCleanupDaemonsetTestSuite) SkipUnsupportedTests(_ storageframework.TestDriver, _ storageframework.TestPattern) {
+}
+
+func (t *s3CSIResourceCleanupDaemonsetTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	type local struct {
+		resources []*storageframework.VolumeResource
+		config    *storageframework.PerTestConfig
+	}
+	var l local
+
+	f := framework.NewFrameworkWithCustomTimeouts(NamespacePrefix+"cleanup-ds", storageframework.GetDriverTimeouts(driver))
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	cleanup := func(ctx context.Context) {
+		var errs []error
+		for _, resource := range l.resources {
+			errs = append(errs, resource.CleanupResource(ctx))
+		}
+		framework.ExpectNoError(errors.NewAggregate(errs), "while cleanup resource")
+	}
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		ginkgo.DeferCleanup(cleanup)
+	})
+
+	// The core safety property of the periodic cleanup job: when it runs, it must
+	// leave a healthy, in-use mount untouched. We first wait for a cleanup pass to
+	// log that it left this volume intact (proving the job actually ran, not just
+	// that time passed), then confirm the source mount and data are still there.
+	ginkgo.It("should run a cleanup pass without disturbing a healthy in-use mount", ginkgo.Serial, func(ctx context.Context) {
+		resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+		l.resources = append(l.resources, resource)
+		pvName := resource.Pv.Name
+
+		targetNode, pods := createPodsOnSameNode(ctx, f, 1, resource)
+		defer deletePodsInOrder(ctx, f, pods)
+
+		toWrite := 1024
+		seed := time.Now().UTC().UnixNano()
+		checkWriteToPathSucceedEventually(ctx, f, pods[0], "/mnt/volume1/keep.txt", toWrite, seed)
+
+		// Wait for a cleanup pass to run and log that it left THIS volume intact.
+		// The PV name is a fresh UUID, so this line can only come from a cleanup pass
+		// over this test's volume during this run — proving the job actually ran.
+		leftIntactMarker := fmt.Sprintf("volume %s healthy", pvName)
+		ginkgo.By("Waiting for a cleanup pass to run and leave the healthy mount intact")
+		gomega.Eventually(ctx, func(ctx context.Context) (bool, error) {
+			return verifyCSINodeLogs(ctx, f, targetNode, leftIntactMarker), nil
+		}).WithTimeout(cleanupObserveTimeout).WithPolling(cleanupObservePoll).Should(gomega.BeTrue())
+
+		// The pass ran and left it alone: source mount still present, data still readable.
+		gomega.Expect(countFuseMountsForVolume(ctx, f, targetNode, pvName)).To(gomega.Equal(1),
+			"cleanup must not remove a healthy in-use source mount for volume %s", pvName)
+		checkReadFromPathSucceedEventually(ctx, f, pods[0], "/mnt/volume1/keep.txt", toWrite, seed)
+	})
+
+	// After a volume's source is reclaimed (last consumer gone), the same PV must
+	// mount cleanly again — reclaim leaves no stale state that blocks a fresh mount.
+	ginkgo.It("should allow the same PV to mount again after its source is reclaimed", ginkgo.Serial, func(ctx context.Context) {
+		resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+		l.resources = append(l.resources, resource)
+		pvName := resource.Pv.Name
+
+		// First pod: mount, write, confirm the source exists.
+		targetNode, pods := createPodsOnSameNode(ctx, f, 1, resource)
+		toWrite := 1024
+		seed := time.Now().UTC().UnixNano()
+		checkWriteToPathSucceedEventually(ctx, f, pods[0], "/mnt/volume1/remount.txt", toWrite, seed)
+		gomega.Expect(countFuseMountsForVolume(ctx, f, targetNode, pvName)).To(gomega.Equal(1))
+
+		// Delete the pod: last consumer gone, so the source is reclaimed.
+		ginkgo.By("Deleting the pod and waiting for the source mount to be reclaimed")
+		deletePodsInOrder(ctx, f, pods)
+		gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
+			return countFuseMountsForVolume(ctx, f, targetNode, pvName), nil
+		}).WithTimeout(cleanupObserveTimeout).WithPolling(cleanupObservePoll).Should(gomega.Equal(0))
+
+		// Pin the new pod to the reclaimed node to confirm the reclaim left no stale state
+		// that blocks a remount there. The pod is Running once created, so the source mount
+		// already exists and a single count is enough.
+		ginkgo.By("Recreating a pod on the reclaimed node and confirming a fresh source mounts")
+		pods2 := createPodOnNode(ctx, f, targetNode, resource)
+		defer deletePodsInOrder(ctx, f, pods2)
+		gomega.Expect(countFuseMountsForVolume(ctx, f, targetNode, pvName)).To(gomega.Equal(1),
+			"expected a fresh source mount for volume %s after remount on the reclaimed node", pvName)
+		checkReadFromPathSucceedEventually(ctx, f, pods2[0], "/mnt/volume1/remount.txt", toWrite, seed)
+	})
+}

--- a/tests/e2e-kubernetes/testsuites/resource_cleanup_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/resource_cleanup_daemonset.go
@@ -128,4 +128,30 @@ func (t *s3CSIResourceCleanupDaemonsetTestSuite) DefineTests(driver storageframe
 			"expected a fresh source mount for volume %s after remount on the reclaimed node", pvName)
 		checkReadFromPathSucceedEventually(ctx, f, pods2[0], "/mnt/volume1/remount.txt", toWrite, seed)
 	})
+
+	// Kill the mounter so the source goes dead, but keep the workload running so no inline
+	// unmount fires — that way only the periodic cleanup job can reclaim the source.
+	ginkgo.It("should reclaim a dead source after the mounter pod is killed", ginkgo.Serial, func(ctx context.Context) {
+		resource := createVolumeResourceWithMountOptions(ctx, l.config, pattern, nil)
+		l.resources = append(l.resources, resource)
+		pvName := resource.Pv.Name
+
+		targetNode, pods := createPodsOnSameNode(ctx, f, 1, resource)
+		defer deletePodsInOrder(ctx, f, pods)
+		toWrite := 1024
+		seed := time.Now().UTC().UnixNano()
+		checkWriteToPathSucceedEventually(ctx, f, pods[0], "/mnt/volume1/dead.txt", toWrite, seed)
+		gomega.Expect(countFuseMountsForVolume(ctx, f, targetNode, pvName)).To(gomega.Equal(1))
+
+		// mount-s3 dies with the mounter pod; the source goes dead (ENOTCONN) but stays listed.
+		ginkgo.By("Killing the mounter pod to make the source dead")
+		killMounterPodOnNode(ctx, f, targetNode)
+
+		// The workload is still running, so no inline unmount fires — only the periodic job
+		// can reap the dead source. Wait for it to be torn down.
+		ginkgo.By("Waiting for the cleanup job to reclaim the dead source")
+		gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
+			return countFuseMountsForVolume(ctx, f, targetNode, pvName), nil
+		}).WithTimeout(cleanupObserveTimeout).WithPolling(cleanupObservePoll).Should(gomega.Equal(0))
+	})
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds a periodic cleanup job for the daemonset mounter — the safety net that reclaims mount resources left behind when inline unmount doesn't fire.

The cleanup job runs every 2 minutes: it walks the `MountMap`, checks each entry against the kernel mount table, and tears down any source that is missing, dead, or has no consumers (source mount, meta file, cred dir). For a source still in the mount table, it probes liveness with a bounded timeout — a dead source is reclaimed, while an undeterminable ("unknown") result is left intact so a live source is never torn down. `releaseTarget` is made concurrency-safe since the job now also deletes map entries.

The republish churn a dead mount would otherwise cause (kubelet re-issuing NodePublishVolume ~every 60s, recreating meta/creds for the job to delete again) is prevented by #918, which this PR is rebased on top of — so the cleanup job reclaims a dead source without fighting republish.

*Testing:*

**Unit tests** (`mount_map_persistence_test.go`, next to the `RebuildMountMap` tests) call `CleanupOrphans()` directly and cover each branch: teardown of a missing, dead, or unused source, refcount reconcile, adoption of an untracked live bind mount, teardown-failure retry, and the skip cases.

**e2e tests** (`resource_cleanup_daemonset.go`) — two Serial specs: a cleanup pass leaves a healthy in-use mount intact, and the same PV mounts again after its source is reclaimed. Both pass on a live EKS cluster.

**Manual testing.** Installed this change on an EKS cluster in daemonset mode. With a workload pod running, I killed only the mounter pod so the source went dead (no inline cleanup fires — only the periodic job can reclaim it):

- The cleanup job left the healthy mount intact on each 2-minute tick (`cleanup: volume s3-pv healthy with 1 live consumer(s), leaving intact`), then detected the dead source on the first tick after the crash and reclaimed it (`cleanup: source .../mnt/s3-pv for volume s3-pv is dead, cleaning up`) — source removed from the mount table, meta file deleted.
- With #918 in place, the ~60s republishes did not recreate the reclaimed resources — the meta file was written once, at the original mount, and never again. No churn.
- Recreating the workload pod mounted a fresh source and read back previously written data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
