### PR TITLE
Add user agent to daemonset mounter approach

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -127,7 +127,7 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 		klog.Info("Using daemonset mounter mode")
 		klog.Info("Note: s3-csi-daemonset-mounter uses OnDelete update strategy - helm upgrade will not restart/upgrade mounter pods automatically")
 
-		dm := mounter.NewDaemonsetMounter(clientset, nodeID, mpmounter.New(), credProvider, nil, nil, nil)
+		dm := mounter.NewDaemonsetMounter(clientset, nodeID, mpmounter.New(), credProvider, nil, nil, nil, kubernetesVersion, variant)
 
 		// Rebuild mount map from persisted .meta.json files + kernel mount table.
 		// Fatal on failure: operating with an empty map while FUSE mounts exist

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/klog/v2"
 	mountutils "k8s.io/mount-utils"
 
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/cluster"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/targetpath"
@@ -101,6 +102,11 @@ type DaemonsetMounter struct {
 	mount        *mpmounter.Mounter
 	credProvider credentialprovider.ProviderInterface
 
+	// kubernetesVersion and variant identify the cluster; used to build the Mountpoint
+	// user-agent so S3-side telemetry sees which cluster the request came from.
+	kubernetesVersion string
+	variant           cluster.Variant
+
 	// Comm dir discovery: commDir caches the path (nil = stale),
 	// rediscoverCh wakes the background watcher to re-discover immediately.
 	commDir      atomic.Pointer[string]
@@ -120,13 +126,15 @@ type DaemonsetMounter struct {
 // mountSyscall, bindMountSyscall, and mountInfoProvider may be nil,
 // in which case the default implementations are used.
 func NewDaemonsetMounter(clientset kubernetes.Interface, nodeID string, mount *mpmounter.Mounter,
-	credProvider credentialprovider.ProviderInterface, mountSyscall mountSyscallFunc, bindMountSyscall bindMountSyscallFunc, mountInfoProvider mountInfoProviderFunc) *DaemonsetMounter {
+	credProvider credentialprovider.ProviderInterface, mountSyscall mountSyscallFunc, bindMountSyscall bindMountSyscallFunc, mountInfoProvider mountInfoProviderFunc, kubernetesVersion string, variant cluster.Variant) *DaemonsetMounter {
 	return &DaemonsetMounter{
 		clientset:         clientset,
 		nodeID:            nodeID,
 		kubeletPath:       util.ContainerKubeletPath(),
 		mount:             mount,
 		credProvider:      credProvider,
+		kubernetesVersion: kubernetesVersion,
+		variant:           variant,
 		rediscoverCh:      make(chan struct{}, 1),
 		mountSyscall:      mountSyscall,
 		bindMountSyscall:  bindMountSyscall,
@@ -280,7 +288,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	// Provision credentials under the lock. We always use entry.CommDir which is set above
 	// (either from an existing healthy entry, or freshly assigned from commDir on new mount).
 	// This ensures credentials are written to the same location that cleanup will look at.
-	credsEnv, err := dm.provideCredentials(ctx, entry.CommDir, volumeID, &credentialCtx)
+	credsEnv, authSource, err := dm.provideCredentials(ctx, entry.CommDir, volumeID, &credentialCtx)
 	if err != nil {
 		return err
 	}
@@ -305,7 +313,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 
 	// New mount: FUSE mount at source, then bind to target.
 
-	if err := dm.fuseMount(ctx, bucketName, entry.SourcePath, volumeID, commDir, args, userEnv, credsEnv); err != nil {
+	if err := dm.fuseMount(ctx, bucketName, entry.SourcePath, volumeID, commDir, args, userEnv, credsEnv, authSource); err != nil {
 		if cleanErr := dm.cleanupMount(entry, credentialCtx.ToCleanupCtx()); cleanErr != nil {
 			klog.Errorf("DaemonsetMounter: cleanup after fuseMount failure for volume %s: %v", volumeID, cleanErr)
 			return err
@@ -338,8 +346,9 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 // fuseMount performs the FUSE mount + FD send + wait cycle at the given path.
 // Credentials are already provisioned by the caller (Mount).
 // commDir is passed from the caller to ensure a single GetCommDir() per NodePublishVolume.
+// authSource is the resolved AuthenticationSource returned by the credential provider
 func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mountPath string,
-	volumeID string, commDir string, args mountpoint.Args, userEnv envprovider.Environment, credsEnv envprovider.Environment) error {
+	volumeID string, commDir string, args mountpoint.Args, userEnv envprovider.Environment, credsEnv envprovider.Environment, authSource credentialprovider.AuthenticationSource) error {
 
 	if err := os.MkdirAll(mountPath, targetDirPerm); err != nil {
 		return fmt.Errorf("failed to create mount directory %q: %w", mountPath, err)
@@ -362,6 +371,9 @@ func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mo
 	}()
 
 	args.Remove(mountpoint.ArgReadOnly)
+
+	// We set the user-agent here so it doesn't get captured into the pod-sharing key or persisted meta.
+	args.Set(mountpoint.ArgUserAgentPrefix, UserAgent(authSource, dm.kubernetesVersion, dm.variant))
 
 	env := envprovider.Environment{}
 	env.Merge(userEnv)
@@ -825,20 +837,20 @@ func (dm *DaemonsetMounter) isSystemDMountpoint(target string) bool {
 }
 
 // provideCredentials creates a per-mount credential directory and provisions credentials into it.
-func (dm *DaemonsetMounter) provideCredentials(ctx context.Context, commDir, volumeID string, credentialCtx *credentialprovider.ProvideContext) (envprovider.Environment, error) {
+func (dm *DaemonsetMounter) provideCredentials(ctx context.Context, commDir, volumeID string, credentialCtx *credentialprovider.ProvideContext) (envprovider.Environment, credentialprovider.AuthenticationSource, error) {
 	mountCredDir := filepath.Join(commDir, volumeID)
 	if err := os.MkdirAll(mountCredDir, credentialprovider.CredentialDirPerm); err != nil {
-		return nil, fmt.Errorf("failed to create credential directory %q: %w", mountCredDir, err)
+		return nil, "", fmt.Errorf("failed to create credential directory %q: %w", mountCredDir, err)
 	}
 	credentialCtx.WritePath = mountCredDir
 	credentialCtx.EnvPath = filepath.Join("/comm", volumeID)
 	credentialCtx.MountKind = credentialprovider.MountKindDaemonset
 
-	env, _, err := dm.credProvider.Provide(ctx, *credentialCtx)
+	env, authSource, err := dm.credProvider.Provide(ctx, *credentialCtx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to provide credentials for mount %s: %w", volumeID, err)
+		return nil, "", fmt.Errorf("failed to provide credentials for mount %s: %w", volumeID, err)
 	}
-	return env, nil
+	return env, authSource, nil
 }
 
 // cleanupCredentials removes the per-mount credential directory.

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -102,8 +102,6 @@ type DaemonsetMounter struct {
 	mount        *mpmounter.Mounter
 	credProvider credentialprovider.ProviderInterface
 
-	// kubernetesVersion and variant identify the cluster; used to build the Mountpoint
-	// user-agent so S3-side telemetry sees which cluster the request came from.
 	kubernetesVersion string
 	variant           cluster.Variant
 
@@ -290,7 +288,7 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 	// This ensures credentials are written to the same location that cleanup will look at.
 	credsEnv, authSource, err := dm.provideCredentials(ctx, entry.CommDir, volumeID, &credentialCtx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to provide credentials for volume %s: %w. %s", volumeID, err, helpMessageForGettingMounterLogs())
 	}
 
 	// Idempotency: if target is already mounted (republish/retry), creds are refreshed above, done.
@@ -346,7 +344,6 @@ func (dm *DaemonsetMounter) mountOrShareSource(ctx context.Context, bucketName s
 // fuseMount performs the FUSE mount + FD send + wait cycle at the given path.
 // Credentials are already provisioned by the caller (Mount).
 // commDir is passed from the caller to ensure a single GetCommDir() per NodePublishVolume.
-// authSource is the resolved AuthenticationSource returned by the credential provider
 func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mountPath string,
 	volumeID string, commDir string, args mountpoint.Args, userEnv envprovider.Environment, credsEnv envprovider.Environment, authSource credentialprovider.AuthenticationSource) error {
 
@@ -372,7 +369,7 @@ func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mo
 
 	args.Remove(mountpoint.ArgReadOnly)
 
-	// We set the user-agent here so it doesn't get captured into the pod-sharing key or persisted meta.
+	// Set after the pod-sharing key is taken from args above, so it stays out of that key and the saved meta.
 	args.Set(mountpoint.ArgUserAgentPrefix, UserAgent(authSource, dm.kubernetesVersion, dm.variant))
 
 	env := envprovider.Environment{}
@@ -848,7 +845,7 @@ func (dm *DaemonsetMounter) provideCredentials(ctx context.Context, commDir, vol
 
 	env, authSource, err := dm.credProvider.Provide(ctx, *credentialCtx)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to provide credentials for mount %s: %w", volumeID, err)
+		return nil, "", err
 	}
 	return env, authSource, nil
 }

--- a/pkg/driver/node/mounter/daemonset_mounter_test.go
+++ b/pkg/driver/node/mounter/daemonset_mounter_test.go
@@ -506,7 +506,8 @@ func TestDaemonsetMounter(t *testing.T) {
 				},
 				nil,
 				nil,
-				"", cluster.DefaultKubernetes,
+				"",
+				cluster.DefaultKubernetes,
 			)
 
 			err := testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target, credentialprovider.ProvideContext{

--- a/pkg/driver/node/mounter/daemonset_mounter_test.go
+++ b/pkg/driver/node/mounter/daemonset_mounter_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	mountutils "k8s.io/mount-utils"
 
+	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/cluster"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider"
 	mock_credentialprovider "github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/credentialprovider/mocks"
 	"github.com/awslabs/mountpoint-s3-csi-driver/pkg/driver/node/envprovider"
@@ -144,7 +145,7 @@ func setupDM(t *testing.T) *dmTestCtx {
 			infos = append(infos, mountutils.MountInfo{MountPoint: mp.Path})
 		}
 		return infos, nil
-	})
+	}, testK8sVersion, cluster.DefaultKubernetes)
 	err = dm.DiscoverCommDir(ctx)
 	assert.NoError(t, err)
 
@@ -196,9 +197,11 @@ func TestDaemonsetMounter(t *testing.T) {
 			got.Fd = 0
 
 			env := envprovider.Default()
+			// The mount must carry the user-agent, built from the same inputs setupDM used.
+			expectedUserAgent := "--user-agent-prefix=" + mounter.UserAgent(credentialprovider.AuthenticationSourceDriver, testK8sVersion, cluster.DefaultKubernetes)
 			assert.Equals(t, mountoptions.Options{
 				BucketName: testCtx.bucketName,
-				Args:       []string{"--prefix=data/"},
+				Args:       []string{"--prefix=data/", expectedUserAgent},
 				Env:        env.List(),
 				VolumeId:   testCtx.volumeID,
 			}, got)
@@ -230,7 +233,7 @@ func TestDaemonsetMounter(t *testing.T) {
 					return 0, nil
 				}, func(source, target string) error {
 					return testCtx.mount.Mount(source, target, "bind", []string{"bind"})
-				}, nil)
+				}, nil, "", cluster.DefaultKubernetes)
 			err := testCtx.dm.DiscoverCommDir(testCtx.ctx)
 			assert.NoError(t, err)
 
@@ -288,7 +291,7 @@ func TestDaemonsetMounter(t *testing.T) {
 					return 0, mountErr
 				}, func(source, target string) error {
 					return testCtx.mount.Mount(source, target, "bind", []string{"bind"})
-				}, nil)
+				}, nil, "", cluster.DefaultKubernetes)
 			err := testCtx.dm.DiscoverCommDir(testCtx.ctx)
 			assert.NoError(t, err)
 
