### PR TITLE
Bump Mountpoint to v1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Unreleased
 
 ### Notable changes
+* Support Mountpoint [version 1.24.0](https://github.com/awslabs/mountpoint-s3/releases/tag/mountpoint-s3-1.24.0) ([#922](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/922))
+  * Mountpoint now supports setting a target for total memory usage via the `--memory-target` CLI argument. This target is not a guaranteed limit but Mountpoint manages the memory available for data buffers to stay within the target: under memory pressure it slows down I/O, reclaims buffers it no longer needs and reduces prefetching. See [the configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#configuring-memory-usage). ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+  * **Breaking**: Mountpoint now limits how many files can be open for writing at the same time, derived from `--memory-target` and `--write-part-size`. Once the limit is reached, opening a file for writing fails with `ENOMEM` until an existing write file handle is closed. See [the configuration documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#maximum-number-of-files-open-for-writing) for how the limit is calculated. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+  * Mountpoint now fails at startup if `--read-part-size` exceeds the memory available for data buffers and `--memory-target` was set explicitly. If the memory target is the default, the read part size is reduced to fit and a warning is logged instead. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+  * Add experimental metrics for observing memory pressure: `experimental.pool.allocation_queue_depth`, `experimental.pool.allocation_queue_wait`, `experimental.mem.cursor_resets`, `experimental.mem.seek_window_resets`, and `experimental.fs.write_handle_limit_exceeded`. See [the metrics documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/METRICS.md). ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+  * Change memory pool metrics in logs. `pool.reserved_bytes` is replaced by `pool.acquired_bytes` and `pool.bytes_in_use`, `pool.allocated_bytes` and `pool.allocate_latency_us` are new, and the `size` dimension on `pool.allocated_pages`, `pool.empty_pages`, `pool.slack_bytes` and `pool.trim_pages` is renamed to `buffer_size`. ([#1936](https://github.com/awslabs/mountpoint-s3/pull/1936))
+  * Fix cgroup memory limit detection for inherited limits from parent slices. ([#1933](https://github.com/awslabs/mountpoint-s3/pull/1933))
+
+# Unreleased
+
+### Notable changes
 * Removed support for AL2, and Ubuntu 22.04.
 * Drop support for Kubernetes 1.30.
 * Support Mountpoint [version 1.23.0](https://github.com/awslabs/mountpoint-s3/releases/tag/mountpoint-s3-1.23.0) ([#868](https://github.com/awslabs/mountpoint-s3-csi-driver/pull/868))

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-ARG MOUNTPOINT_VERSION=1.23.0
+ARG MOUNTPOINT_VERSION=1.24.0
 
 # Download the mountpoint tarball and produce an installable directory
 FROM --platform=$TARGETPLATFORM public.ecr.aws/amazonlinux/amazonlinux:2023 as mp_builder

--- a/pkg/driver/node/mounter/pod_mounter.go
+++ b/pkg/driver/node/mounter/pod_mounter.go
@@ -236,12 +236,6 @@ func (pm *PodMounter) mountS3AtSource(ctx context.Context, source string, mpPod 
 		return fmt.Errorf("Failed to mount %s: %w", source, err)
 	}
 
-	// Remove the read-only argument from the list as mount-s3 does not support it when using FUSE
-	// file descriptor (we already pass MS_RDONLY flag during mount syscall in `pod_mounter_linux.go`)
-	if args.Has(mountpoint.ArgReadOnly) {
-		args.Remove(mountpoint.ArgReadOnly)
-	}
-
 	// This will set to false in the success condition. This is set to `true` by default to
 	// ensure we don't leave `source` mounted if Mountpoint is not started to serve requests for it.
 	unmount := true

--- a/pkg/driver/node/mounter/pod_mounter_test.go
+++ b/pkg/driver/node/mounter/pod_mounter_test.go
@@ -236,6 +236,7 @@ func TestPodMounter(t *testing.T) {
 			assert.Equals(t, mountoptions.Options{
 				BucketName: testCtx.bucketName,
 				Args: []string{
+					mountpoint.ArgReadOnly,
 					"--user-agent-prefix=" + mounter.UserAgent(credentialprovider.AuthenticationSourceDriver, testK8sVersion, cluster.DefaultKubernetes),
 				},
 				Env: env.List(),


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Bump Mountpoint to v1.24.0.

Mountpoint v1.24.0 accepts `--read-only` with a FUSE file descriptor mount point, so stop dropping the argument before sending mount options to the Mountpoint Pod.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
