### PR TITLE
Add k8s 1.36.1 to v1 backport

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -11,7 +11,7 @@ matrix:
       "Ubuntu2404",
     ]
   kubernetes-version:
-    ["1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0"]
+    ["1.31.0", "1.32.1", "1.33.2", "1.34.1", "1.35.0", "1.36.1"]
   include:
     # Enable enforcing mode for SELinux in AL2023, it's easier to list it in "include"
     # field rather than trying to exclude all other variants.


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: Adds k8s 1.36.1 to matrix, following main

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
