### PR TITLE
Document kubectl drain failure on Mountpoint pods

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -145,6 +145,24 @@ This error occurs when workload pods are terminated before the Mountpoint pod th
 
 **Recommendation:** Keep workload pod termination grace periods sufficiently low to ensure graceful shutdown completes within the Mountpoint pod's 10-minute window and the grace period specified in the `drain` operation (e.g. via Karpenter NodePool [settings](https://karpenter.sh/docs/concepts/nodepools/#spectemplatespecterminationgraceperiod)).
 
+## My node drain fails with "cannot delete Pods that declare no controller"
+
+`kubectl drain` refuses to evict the Mountpoint pods, failing with:
+
+```
+cannot delete Pods that declare no controller (use --force to override): mount-s3/mp-xxxxx
+```
+
+The Mountpoint pods (`mp-*` in the `mount-s3` namespace) have no owning controller, so `kubectl drain` won't evict them without `--force`. Passing `--force` is safe — the Mountpoint pods keep serving the volume during their grace period so workloads shut down first (see ["Transport endpoint is not connected"](#my-workload-pods-are-getting-transport-endpoint-is-not-connected-errors-during-node-drain) above):
+
+```
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data --force
+```
+
+[`--delete-emptydir-data`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#drain) is required because the Mountpoint pods use an [in-memory `emptyDir`](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/e9031e3542fb421ec5a7242a2359a24043b6c6c1/pkg/podmounter/mppod/creator.go#L191-L199) (`/comm`) that `kubectl drain` won't evict otherwise, even with `--force`; `--ignore-daemonsets` is a standard drain flag for the node's DaemonSets, including the driver's `s3-csi-node`.
+
+Note that `--force` does **not** bypass PodDisruptionBudgets. If a workload's PDB does not allow the disruption (for example `maxUnavailable: 0`), the drain stalls with `Cannot evict pod as it would violate the pod's disruption budget.` — that is the PDB protecting your workload. Relax the PDB so the workload can reschedule, rather than deleting its pods to force the drain through.
+
 ## Cluster Autoscaler blocked by Mountpoint pods (prior to v2.5.0)
 
 Prior to version v2.5.0, Cluster Autoscaler may stop scaling nodes down due to `mount-s3/mp-*` pods blocking node removal.


### PR DESCRIPTION
*Issue #, if available:* #787

*Description of changes:*

Adds a troubleshooting entry for the `kubectl drain` failure on controller-less Mountpoint pods (#787): the `mp-*` pods have no owning controller, so `kubectl drain` refuses them without `--force` (`cannot delete Pods that declare no controller`).

The entry explains the `--force` workaround (safe because the Mountpoint pods keep serving the volume during their grace period), and notes that `--force` does not bypass PodDisruptionBudgets — a restrictive PDB can still stall the drain, and force-deleting those pods can interrupt the application.

**_Testing_**:
I tested manually and confirmed the behaviour

Docs-only change; no behavior change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.