### PR TITLE
Deprecate GitHub branch Helm chart installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ The S3 CSI Driver is distributed through the following supported channels:
 - **Helm repository** — `helm repo add aws-mountpoint-s3-csi-driver https://awslabs.github.io/mountpoint-s3-csi-driver`
 
 > [!WARNING]
-> Installing directly from a GitHub branch (`main`, `release-X.Y`, or any other) is not supported. Charts in the GitHub repository may reference unreleased images or contain in-progress changes that are incompatible with published binaries.
-> **After September 1, 2026, charts on the main branch will no longer be installable.** Please migrate to the Helm repository or EKS Addon installation method before this date.
+> Installing directly from a GitHub branch (`main`, `release-X.Y`, or any other) is not supported. Charts in the GitHub repository may reference unreleased images or contain in-progress changes that are incompatible with published binaries. Please migrate to the Helm repository or EKS Addon installation methods.
 
 See [Driver Installation](docs/INSTALL.md) for detailed instructions.
 

--- a/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
@@ -6,7 +6,7 @@ Learn more about the file system operations Mountpoint supports: https://github.
 WARNING: This is an unsupported development installation from a Git checkout. Do NOT use it for production workloads.
 The chart in this repository may reference container images that have not been published yet,
 or contain in-progress changes that are incompatible with the images it references.
-Please use a supported installation method instead described in https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md.
+Please see supported installation methods in https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md.
 {{- end }}
 {{- if .Release.IsUpgrade }}
 

--- a/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/NOTES.txt
@@ -1,14 +1,12 @@
 Thank you for using Mountpoint for Amazon S3 CSI Driver v{{ .Chart.Version }}.
 
 Learn more about the file system operations Mountpoint supports: https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md
-{{- if and (not .Values.isHelmRepo) (not .Values.isEKSAddon) }}
+{{- if .Values.unsupportedDevInstall }}
 
