### PR TITLE
Propagate seLinuxOptions to the mounter daemonset pod

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/mounter-daemonset.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/mounter-daemonset.yaml
@@ -77,6 +77,15 @@ spec:
             drop: ["ALL"]
           seccompProfile:
             type: RuntimeDefault
+          {{- if eq (include "aws-mountpoint-s3-csi-driver.isOpenShift" .) "false" }}
+          {{- with .Values.node.seLinuxOptions }}
+          seLinuxOptions:
+            user: {{ .user }}
+            type: {{ .type }}
+            role: {{ .role }}
+            level: {{ .level }}
+          {{- end }}
+          {{- end }}
         volumeMounts:
           - name: comm
             mountPath: /comm


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Propagates `seLinuxOptions` to the secondary mounter daemonset (`s3-csi-daemonset-mounter`) pod, matching how the primary `s3-csi-node` pod already sets it (`node.yaml`). On SELinux-enforcing clusters (e.g. OpenShift) the mounter runs `mount-s3` and serves the mounted files, so it needs the operator-chosen SELinux label or mounts can be denied.

Reuses the existing `.Values.node.seLinuxOptions` knob (one value for both pods, set once) with the same `{{- with }}` guard, so the block is omitted when the value is unset. No new values.

This is one item of the V2 operational-parity task; the remaining items and the full helm chart tests are separate CRs.

## Testing

**1) Helm chart validation.** I rendered the chart and checked the mounter pod. When the SELinux value is set, the block shows up with the right values. When it is not set, the block is left out. This shows the chart builds a correct pod spec.

**2) Deploying.** I deployed to a dev cluster in daemonset mode and looked at the running mounter pod. The SELinux settings are there on the live pod. This shows the setting really reaches the mounter, not just on paper.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
