### PR TITLE
Improvements to isHealthyMountpoint check and remove the remaining fr…

### DIFF
--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -224,10 +224,17 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	// If source is mounted, check health first. Dead source = mark not mounted so we go
 	// through the fresh-mount path below. Only enforce compatibility on a healthy (living) source.
 	if entry.sourceMounted {
-		if !dm.IsSourceHealthy(ctx, entry.SourcePath) {
+		healthy, healthErr := dm.IsSourceHealthy(ctx, entry.SourcePath)
+		switch {
+		case healthErr != nil:
+			// Health could not be determined (transient error or timeout). Fail closed:
+			// do NOT tear down a possibly-live source out from under active consumers.
+			// Return an error so kubelet retries NodePublishVolume.
+			return fmt.Errorf("cannot determine health of existing source mount for volume %s, will retry: %w", volumeID, healthErr)
+		case !healthy:
 			klog.V(2).Infof("DaemonsetMounter: source %s is dead for volume %s, will clean up and re-mount", entry.SourcePath, volumeID)
 			entry.sourceMounted = false
-		} else {
+		default:
 			// Healthy source — enforce compatibility before any credential writes.
 			if err := entry.Params.ValidateCompatibility(&incomingParams); err != nil {
 				return fmt.Errorf("cannot share mount for volume %s: %w", volumeID, err)
@@ -539,15 +546,30 @@ func (dm *DaemonsetMounter) IsMountPoint(target string) (bool, error) {
 // IsSourceHealthy checks if the FUSE mount at sourcePath is alive and serving.
 // Runs the check in a goroutine bounded by ctx to avoid blocking forever if
 // the FUSE daemon is alive but not reading from the fd (frozen).
-func (dm *DaemonsetMounter) IsSourceHealthy(ctx context.Context, sourcePath string) bool {
-	ch := make(chan bool, 1)
-	go func() { ch <- dm.mount.IsHealthyMountpoint(sourcePath) }()
+//
+// It mirrors [mpmounter.Mounter.IsHealthyMountpoint]'s three-way result:
+//   - (true, nil):  healthy.
+//   - (false, nil): definitely dead.
+//   - (false, err): UNKNOWN — health could not be determined (transient error or
+//     the check timed out). Callers MUST NOT treat this as dead.
+func (dm *DaemonsetMounter) IsSourceHealthy(ctx context.Context, sourcePath string) (bool, error) {
+	type result struct {
+		healthy bool
+		err     error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		healthy, err := dm.mount.IsHealthyMountpoint(sourcePath)
+		ch <- result{healthy: healthy, err: err}
+	}()
 	select {
-	case healthy := <-ch:
-		return healthy
+	case r := <-ch:
+		return r.healthy, r.err
 	case <-ctx.Done():
-		klog.V(2).Infof("DaemonsetMounter: IsSourceHealthy timed out for %s, treating as dead", sourcePath)
-		return false
+		// Timeout is itself "unknown" (e.g. a frozen daemon not reading the fd),
+		// not a definite "dead" — surface it as an error so callers fail closed.
+		klog.V(2).Infof("DaemonsetMounter: IsSourceHealthy timed out for %s, treating as unknown", sourcePath)
+		return false, ctx.Err()
 	}
 }
 

--- a/pkg/driver/node/mounter/daemonset_mounter_test.go
+++ b/pkg/driver/node/mounter/daemonset_mounter_test.go
@@ -890,3 +890,186 @@ func mounterPod(name string, phase corev1.PodPhase) *corev1.Pod {
 		Status: corev1.PodStatus{Phase: phase},
 	}
 }
+
+// --- IsSourceHealthy health-state tests ---
+//
+// IsSourceHealthy wraps CheckMountpoint -> IsHealthyMountpoint (bounded by ctx),
+// so these tests exercise that whole chain and assert the tri-state result:
+//   (true, nil)  = healthy
+//   (false, nil) = definitely dead
+//   (false, err) = UNKNOWN (callers MUST NOT treat as dead)
+
+// mountpointDevice is the device name CheckMountpoint expects (mpmounter's fsName).
+const mountpointDevice = "mountpoint-s3"
+
+// fakeHealthMount is a minimal mountutils.Interface stub that lets tests control
+// what IsMountPoint and List return. Only these two methods are used by
+// CheckMountpoint; any other call would panic (embedded nil interface), which is
+// the intended guard.
+type fakeHealthMount struct {
+	mountutils.Interface
+
+	isMountPoint    bool
+	isMountPointErr error
+	listResult      []mountutils.MountPoint
+	listErr         error
+}
+
+func (f *fakeHealthMount) IsMountPoint(_ string) (bool, error) {
+	return f.isMountPoint, f.isMountPointErr
+}
+
+func (f *fakeHealthMount) List() ([]mountutils.MountPoint, error) {
+	return f.listResult, f.listErr
+}
+
+// healthPathErr wraps an errno the way filesystem calls do (*os.PathError), which
+// is what mount-utils' IsCorruptedMnt expects to unwrap.
+func healthPathErr(errno syscall.Errno) error {
+	return &os.PathError{Op: "open", Path: "/some/source", Err: errno}
+}
+
+// newHealthDM builds a DaemonsetMounter wired only with the given mount interface;
+// IsSourceHealthy touches nothing else.
+func newHealthDM(mount mountutils.Interface) *mounter.DaemonsetMounter {
+	return mounter.NewDaemonsetMounter(nil, "", mpmounter.NewWithMount(mount), nil, nil, nil, nil)
+}
+
+// healthSource returns a real, existing directory when exists is true (so statx
+// and os.Open succeed), or a path guaranteed not to exist otherwise.
+func healthSource(t *testing.T, exists bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if exists {
+		return dir
+	}
+	return filepath.Join(dir, "does-not-exist")
+}
+
+func TestIsSourceHealthy_States(t *testing.T) {
+	tests := []struct {
+		name   string
+		exists bool // whether the source path exists on disk (drives statx/os.Open)
+		fake   *fakeHealthMount
+
+		wantHealthy bool
+		wantErr     bool // true => UNKNOWN
+	}{
+		{
+			name:        "missing source is dead",
+			exists:      false,
+			fake:        &fakeHealthMount{},
+			wantHealthy: false,
+			wantErr:     false,
+		},
+		{
+			name:        "not a mount is dead",
+			exists:      true,
+			fake:        &fakeHealthMount{isMountPoint: false},
+			wantHealthy: false,
+			wantErr:     false,
+		},
+		{
+			name:        "ENOTCONN is dead",
+			exists:      true,
+			fake:        &fakeHealthMount{isMountPointErr: healthPathErr(syscall.ENOTCONN)},
+			wantHealthy: false,
+			wantErr:     false,
+		},
+		{
+			name:        "EINTR is unknown",
+			exists:      true,
+			fake:        &fakeHealthMount{isMountPointErr: healthPathErr(syscall.EINTR)},
+			wantHealthy: false,
+			wantErr:     true,
+		},
+		{
+			name:   "different device is dead",
+			exists: true,
+			fake: &fakeHealthMount{
+				isMountPoint: true,
+				listResult:   []mountutils.MountPoint{{Path: "TARGET", Device: "ext4"}},
+			},
+			wantHealthy: false,
+			wantErr:     false,
+		},
+		{
+			name: "List failure is unknown",
+			// CheckMountpoint wraps the List error with %w, so it is no longer a
+			// bare *os.PathError; IsCorruptedMnt can't classify it, and it is
+			// (correctly) treated as UNKNOWN rather than dead.
+			exists: true,
+			fake: &fakeHealthMount{
+				isMountPoint: true,
+				listErr:      healthPathErr(syscall.EIO),
+			},
+			wantHealthy: false,
+			wantErr:     true,
+		},
+		{
+			name:   "live Mountpoint is healthy",
+			exists: true,
+			fake: &fakeHealthMount{
+				isMountPoint: true,
+				listResult:   []mountutils.MountPoint{{Path: "TARGET", Device: mountpointDevice}},
+			},
+			wantHealthy: true,
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := healthSource(t, tt.exists)
+			// Fill in the real source path for list entries that reference it.
+			for i := range tt.fake.listResult {
+				if tt.fake.listResult[i].Path == "TARGET" {
+					tt.fake.listResult[i].Path = source
+				}
+			}
+
+			dm := newHealthDM(tt.fake)
+			healthy, err := dm.IsSourceHealthy(context.Background(), source)
+
+			assert.Equals(t, tt.wantHealthy, healthy)
+			assert.Equals(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
+// blockingMount blocks in IsMountPoint until released, so we can drive the
+// ctx-timeout (UNKNOWN) branch of IsSourceHealthy deterministically.
+type blockingMount struct {
+	mountutils.Interface
+	release chan struct{}
+}
+
+func (b *blockingMount) IsMountPoint(_ string) (bool, error) {
+	<-b.release
+	return true, nil
+}
+
+// List is reached only after the probe is released on cleanup; returning an
+// empty table lets the background goroutine finish without a nil-interface panic.
+func (b *blockingMount) List() ([]mountutils.MountPoint, error) {
+	return nil, nil
+}
+
+func TestIsSourceHealthy_TimeoutIsUnknown(t *testing.T) {
+	release := make(chan struct{})
+	// Release the blocked probe on cleanup so the background goroutine (which
+	// sends to a buffered channel) exits without leaking.
+	t.Cleanup(func() { close(release) })
+
+	dm := newHealthDM(&blockingMount{release: release})
+	source := healthSource(t, true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	healthy, err := dm.IsSourceHealthy(ctx, source)
+
+	// A timed-out health check is UNKNOWN, not dead — must return an error.
+	assert.Equals(t, false, healthy)
+	assert.Equals(t, true, err != nil)
+}

--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"syscall"
 
 	"k8s.io/klog/v2"
 	mountutils "k8s.io/mount-utils"
@@ -126,12 +127,32 @@ func (m *Mounter) IsMountPoint(target Target) (bool, error) {
 	return m.mount.IsMountPoint(target)
 }
 
-// IsHealthyMountpoint checks whether `target` is both a valid Mountpoint mount AND the FUSE daemon is alive.
+// IsHealthyMountpoint reports whether `target` is a live Mountpoint mount.
+//
+// It returns a three-way result so callers can distinguish "definitely dead"
+// from "couldn't determine", and avoid tearing down a possibly-live source on a
+// transient error:
+//   - (true, nil):  healthy.
+//   - (false, nil): definitely dead — not a Mountpoint mount, corrupted mount,
+//     or the FUSE daemon returned ENOTCONN.
+//   - (false, err): UNKNOWN — a transient error (e.g. failure reading the mount
+//     table, EINTR, fd exhaustion) prevented a determination. Callers MUST NOT
+//     treat this as dead; they should retry later.
+//
 // A dead FUSE mount (after mounter pod crash) stays in the mount table but returns ENOTCONN on any I/O.
-func (m *Mounter) IsHealthyMountpoint(target Target) bool {
+func (m *Mounter) IsHealthyMountpoint(target Target) (bool, error) {
 	isMounted, err := m.CheckMountpoint(target)
-	if err != nil || !isMounted {
-		return false
+	if err != nil {
+		// A corrupted mount is a definite "dead" signal.
+		if m.IsMountpointCorrupted(err) {
+			return false, nil
+		}
+		// Anything else (e.g. couldn't stat or list the mount table) is UNKNOWN.
+		return false, fmt.Errorf("cannot determine mount health for %q: %w", target, err)
+	}
+	if !isMounted {
+		// Not our mount (or not a mount at all) — definitely not a live Mountpoint.
+		return false, nil
 	}
 
 	// Mount entry exists in the table — verify the FUSE daemon is alive.
@@ -142,10 +163,15 @@ func (m *Mounter) IsHealthyMountpoint(target Target) bool {
 	// causing false negatives during transient network issues.
 	f, err := os.Open(target)
 	if err != nil {
-		return false
+		// A dead FUSE daemon returns ENOTCONN — that's a definite "dead".
+		if errors.Is(err, syscall.ENOTCONN) {
+			return false, nil
+		}
+		// Transient errors (EINTR, EMFILE/ENFILE, ENOMEM, ...) are UNKNOWN, not dead.
+		return false, fmt.Errorf("cannot open %q to probe FUSE liveness: %w", target, err)
 	}
 	f.Close()
-	return true
+	return true, nil
 }
 
 // IsMountpointCorrupted returns whether an error returned from [Mounter.CheckMountpoint]

--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -4,8 +4,8 @@ package mounter
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
-	"syscall"
 
 	"k8s.io/klog/v2"
 	mountutils "k8s.io/mount-utils"
@@ -143,6 +143,11 @@ func (m *Mounter) IsMountPoint(target Target) (bool, error) {
 func (m *Mounter) IsHealthyMountpoint(target Target) (bool, error) {
 	isMounted, err := m.CheckMountpoint(target)
 	if err != nil {
+		// A missing target directory means there is no mount there at all —
+		// definitely not a live Mountpoint, so treat it as dead.
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
 		// A corrupted mount is a definite "dead" signal.
 		if m.IsMountpointCorrupted(err) {
 			return false, nil
@@ -163,8 +168,10 @@ func (m *Mounter) IsHealthyMountpoint(target Target) (bool, error) {
 	// causing false negatives during transient network issues.
 	f, err := os.Open(target)
 	if err != nil {
-		// A dead FUSE daemon returns ENOTCONN — that's a definite "dead".
-		if errors.Is(err, syscall.ENOTCONN) {
+		// Same classification as the CheckMountpoint probe above: a vanished target
+		// (ENOENT) or a corrupted/dead mount (ENOTCONN, ESTALE, EIO, ...) is a
+		// definite "dead" signal. IsMountpointCorrupted unwraps the *os.PathError.
+		if errors.Is(err, fs.ErrNotExist) || m.IsMountpointCorrupted(err) {
 			return false, nil
 		}
 		// Transient errors (EINTR, EMFILE/ENFILE, ENOMEM, ...) are UNKNOWN, not dead.

--- a/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
+++ b/tests/e2e-kubernetes/testsuites/pod_sharing_daemonset.go
@@ -665,7 +665,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			// mount-s3 process should be running while pod is mounted
 			ginkgo.By("Verifying mount-s3 process exists while pod is mounted")
 			dumpMountpointProcesses(ctx, f, targetNode, "while pod mounted")
-			framework.Gomega().Eventually(ctx, func(ctx context.Context) (int, error) {
+			gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
 				count := countMountpointProcessesForVolume(ctx, f, targetNode, bucketName)
 				return count, nil
 			}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(gomega.Equal(1))
@@ -691,7 +691,7 @@ func (t *s3CSIPodSharingDaemonsetTestSuite) DefineTests(driver storageframework.
 			// Verify mount-s3 process for this volume has terminated in the mounter pod
 			ginkgo.By("Verifying mount-s3 process terminated after last consumer unmounts")
 			dumpMountpointProcesses(ctx, f, targetNode, "after last consumer unmounts")
-			framework.Gomega().Eventually(ctx, func(ctx context.Context) (int, error) {
+			gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
 				count := countMountpointProcessesForVolume(ctx, f, targetNode, bucketName)
 				return count, nil
 			}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(gomega.Equal(0))
@@ -950,7 +950,7 @@ func ptrInt64(v int64) *int64 {
 // assertPodFailsToMount waits for a pod to have a mount failure event containing the given substring.
 // The pod should be stuck in ContainerCreating due to volume mount failure.
 func assertPodFailsToMount(ctx context.Context, f *framework.Framework, pod *v1.Pod, errorSubstring string) {
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (bool, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (bool, error) {
 		events, err := f.ClientSet.CoreV1().Events(pod.Namespace).List(ctx, metav1.ListOptions{
 			FieldSelector: "involvedObject.name=" + pod.Name,
 		})
@@ -974,7 +974,7 @@ func assertPodFailsToMount(ctx context.Context, f *framework.Framework, pod *v1.
 // Retries on transient exec errors (container restarting, etc.) for up to 1 minute.
 func countFuseMountsForVolume(ctx context.Context, f *framework.Framework, nodeName, volumeID string) int {
 	var result int
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (int, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
 		// Find the CSI node pod on this node
 		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=s3-csi-node",
@@ -1057,7 +1057,7 @@ func killCSINodePodOnNode(ctx context.Context, f *framework.Framework, nodeName 
 
 // waitForCSINodePodReady waits for the CSI node pod on the given node to be Running and Ready.
 func waitForCSINodePodReady(ctx context.Context, f *framework.Framework, nodeName string) {
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (bool, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (bool, error) {
 		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=s3-csi-node",
 			FieldSelector: "spec.nodeName=" + nodeName,
@@ -1091,7 +1091,7 @@ func isPodReady(pod *v1.Pod) bool {
 // Only retries when exec fails; if exec succeeds and file is MISSING, that's a real result.
 func checkMetaFileExists(ctx context.Context, f *framework.Framework, nodeName, volumeID string) bool {
 	var result bool
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
 		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=s3-csi-node",
 			FieldSelector: "spec.nodeName=" + nodeName,
@@ -1138,7 +1138,7 @@ func killMounterPodOnNode(ctx context.Context, f *framework.Framework, nodeName 
 
 // waitForMounterPodReady waits for the mounter pod on the given node to be Running and Ready.
 func waitForMounterPodReady(ctx context.Context, f *framework.Framework, nodeName string) {
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (bool, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (bool, error) {
 		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=s3-csi-daemonset-mounter",
 			FieldSelector: "spec.nodeName=" + nodeName,
@@ -1178,7 +1178,7 @@ func assertPodIOFails(ctx context.Context, f *framework.Framework, pod *v1.Pod, 
 // Retries on transient exec errors for up to 30 seconds.
 func readMetaFileContent(ctx context.Context, f *framework.Framework, nodeName, volumeID string) string {
 	var result string
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
 		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=s3-csi-node",
 			FieldSelector: "spec.nodeName=" + nodeName,
@@ -1210,7 +1210,7 @@ func readMetaFileContent(ctx context.Context, f *framework.Framework, nodeName, 
 // Retries on transient exec errors for up to 30 seconds.
 func checkDeviceIDAtSourcePath(ctx context.Context, f *framework.Framework, nodeName, volumeID, deviceID string) bool {
 	var result bool
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
 		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=s3-csi-node",
 			FieldSelector: "spec.nodeName=" + nodeName,
@@ -1242,7 +1242,7 @@ func checkDeviceIDAtSourcePath(ctx context.Context, f *framework.Framework, node
 // Retries on transient exec errors for up to 30 seconds.
 func getMetaFileMtime(ctx context.Context, f *framework.Framework, nodeName, volumeID string) string {
 	var result string
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
 		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=s3-csi-node",
 			FieldSelector: "spec.nodeName=" + nodeName,
@@ -1271,7 +1271,7 @@ func getMetaFileMtime(ctx context.Context, f *framework.Framework, nodeName, vol
 // Retries on transient exec errors for up to 30 seconds.
 func getFuseSourceDeviceID(ctx context.Context, f *framework.Framework, nodeName, volumeID string) string {
 	var result string
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
 		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=s3-csi-node",
 			FieldSelector: "spec.nodeName=" + nodeName,
@@ -1338,7 +1338,7 @@ func dumpMountTable(ctx context.Context, f *framework.Framework, nodeName, label
 // for at least 5 seconds. This prevents race conditions where we exec into a pod that
 // just started but hasn't fully initialized (e.g., RebuildMountMap + DiscoverCommDir).
 func waitForCSINodePodStable(ctx context.Context, f *framework.Framework, nodeName string) {
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (bool, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (bool, error) {
 		pods, err := f.ClientSet.CoreV1().Pods(csiDriverDaemonSetNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=s3-csi-node",
 			FieldSelector: "spec.nodeName=" + nodeName,
@@ -1470,7 +1470,7 @@ func queryCredentialDirStatus(ctx context.Context, f *framework.Framework, nodeN
 // checkCredentialDirExists polls until the credential directory EXISTS in the mounter pod (up to 1 minute).
 func checkCredentialDirExists(ctx context.Context, f *framework.Framework, nodeName, volumeID string) bool {
 	var result bool
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
 		status, err := queryCredentialDirStatus(ctx, f, nodeName, volumeID)
 		if err != nil {
 			framework.Logf("Failed to check credential dir (retrying): %v", err)
@@ -1488,7 +1488,7 @@ func checkCredentialDirExists(ctx context.Context, f *framework.Framework, nodeN
 // checkCredentialDirRemoved polls until the credential directory is MISSING from the mounter pod (up to 1 minute).
 func checkCredentialDirRemoved(ctx context.Context, f *framework.Framework, nodeName, volumeID string) bool {
 	var result bool
-	framework.Gomega().Eventually(ctx, func(ctx context.Context) (string, error) {
+	gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
 		status, err := queryCredentialDirStatus(ctx, f, nodeName, volumeID)
 		if err != nil {
 			framework.Logf("Failed to check credential dir removal (retrying): %v", err)


### PR DESCRIPTION
*Description of changes:*
IsHealthyMountpoint / IsSourceHealthy are now tri-state ((bool, error)): healthy, definitely dead (ENOTCONN/corrupted), or unknown (transient error or timeout). Previously any error collapsed to "dead".
mountOrShareSource fails closed on unknown health: it returns an error so kubelet retries, instead of tearing down a source mount that may still be serving live consumers.
e2e tests: replaced framework.Gomega().Eventually(...) with package-level gomega.Eventually(...) in pod_sharing_daemonset.go

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
