### PR TITLE
Do not proceed with mount for dead targets

### DIFF
--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -171,6 +171,20 @@ func (dm *DaemonsetMounter) Mount(ctx context.Context, bucketName string, target
 		return nil
 	}
 
+	// Classify the workload target before doing any mount work.
+	// IsTargetHealthy does an IO probe (same as source health check) with ctx timeout.
+	//   - (true, nil):  target is healthy or absent (fresh) — proceed.
+	//   - (false, nil): dead/corrupted — nothing to do; return nil.
+	//   - (false, err): unknown — let kubelet retry.
+	targetHealthy, targetErr := dm.IsTargetHealthy(ctx, target)
+	if targetErr != nil {
+		return fmt.Errorf("cannot determine health of target %q for volume %s, will retry: %w", target, credentialCtx.VolumeID, targetErr)
+	}
+	if !targetHealthy {
+		klog.V(2).Infof("DaemonsetMounter: target %s for volume %s is a corrupted mount; not proceeding, pod re-creation %s required for recovery", target, credentialCtx.VolumeID, credentialCtx.WorkloadPodID)
+		return nil
+	}
+
 	// Extract PV name from target path to use as the volume identifier for sharing and filesystem paths.
 	// PV names are Kubernetes resource names — guaranteed DNS-safe (no '/', no '..', alphanumeric + '-' + '.').
 	// Target path format: /var/lib/kubelet/pods/<podUID>/volumes/kubernetes.io~csi/<pv-name>/mount
