### PR TITLE
Do not fail tests if the S3 bucket already exists

### DIFF
--- a/tests/e2e-kubernetes/s3client/client.go
+++ b/tests/e2e-kubernetes/s3client/client.go
@@ -3,6 +3,7 @@ package s3client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -154,10 +155,18 @@ func (c *Client) create(ctx context.Context, input *s3.CreateBucketInput) Delete
 	bucketName := *input.Bucket
 
 	_, err := c.client.CreateBucket(ctx, input)
-	framework.ExpectNoError(err, "Failed to create S3 bucket %s", bucketName)
-	if err == nil {
-		framework.Logf("S3 Bucket %s created", bucketName)
+	// The S3 client is configured with retries (see NewWithRegion). Under transient
+	// failures the first attempt can succeed server-side while still returning an error,
+	// and a retry will then observe BucketAlreadyOwnedByYou. That response confirms
+	// this account already owns the bucket, so the create is effectively done — treat
+	// it as success. BucketAlreadyExists (owned by a *different* account) is NOT
+	// swallowed here and will still fail the test.
+	if _, ok := errors.AsType[*types.BucketAlreadyOwnedByYou](err); ok {
+		framework.Logf("S3 Bucket %s already owned by this account; treating as created", bucketName)
+	} else {
+		framework.ExpectNoError(err, "Failed to create S3 bucket %s", bucketName)
 	}
+	framework.Logf("S3 Bucket %s created", bucketName)
 
 	return func(ctx context.Context) error {
 		return c.delete(ctx, bucketName)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Problem: 
- The SDK can retry, causing `BucketAlreadyOwnedByYou` errors for the initial creation if the backend actually created the bucket.
- This can cause a flaky test failure even though everything's actually fine.

Solution: 
- Don't fail the tests if we get `BucketAlreadyOwnedByYou`, and assume we actually created the bucket successfully.

Testing:
- Ran one e2e test and verified that it still passes
- Verified that if I hard-code the bucket name to be created, the new code path is executed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