@@ -451,7 +454,7 @@ func TestDaemonsetMounter(t *testing.T) {
 					t.Setenv("CONTAINER_KUBELET_PATH", t.TempDir())
 
 					client := fake.NewSimpleClientset(tt.pods...)
-					dm := mounter.NewDaemonsetMounter(client, "test-node", mpmounter.NewWithMount(mountutils.NewFakeMounter(nil)), nil, nil, nil, nil)
+					dm := mounter.NewDaemonsetMounter(client, "test-node", mpmounter.NewWithMount(mountutils.NewFakeMounter(nil)), nil, nil, nil, nil, "", cluster.DefaultKubernetes)
 
 					ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 					defer cancel()
@@ -503,6 +506,7 @@ func TestDaemonsetMounter(t *testing.T) {
 				},
 				nil,
 				nil,
+				"", cluster.DefaultKubernetes,
 			)
 
 			err := testCtx.dm.Mount(testCtx.ctx, testCtx.bucketName, target, credentialprovider.ProvideContext{
@@ -661,7 +665,7 @@ func TestDaemonsetMounter_PodSharing(t *testing.T) {
 			mpmounter.NewWithMount(testCtx.mount), mockCredProvider,
 			testCtx.mountSyscall, func(source, target string) error {
 				return testCtx.mount.Mount(source, target, "bind", []string{"bind"})
-			}, nil)
+			}, nil, "", cluster.DefaultKubernetes)
 		err := testCtx.dm.DiscoverCommDir(testCtx.ctx)
 		assert.NoError(t, err)
 