@@ -547,11 +561,14 @@ func (dm *DaemonsetMounter) IsMountPoint(target string) (bool, error) {
 // Runs the check in a goroutine bounded by ctx to avoid blocking forever if
 // the FUSE daemon is alive but not reading from the fd (frozen).
 //
-// It mirrors [mpmounter.Mounter.IsHealthyMountpoint]'s three-way result:
-//   - (true, nil):  healthy.
-//   - (false, nil): definitely dead.
-//   - (false, err): UNKNOWN — health could not be determined (transient error or
-//     the check timed out). Callers MUST NOT treat this as dead.
+// Uses [mpmounter.Mounter.IsHealthyMountpoint] which returns:
+//   - (true, nil):             healthy — live Mountpoint daemon confirmed via IO.
+//   - (false, ErrMountAbsent): path absent or not a Mountpoint mount.
+//   - (false, nil):            dead/corrupted daemon (ENOTCONN, ESTALE, EIO).
+//   - (false, err):            UNKNOWN — transient error; callers MUST NOT treat as dead.
+//
+// For the source, "absent" means the mount is dead — so ErrMountAbsent is folded into
+// (false, nil). Callers get the original three-way contract: healthy / dead / unknown.
 func (dm *DaemonsetMounter) IsSourceHealthy(ctx context.Context, sourcePath string) (bool, error) {
 	type result struct {
 		healthy bool
@@ -560,15 +577,49 @@ func (dm *DaemonsetMounter) IsSourceHealthy(ctx context.Context, sourcePath stri
 	ch := make(chan result, 1)
 	go func() {
 		healthy, err := dm.mount.IsHealthyMountpoint(sourcePath)
-		ch <- result{healthy: healthy, err: err}
+		if errors.Is(err, mpmounter.ErrMountAbsent) {
+			ch <- result{false, nil} // absent source = dead
+			return
+		}
+		ch <- result{healthy, err}
 	}()
 	select {
 	case r := <-ch:
 		return r.healthy, r.err
 	case <-ctx.Done():
-		// Timeout is itself "unknown" (e.g. a frozen daemon not reading the fd),
-		// not a definite "dead" — surface it as an error so callers fail closed.
 		klog.V(2).Infof("DaemonsetMounter: IsSourceHealthy timed out for %s, treating as unknown", sourcePath)
+		return false, ctx.Err()
+	}
+}
+
+// IsTargetHealthy checks if the workload's bind-mount target is a live Mountpoint mount.
+// Same pattern as [DaemonsetMounter.IsSourceHealthy] (goroutine + ctx timeout, same IO probe),
+// but returns (bool, error) with ErrMountAbsent passed through rather than folded into dead.
+//
+// Callers interpret:
+//   - (true, nil):             target is healthy (already mounted, republish/idempotent).
+//   - (false, ErrMountAbsent): target is absent/fresh — proceed with mount.
+//   - (false, nil):            target mount is dead/corrupted — do NOT proceed (return nil).
+//   - (false, err):            UNKNOWN — let kubelet retry.
+func (dm *DaemonsetMounter) IsTargetHealthy(ctx context.Context, target string) (bool, error) {
+	type result struct {
+		healthy bool
+		err     error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		healthy, err := dm.mount.IsHealthyMountpoint(target)
+		if errors.Is(err, mpmounter.ErrMountAbsent) {
+			ch <- result{true, nil} // absent target = fresh mount, proceed
+			return
+		}
+		ch <- result{healthy, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.healthy, r.err
+	case <-ctx.Done():
+		klog.V(2).Infof("DaemonsetMounter: IsTargetHealthy timed out for %s, treating as unknown", target)
 		return false, ctx.Err()
 	}
 }

--- a/pkg/driver/node/mounter/daemonset_mounter_test.go
+++ b/pkg/driver/node/mounter/daemonset_mounter_test.go
@@ -571,7 +571,7 @@ func TestDaemonsetMounter(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error on cancelled context")
 			}
-			assert.Contains(t, err.Error(), "failed to send mount options")
+			assert.Contains(t, err.Error(), "cannot determine health of target")
 
 			// Verify commDir was NOT nilled by the cancelled context
 			_, err = testCtx.dm.GetCommDir()
@@ -1072,4 +1072,208 @@ func TestIsSourceHealthy_TimeoutIsUnknown(t *testing.T) {
 	// A timed-out health check is UNKNOWN, not dead — must return an error.
 	assert.Equals(t, false, healthy)
 	assert.Equals(t, true, err != nil)
+}
+
+// --- IsTargetHealthy health-state tests ---
+//
+// IsTargetHealthy uses the same IsHealthyMountpoint probe as IsSourceHealthy, but the
+// interpretation differs: ErrMountAbsent maps to (true, nil) rather than (false, nil),
+// because a missing or not-yet-mounted target is the normal fresh-mount case.
+
+func TestIsTargetHealthy_States(t *testing.T) {
+	tests := []struct {
+		name   string
+		exists bool // whether the target path exists on disk (drives statx/os.Open)
+		fake   *fakeHealthMount
+
+		wantHealthy bool
+		wantErr     bool // true => UNKNOWN (caller retries)
+	}{
+		{
+			// Fresh mount: target directory does not exist yet. ErrMountAbsent → (true, nil).
+			name:        "missing target is healthy (absent = proceed)",
+			exists:      false,
+			fake:        &fakeHealthMount{},
+			wantHealthy: true,
+			wantErr:     false,
+		},
+		{
+			// Fresh mount: target exists but is not a mount. ErrMountAbsent → (true, nil).
+			name:        "not a mount is healthy (absent = proceed)",
+			exists:      true,
+			fake:        &fakeHealthMount{isMountPoint: false},
+			wantHealthy: true,
+			wantErr:     false,
+		},
+		{
+			// Corrupted/dead mount: ENOTCONN from IsMountPoint → (false, nil).
+			name:        "ENOTCONN is dead (corrupted)",
+			exists:      true,
+			fake:        &fakeHealthMount{isMountPointErr: healthPathErr(syscall.ENOTCONN)},
+			wantHealthy: false,
+			wantErr:     false,
+		},
+		{
+			// Transient error: EINTR → UNKNOWN (false, err).
+			name:        "EINTR is unknown",
+			exists:      true,
+			fake:        &fakeHealthMount{isMountPointErr: healthPathErr(syscall.EINTR)},
+			wantHealthy: false,
+			wantErr:     true,
+		},
+		{
+			// Different device in mount table → not a Mountpoint mount → ErrMountAbsent → (true, nil).
+			name:   "different device is healthy (absent = proceed)",
+			exists: true,
+			fake: &fakeHealthMount{
+				isMountPoint: true,
+				listResult:   []mountutils.MountPoint{{Path: "TARGET", Device: "ext4"}},
+			},
+			wantHealthy: true,
+			wantErr:     false,
+		},
+		{
+			// List failure → UNKNOWN (false, err).
+			name:   "List failure is unknown",
+			exists: true,
+			fake: &fakeHealthMount{
+				isMountPoint: true,
+				listErr:      healthPathErr(syscall.EIO),
+			},
+			wantHealthy: false,
+			wantErr:     true,
+		},
+		{
+			// Live Mountpoint mount → os.Open succeeds → (true, nil).
+			name:   "live Mountpoint is healthy",
+			exists: true,
+			fake: &fakeHealthMount{
+				isMountPoint: true,
+				listResult:   []mountutils.MountPoint{{Path: "TARGET", Device: mountpointDevice}},
+			},
+			wantHealthy: true,
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := healthSource(t, tt.exists)
+			// Fill in the real target path for list entries that reference it.
+			for i := range tt.fake.listResult {
+				if tt.fake.listResult[i].Path == "TARGET" {
+					tt.fake.listResult[i].Path = target
+				}
+			}
+
+			dm := newHealthDM(tt.fake)
+			healthy, err := dm.IsTargetHealthy(context.Background(), target)
+
+			assert.Equals(t, tt.wantHealthy, healthy)
+			assert.Equals(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
+func TestIsTargetHealthy_TimeoutIsUnknown(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	dm := newHealthDM(&blockingMount{release: release})
+	target := healthSource(t, true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	healthy, err := dm.IsTargetHealthy(ctx, target)
+
+	// A timed-out health check is UNKNOWN, not dead — must return an error.
+	assert.Equals(t, false, healthy)
+	assert.Equals(t, true, err != nil)
+}
+
+// TestMount_CorruptedTarget_NoMapEntryNoMeta verifies that when Mount is called with a
+// corrupted target (ENOTCONN), it returns nil without creating a meta file. This is the
+// churn-prevention invariant: a corrupted target causes an early bail, leaving cleanup to
+// the periodic job rather than churning mount/creds every republish.
+func TestMount_CorruptedTarget_NoMapEntryNoMeta(t *testing.T) {
+	kubeletPath := t.TempDir()
+	const volumeID = "pv-corrupted-target"
+
+	// A target path that exists on disk (kubelet created it) but IsMountPoint returns
+	// a corrupted-mount error. We simulate this by making the fakeHealthMount return
+	// ENOTCONN when CheckMountpoint runs IsMountPoint on the target.
+	targetDir := filepath.Join(kubeletPath, "pods", "pod-uid-123", "volumes", "kubernetes.io~csi", volumeID, "mount")
+	assert.NoError(t, os.MkdirAll(targetDir, 0750))
+
+	// Wire a DaemonsetMounter whose mount.CheckMountpoint (via IsMountPoint) returns ENOTCONN
+	// for any path — simulating a corrupted bind mount at the target.
+	corruptedMount := &fakeHealthMount{
+		isMountPointErr: healthPathErr(syscall.ENOTCONN),
+	}
+	dm := mounter.NewDaemonsetMounter(
+		nil, "test-node",
+		mpmounter.NewWithMount(corruptedMount),
+		nil, nil, nil, nil,
+	)
+
+	ctx := context.Background()
+	credCtx := credentialprovider.ProvideContext{
+		VolumeID:      volumeID,
+		WorkloadPodID: "pod-uid-123",
+	}
+
+	err := dm.Mount(ctx, "test-bucket", targetDir, credCtx, mountpoint.Args{}, "", nil)
+
+	// Mount should return nil (nothing to do, corrupted target).
+	assert.NoError(t, err)
+
+	// No meta file should exist — Mount bailed before writing anything.
+	metaPath := mounter.MetaFileName(kubeletPath, volumeID)
+	_, statErr := os.Stat(metaPath)
+	assert.Equals(t, true, os.IsNotExist(statErr))
+}
+
+// TestMount_AbsentTarget_ProceedsToMount verifies that when Mount is called with a target
+// that does not exist (fs.ErrNotExist — the fresh-mount case), IsTargetHealthy returns
+// (true, nil) and Mount proceeds past the health check rather than bailing with nil.
+// It will eventually error downstream (e.g. commDir not discovered), but the point is it
+// does NOT return nil like a corrupted target — it tries to mount. This proves the
+// not-exist accommodation works: a missing target is "absent/fresh → proceed", not "dead".
+func TestMount_AbsentTarget_ProceedsToMount(t *testing.T) {
+	kubeletPath := t.TempDir()
+	const volumeID = "pv-absent-target"
+
+	// Target path does NOT exist on disk — simulates a fresh first mount where kubelet
+	// hasn't created the dir yet (or it was cleaned up).
+	targetDir := filepath.Join(kubeletPath, "pods", "pod-uid-456", "volumes", "kubernetes.io~csi", volumeID, "mount")
+	// Intentionally NOT creating targetDir.
+
+	// Use a fakeHealthMount that has never been a mount — but statx will fail with ENOENT
+	// since the path doesn't exist. IsTargetHealthy should return (true, nil) and proceed.
+	dm := mounter.NewDaemonsetMounter(
+		nil, "test-node",
+		mpmounter.NewWithMount(&fakeHealthMount{}),
+		nil, nil, nil, nil,
+	)
+
+	ctx := context.Background()
+	credCtx := credentialprovider.ProvideContext{
+		VolumeID:      volumeID,
+		WorkloadPodID: "pod-uid-456",
+	}
+
+	err := dm.Mount(ctx, "test-bucket", targetDir, credCtx, mountpoint.Args{}, "", nil)
+
+	// Mount should NOT return nil — it should proceed past the health check and eventually
+	// error out downstream (e.g. "comm dir not yet discovered" since we didn't set up
+	// the mounter pod). The key assertion is that err != nil (it tried to mount) rather
+	// than err == nil (it bailed like a corrupted target).
+	assert.Equals(t, true, err != nil)
+
+	// No meta file should exist — Mount errored before reaching WriteMeta because commDir
+	// is not configured in this minimal test setup.
+	metaPath := mounter.MetaFileName(kubeletPath, volumeID)
+	_, statErr := os.Stat(metaPath)
+	assert.Equals(t, true, os.IsNotExist(statErr))
 }

--- a/pkg/mountpoint/mounter/mount.go
+++ b/pkg/mountpoint/mounter/mount.go
@@ -143,10 +143,9 @@ func (m *Mounter) IsMountPoint(target Target) (bool, error) {
 func (m *Mounter) IsHealthyMountpoint(target Target) (bool, error) {
 	isMounted, err := m.CheckMountpoint(target)
 	if err != nil {
-		// A missing target directory means there is no mount there at all —
-		// definitely not a live Mountpoint, so treat it as dead.
+		// A missing target directory means there is no mount there at all.
 		if errors.Is(err, fs.ErrNotExist) {
-			return false, nil
+			return false, ErrMountAbsent
 		}
 		// A corrupted mount is a definite "dead" signal.
 		if m.IsMountpointCorrupted(err) {
@@ -156,8 +155,8 @@ func (m *Mounter) IsHealthyMountpoint(target Target) (bool, error) {
 		return false, fmt.Errorf("cannot determine mount health for %q: %w", target, err)
 	}
 	if !isMounted {
-		// Not our mount (or not a mount at all) — definitely not a live Mountpoint.
-		return false, nil
+		// Not our mount (or not a mount at all).
+		return false, ErrMountAbsent
 	}
 
 	// Mount entry exists in the table — verify the FUSE daemon is alive.
@@ -168,10 +167,12 @@ func (m *Mounter) IsHealthyMountpoint(target Target) (bool, error) {
 	// causing false negatives during transient network issues.
 	f, err := os.Open(target)
 	if err != nil {
-		// Same classification as the CheckMountpoint probe above: a vanished target
-		// (ENOENT) or a corrupted/dead mount (ENOTCONN, ESTALE, EIO, ...) is a
-		// definite "dead" signal. IsMountpointCorrupted unwraps the *os.PathError.
-		if errors.Is(err, fs.ErrNotExist) || m.IsMountpointCorrupted(err) {
+		// A vanished target (ENOENT) — path went away between the checks.
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, ErrMountAbsent
+		}
+		// A corrupted/dead mount (ENOTCONN, ESTALE, EIO, ...) — definite dead.
+		if m.IsMountpointCorrupted(err) {
 			return false, nil
 		}
 		// Transient errors (EINTR, EMFILE/ENFILE, ENOMEM, ...) are UNKNOWN, not dead.
@@ -188,3 +189,9 @@ func (m *Mounter) IsHealthyMountpoint(target Target) (bool, error) {
 func (m *Mounter) IsMountpointCorrupted(err error) bool {
 	return mountutils.IsCorruptedMnt(err)
 }
+
+// ErrMountAbsent indicates that the path does not exist or is not a Mountpoint mount.
+// Returned by IsHealthyMountpoint so callers that need to distinguish "absent/fresh"
+// from "dead/corrupted" can do so. Source callers fold this into (false, nil) = dead;
+// target callers treat it as "proceed with fresh mount".
+var ErrMountAbsent = errors.New("mounter: mount path does not exist or is not a Mountpoint mount")


### PR DESCRIPTION
*Issue #, if available:*
When the periodic cleanup job in PR https://github.com/awslabs/mountpoint-s3-csi-driver/pull/911 reaps a dead source, kubelet's requiresRepublish keeps calling NodePublishVolume for the now-corrupted target, recreating meta/creds every ~60s only to have cleanup delete them again.

This PR adds an IsTargetHealthy IO probe (mirroring IsSourceHealthy) at the Mount entry point. A corrupted target (ENOTCONN etc) returns nil immediately — no meta, no creds, no churn. An absent target (fresh mount) proceeds normally.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
