### PR TITLE
Detect dead Mountpoint mounts by requesting STATX_TYPE in the health check

### DIFF
--- a/pkg/mountpoint/mounter/mount_linux.go
+++ b/pkg/mountpoint/mounter/mount_linux.go
@@ -85,7 +85,12 @@ func bindMount(source, target string) error {
 
 func statx(path string) error {
 	var stat unix.Statx_t
-	if err := unix.Statx(unix.AT_FDCWD, path, unix.AT_STATX_FORCE_SYNC, 0, &stat); err != nil {
+	// The mask must request at least one attribute (STATX_TYPE here): with an
+	// empty mask the kernel can answer from the dentry cache without consulting
+	// the filesystem even with AT_STATX_FORCE_SYNC, so a FUSE mount whose
+	// Mountpoint process has died still reports success and the dead mount is
+	// never detected as corrupted.
+	if err := unix.Statx(unix.AT_FDCWD, path, unix.AT_STATX_FORCE_SYNC, unix.STATX_TYPE, &stat); err != nil {
 		if err == unix.ENOSYS {
 			// statx() syscall is not supported, retry with regular os.Stat
 			_, err = os.Stat(path)


### PR DESCRIPTION
Fixes #576.

## What happened

We hit this in production (driver v2.7.0, pod-mounter): a Mountpoint Pod's mount-s3 process was OOM-killed, and for 2.5 hours the node driver logged `Target path ... is already mounted. Only refreshed credentials.` on every kubelet republish while:

- every workload pod sharing that volume on the node kept a dead mount (`Transport endpoint is not connected` on every operation),
- the replacement Mountpoint Pod was never sent mount options and crash-looped on `/comm/mount.sock` with `Failed to receive mount options ... i/o timeout`,
- new workload pods scheduled onto the node bind-mounted the same dead filesystem and started Running with it.

## Root cause

`statx()` in `pkg/mountpoint/mounter/mount_linux.go` passes an **empty attribute mask**. With `mask=0` the kernel may satisfy the call from the dentry cache without consulting the filesystem, even with `AT_STATX_FORCE_SYNC` — the sync flag only forces synchronization for attributes that are actually requested. On a FUSE mount whose Mountpoint process has died, the call therefore succeeds, `CheckMountpoint()` reports the mount as healthy, and the corrupted-mount recovery path never runs.

## Fix

Request `STATX_TYPE`. Any non-empty mask forces the FUSE getattr, so a dead mount fails with `ENOTCONN`, `IsMountpointCorrupted()` recognizes it, and the existing recovery path (unmount, re-mount, re-send mount options to the waiting Mountpoint Pod) takes over. Since the CSIDriver sets `requiresRepublish: true`, kubelet re-publishes every volume periodically, so affected workloads self-heal within a couple of minutes of the Mountpoint process dying — no manual intervention.

The `ENOSYS` fallback to `os.Stat` is unchanged.

## Verification

Reproduced with mount-s3 1.22.3 on kernel 6.12 using the pod-mounter fd topology (mount performed via this package with the FUSE fd handed to `mount-s3 <bucket> /dev/fd/3` as `ExtraFiles[0]`, the mounting process closing its fd copy afterwards, plus bind mounts to two workload target paths):

1. SIGKILL mount-s3 → mount table still lists the mount; reads fail `ENOTCONN`.
2. Before this change: `CheckMountpoint()` on both source and bind targets returns `(true, nil)` — the "already mounted" wedge. A raw `statx` with `STATX_BASIC_STATS | AT_STATX_FORCE_SYNC` on the same paths returns `ENOTCONN`, and `mask=0` returns success, isolating the mask as the discriminator.
3. After this change: `CheckMountpoint()` returns `ENOTCONN`, `IsMountpointCorrupted()` returns true, and the unmount → re-mount → re-send-options → re-bind cycle restores working reads on the workload targets.

One behavioral note: on read-only mounts the kernel previously served these checks from the (indefinite-TTL) attribute cache; with a non-empty mask each health check now performs one FUSE getattr on the mount root, which Mountpoint answers from its own metadata cache — negligible at the republish cadence.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)