@@ -936,7 +940,7 @@ func healthPathErr(errno syscall.Errno) error {
 // newHealthDM builds a DaemonsetMounter wired only with the given mount interface;
 // IsSourceHealthy touches nothing else.
 func newHealthDM(mount mountutils.Interface) *mounter.DaemonsetMounter {
-	return mounter.NewDaemonsetMounter(nil, "", mpmounter.NewWithMount(mount), nil, nil, nil, nil)
+	return mounter.NewDaemonsetMounter(nil, "", mpmounter.NewWithMount(mount), nil, nil, nil, nil, "", cluster.DefaultKubernetes)
 }
 
 // healthSource returns a real, existing directory when exists is true (so statx
@@ -1219,6 +1223,7 @@ func TestMount_CorruptedTarget_NoMapEntryNoMeta(t *testing.T) {
 		nil, "test-node",
 		mpmounter.NewWithMount(corruptedMount),
 		nil, nil, nil, nil,
+		"", cluster.DefaultKubernetes,
 	)
 
 	ctx := context.Background()
@@ -1259,6 +1264,7 @@ func TestMount_AbsentTarget_ProceedsToMount(t *testing.T) {
 		nil, "test-node",
 		mpmounter.NewWithMount(&fakeHealthMount{}),
 		nil, nil, nil, nil,
+		"", cluster.DefaultKubernetes,
 	)
 
 	ctx := context.Background()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds the Mountpoint user-agent to the V3 daemonset mounter. V2 (`PodMounter`) already
stamps `mount-s3` requests with a telemetry string (`s3-csi-driver/<ver> credential-source#<src>
k8s/<ver> md/install#<method>`); V3 didn't, so V3 mounts were untagged. This brings V3 to parity.

How: give `DaemonsetMounter` the `kubernetesVersion` and `variant` it was missing (passed in
from `driver.go`), stop discarding the resolved auth source from `provideCredentials`, and set
`--user-agent-prefix` inside `fuseMount`. Setting it there — after the pod-sharing options are
snapshotted — keeps the user-agent out of the sharing compatibility key and the persisted meta.

### Testing
Unit tests
Extended the daemonset "Correctly passes mount options" test to assert the args sent to
`mount-s3` include `--user-agent-prefix=<UserAgent(...)>`, built from the same inputs.

Situations covered for the V3 user-agent:

| Situation | Covered by |
|---|---|
| V3 mount actually sets `--user-agent-prefix` and sends it to `mount-s3` | `daemonset_mounter_test.go` — "Correctly passes mount options" (this PR) |
| String format: `credential-source#driver` vs `#pod` | `user_agent_test.go` — `TestUserAgent` (pre-existing) |
| String format: k8s version present vs empty (segment dropped) | `user_agent_test.go` — `TestUserAgent` (pre-existing) |
| String format: OpenShift variant + install method (helm / eks-addon / kustomize / unknown) | `user_agent_test.go` — `TestUserAgent` (pre-existing) |


Manual tests
Deployed to an EKS cluster in daemonset mode, mounted a volume, and confirmed the live
`mount-s3` process's cmdline contained `--user-agent-prefix=s3-csi-driver/2.7.0
credential-source#driver k8s/v1.36.2-eks-... md/install#helm`.

No e2e test was added — the user-agent is unit-tested only, matching V2's testign coverage
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
