### PR TITLE
kustomize: sync sidecar image versions with Helm chart

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -121,7 +121,7 @@ spec:
               cpu: 10m
               memory: 40Mi
         - name: node-driver-registrar
-          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.3
+          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.5
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true
@@ -159,7 +159,7 @@ spec:
               cpu: 10m
               memory: 40Mi
         - name: liveness-probe
-          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.3
+          image: public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.5
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

PR #910 bumped the node-driver-registrar and livenessprobe sidecars to `-eksbuild.5` in the Helm chart values but left the Kustomize base at `-eksbuild.3`, so Kustomize installs kept pulling the older images.

Bump both to match the chart:
  - csi-node-driver-registrar v2.17.0-eksbuild.3 -> v2.17.0-eksbuild.5
  - livenessprobe             v2.19.0-eksbuild.3 -> v2.19.0-eksbuild.5

Verified that `kubectl kustomize deploy/kubernetes/overlays/stable` and `helm template charts/aws-mountpoint-s3-csi-driver` now emit identical image references.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