-WARNING: You are installing from a GitHub branch.
-This installation method will stop working after September 1, 2026.
-Please migrate to a supported installation method:
-  - Helm repo: helm repo add aws-mountpoint-s3-csi-driver https://awslabs.github.io/mountpoint-s3-csi-driver
-  - EKS Addon: See https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html
-For more details, see: https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md
+WARNING: This is an unsupported development installation from a Git checkout. Do NOT use it for production workloads.
+The chart in this repository may reference container images that have not been published yet,
+or contain in-progress changes that are incompatible with the images it references.
+Please use a supported installation method instead described in https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md.
 {{- end }}
 {{- if .Release.IsUpgrade }}
 

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -1,3 +1,13 @@
+{{- if and (not .Values.isHelmRepo) (not .Values.isEKSAddon) (not .Values.unsupportedDevInstall) -}}
+{{- fail `
+
+ERROR: This Helm chart cannot be installed directly from GitHub main branch, as it may reference unreleased images.
+
+Please migrate to a supported installation method described in https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md.
+For (unsupported) development installation, please set the 'unsupportedDevInstall' value to 'true'.
+See https://github.com/awslabs/mountpoint-s3-csi-driver/issues/859 for more details.
+` -}}
+{{- end -}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/node.yaml
@@ -113,7 +113,7 @@ spec:
             - name: EKS_POD_IDENTITY_AGENT_CONTAINER_CREDENTIALS_FULL_URI
               value: {{ .Values.eksPodIdentityAgent.containerCredentialsFullURI }}
             - name: INSTALLATION_TYPE
-              value: {{ if .Values.isEKSAddon }}eks-addon{{ else }}helm{{ end }}
+              value: {{ if .Values.isEKSAddon }}eks-addon{{ else if .Values.isHelmRepo }}helm{{ else }}helm-dev{{ end }}
             {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/dev/README.md
+++ b/dev/README.md
@@ -396,6 +396,7 @@ $ pwd
 # "image.pullPolicy=Always" disables this caching behaviour and ensures Kubernetes would always pull the latest image each time it starts the CSI Driver's containers.
 $ helm upgrade --install aws-mountpoint-s3-csi-driver \
     --namespace kube-system \
+    --set unsupportedDevInstall=true \
     --set image.repository="111122223333.dkr.ecr.eu-north-1.amazonaws.com/mp-dev" \
     --set image.pullPolicy=Always \
     --set image.tag=latest \

--- a/dev/README.md
+++ b/dev/README.md
@@ -268,6 +268,7 @@ $ pwd
 
 $ helm upgrade --install aws-mountpoint-s3-csi-driver \
     --namespace kube-system \
+    --set unsupportedDevInstall=true \
    ./charts/aws-mountpoint-s3-csi-driver
 ```
 
@@ -275,9 +276,12 @@ This would install the Helm chart with the default values. You can customise [de
 ```bash
 $ helm upgrade --install aws-mountpoint-s3-csi-driver \
     --namespace kube-system \
+    --set unsupportedDevInstall=true \
     --set controller.nodeSelector."kubernetes\.io/role"="control-plane" \
    ./charts/aws-mountpoint-s3-csi-driver
 ```
+
+Note that `--set unsupportedDevInstall=true` is required for development installs, because we made `helm install` from GitHub branches fail, as it may reference container images that have not been published yet or contain in-progress changes that are incompatible with the images it references.
 
 You can verify that the CSI Driver is installed by listing all Pods owned by the CSI Driver:
 ```bash

--- a/dev/mp-dev.sh
+++ b/dev/mp-dev.sh
@@ -135,6 +135,7 @@ deploy_helm_chart() {
     echo "deploying Helm chart..."
     helm upgrade --install aws-mountpoint-s3-csi-driver \
         --namespace kube-system \
+        --set unsupportedDevInstall=true \
         --set image.repository="${ecr_repository_url}" \
         --set image.pullPolicy=Always \
         --set image.tag=latest \

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,8 +10,12 @@
 
 ## Installation
 
+Supported installation methods:
+- [Amazon EKS managed add-on](#amazon-eks-managed-add-on): see [Amazon EKS docs](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html)
+- [Helm repository](#helm): `https://awslabs.github.io/mountpoint-s3-csi-driver`
+
 > [!WARNING]
-> **Supported installation methods:** EKS Addon or the official Helm repository: `https://awslabs.github.io/mountpoint-s3-csi-driver`. Installing from a GitHub branch (`main`, `release-X.Y`, or any other; via `helm install ./charts/...`, or GitOps tools pointing at this repository) is not supported and may break without notice during releases.
+> Installing from a GitHub branch (`main`, `release-X.Y`, or any other; via `helm install ./charts/...`, or GitOps tools pointing at this repository) is not supported and is not installable. For more details, please see GitHub issue [Helm chart installation from main branch will stop working on September 1, 2026 #859](https://github.com/awslabs/mountpoint-s3-csi-driver/issues/859).
 
 ### Cluster setup (optional)
 
@@ -61,7 +65,7 @@ You may deploy the Mountpoint for Amazon S3 CSI Driver via [Amazon EKS managed a
 
 #### Amazon EKS managed add-on
 
-See [the Amazon EKS guide](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html) for more details on installing the Amazon EKS managed add-on of Mountpoint for Amazon S3 CSI Driver.
+See [Amazon EKS docs](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html) for more details on installing the Amazon EKS managed add-on of Mountpoint for Amazon S3 CSI Driver.
 
 #### Helm
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,12 +10,12 @@
 
 ## Installation
 
-Supported installation methods:
-- [Amazon EKS managed add-on](#amazon-eks-managed-add-on): see [Amazon EKS docs](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html)
-- [Helm repository](#helm): `https://awslabs.github.io/mountpoint-s3-csi-driver`
+The S3 CSI Driver is distributed through the following supported channels:
+- [**EKS Addon**](#amazon-eks-managed-add-on) (recommended for EKS clusters) — see [Amazon EKS guide](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html)
+- [**Helm repository**](#helm) — `helm repo add aws-mountpoint-s3-csi-driver https://awslabs.github.io/mountpoint-s3-csi-driver`
 
 > [!WARNING]
-> Installing from a GitHub branch (`main`, `release-X.Y`, or any other; via `helm install ./charts/...`, or GitOps tools pointing at this repository) is not supported and is not installable. For more details, please see GitHub issue [Helm chart installation from main branch will stop working on September 1, 2026 #859](https://github.com/awslabs/mountpoint-s3-csi-driver/issues/859).
+> Installing directly from a GitHub branch (`main`, `release-X.Y`, or any other) is not supported. Charts in the GitHub repository may reference unreleased images or contain in-progress changes that are incompatible with published binaries. Please migrate to the Helm repository or EKS Addon installation methods. For more details, please see [GitHub issue #859](https://github.com/awslabs/mountpoint-s3-csi-driver/issues/859).
 
 ### Cluster setup (optional)
 
@@ -65,7 +65,7 @@ You may deploy the Mountpoint for Amazon S3 CSI Driver via [Amazon EKS managed a
 
 #### Amazon EKS managed add-on
 
-See [Amazon EKS docs](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html) for more details on installing the Amazon EKS managed add-on of Mountpoint for Amazon S3 CSI Driver.
+See [the Amazon EKS guide](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html) for more details on installing the Amazon EKS managed add-on of Mountpoint for Amazon S3 CSI Driver.
 
 #### Helm
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -57,11 +57,12 @@ func DetectVariant(client *rest.Config, log logr.Logger) Variant {
 // InstallationMethod returns the installation method for the CSI driver.
 // It reads the INSTALLATION_TYPE environment variable and returns its value,
 // falling back to "unknown" if the variable is not set.
-// Known values: eks-addon, helm, kustomize.
+// Known values: eks-addon, helm, helm-dev, kustomize.
+// (Note helm-dev is installation method for development purposes only, set by unsupportedDevInstall flag)
 func InstallationMethod() string {
 	method := strings.ToLower(strings.TrimSpace(os.Getenv("INSTALLATION_TYPE")))
 	switch method {
-	case "eks-addon", "helm", "kustomize":
+	case "eks-addon", "helm", "helm-dev", "kustomize":
 		return method
 	}
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -56,6 +56,11 @@ func TestInstallationMethod(t *testing.T) {
 			expected: "eks-addon",
 		},
 		{
+			name:     "helm-dev should be recognized",
+			input:    "helm-dev",
+			expected: "helm-dev",
+		},
+		{
 			name:     "value should be sanitized and lowercased",
 			input:    "  HELM  ",
 			expected: "helm",

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -107,6 +107,11 @@ func NewDriver(endpoint string, mpVersion string, nodeID string) (*Driver, error
 	version := version.GetVersion()
 	klog.Infof("Driver version: %v, Git commit: %v, build date: %v, nodeID: %v, mount-s3 version: %v, kubernetes version: %v, variant: %s, install: %v",
 		version.DriverVersion, version.GitCommit, version.BuildDate, nodeID, mpVersion, kubernetesVersion, variant.String(), installMethod)
+	if installMethod == "helm-dev" {
+		klog.Warning("This is an unsupported development installation from a Git checkout. Do NOT use it for production workloads. " +
+			"The chart in this repository may reference container images that have not been published yet, or contain in-progress changes that are incompatible with the images it references. " +
+			"Please see supported installation methods in https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/INSTALL.md.")
+	}
 	// `credentialprovider.RegionFromIMDSOnce` is a `sync.OnceValues` and it only makes request to IMDS once,
 	// this call is basically here to pre-warm the cache of IMDS call.
 	go func() {

--- a/pkg/driver/node/mounter/user_agent_test.go
+++ b/pkg/driver/node/mounter/user_agent_test.go
@@ -73,6 +73,12 @@ func TestUserAgent(t *testing.T) {
 			installationType:     "helm",
 			result:               "s3-csi-driver/ credential-source#driver k8s/v1.28.0 md/install#helm",
 		},
+		"helm dev installation method": {
+			k8sVersion:           "v1.36.0",
+			authenticationSource: credentialprovider.AuthenticationSourceDriver,
+			installationType:     "helm-dev",
+			result:               "s3-csi-driver/ credential-source#driver k8s/v1.36.0 md/install#helm-dev",
+		},
 		"openshift with helm": {
 			k8sVersion:           "v1.33.6",
 			authenticationSource: credentialprovider.AuthenticationSourcePod,

--- a/scripts/verify-helm-images.sh
+++ b/scripts/verify-helm-images.sh
@@ -122,7 +122,7 @@ verify_sidecar_images_in_chart() {
 }
 
 echo "== Verifying standard images =="
-verify_sidecar_images_in_chart "helm template $CHART_DIR"
+verify_sidecar_images_in_chart "helm template $CHART_DIR --set unsupportedDevInstall=true"
 
 if [[ ${PUBLIC_ONLY} -eq 0 ]]; then
   echo "== Verifying EKS Addon images =="

--- a/tests/e2e-kubernetes/scripts/helm.sh
+++ b/tests/e2e-kubernetes/scripts/helm.sh
@@ -67,6 +67,7 @@ function helm_install_driver() {
 
   $HELM_BIN upgrade --install $RELEASE_NAME --namespace kube-system ./charts/aws-mountpoint-s3-csi-driver --values \
     ./charts/aws-mountpoint-s3-csi-driver/values.yaml \
+    --set unsupportedDevInstall=true \
     --set image.repository=${REPOSITORY} \
     --set image.tag=${TAG} \
     --set image.pullPolicy=Always \

--- a/tests/e2e-kubernetes/testsuites/upgrade.go
+++ b/tests/e2e-kubernetes/testsuites/upgrade.go
@@ -471,6 +471,7 @@ func (t *s3CSIUpgradeTestSuite) DefineTests(driver storageframework.TestDriver, 
 // without image overrides so the chart's default image would be used.
 func buildHelmValuesBase() map[string]any {
 	return map[string]any{
+		"unsupportedDevInstall": true,
 		"node": map[string]any{
 			"podInfoOnMountCompat": map[string]any{
 				"enable": "true",


### PR DESCRIPTION
> [!NOTE]
> To merge on September 1, 2026 as promised in the pinned GitHub issue.

### Description of changes

*Issue #, if available:*  https://github.com/awslabs/mountpoint-s3-csi-driver/issues/859

- Add `unsupportedDevInstall` flag for dev bypass (Naming TBD)
- Fail in helm render if not using Helm / EKS Addon / dev installation methods
- Add helm-dev `INSTALLATION_TYPE`, add field to user agent with test edits
- Warn users if they are on dev installation type in node logs and in helm install (NOTES.txt).

Development breaking change: Developers must use `--set unsupportedDevInstall=true ` flag from now on:
```
helm upgrade --install aws-mountpoint-s3-csi-driver \
    --namespace kube-system \
    --set unsupportedDevInstall=true \
    ...
```
(No changes if you use mp-dev.sh script)

### Testing

1: Helm render
```
helm template charts/aws-mountpoint-s3-csi-driver
Error: execution error at (aws-mountpoint-s3-csi-driver/templates/node.yaml:2:4):

ERROR: This Helm chart cannot be installed directly from GitHub main branch, as it may reference unreleased images.
...
```

2: verify-helm-images / helm.sh tests will be covered in GitHub tests.

3: upgrade tests (no inputs for latest release -> source tests, ran on [jet-tong:chore/deprecate-main-branch-helm-chart-sept-1-2026](https://github.com/jet-tong/mountpoint-s3-csi-driver/tree/chore/deprecate-main-branch-helm-chart-sept-1-2026) branch): https://github.com/jet-tong/mountpoint-s3-csi-driver/actions/runs/33090856790

4: Unit tests for the user agent part

(Will skip testing the warning log in driver.go that mirrors NOTES.txt warning, it's for unsupportedDevInstall flag users only)

5: Tested k8s resources not updated when installing with the failure - ran  `./dev/mp-dev.sh deploy-helm-chart` without the unsupportedDevInstall line, controller didn't get restarted/updated, with the Error: UPGRADE FAILED: execution error failure. The failure fails during rendering stage, which is before anything gets sent to kubernetes. [Source](https://helm.sh/docs/chart_template_guide/getting_started/#:~:text=When%20Helm%20evaluates%20a%20chart%2C%20it%20will%20send%20all%20of%20the%20files%20in%20the%20templates/%20directory%20through%20the%20template%20rendering%20engine.%20It%20then%20collects%20the%20results%20of%20those%20templates%20and%20sends%20them%20on%20to%20Kubernetes).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
