### PR TITLE
Add Helm chart render test to unit CI

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -40,6 +40,15 @@ jobs:
     - name: Test
       run: make test
 
+    - name: Install Helm
+      run: |
+        source tests/e2e-kubernetes/scripts/helm.sh
+        helm_install "$(pwd)/bin"
+        echo "$(pwd)/bin" >> "$GITHUB_PATH"
+
+    - name: Helm chart template tests
+      run: make test/helm-template
+
     - name: Check test coverage
       run: make cover
 

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,11 @@ test:
 	# TestE2E is the Ginkgo e2e suite entry point which requires a live cluster, so we skip it.
 	cd tests/e2e-kubernetes && go test -v -skip TestE2E ./...
 
+.PHONY: test/helm-template
+test/helm-template:
+	helm lint --strict ./charts/aws-mountpoint-s3-csi-driver
+	go test -v -count=1 ./tests/helm-template/...
+
 .PHONY: cover
 cover:
 	${GOBIN}/go-test-coverage --config=./.testcoverage.yml

--- a/tests/helm-template/helpers_test.go
+++ b/tests/helm-template/helpers_test.go
@@ -1,0 +1,41 @@
+// Package helmtemplate checks the Helm chart renders with `helm template`.
+package helmtemplate
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const releaseName = "s3-csi"
+
+// chartPath returns the absolute path to the Helm chart.
+func chartPath() string {
+	_, f, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(f), "..", "..", "charts", "aws-mountpoint-s3-csi-driver")
+}
+
+// helmBin returns the helm binary to use ("helm" on PATH by default).
+func helmBin() string {
+	if b := os.Getenv("HELM_BIN"); b != "" {
+		return b
+	}
+	return "helm"
+}
+
+// renderChart runs `helm template` with the chart's default values and fails
+// the test if the chart does not render.
+func renderChart(t *testing.T) {
+	t.Helper()
+	// unsupportedDevInstall=true bypasses the guard that blocks `helm template`
+	// on the chart outside the official Helm repo.
+	cmd := exec.Command(helmBin(), "template", releaseName, chartPath(), "--set", "unsupportedDevInstall=true")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("helm template failed: %v\nstderr: %s", err, stderr.String())
+	}
+}

--- a/tests/helm-template/render_test.go
+++ b/tests/helm-template/render_test.go
@@ -1,0 +1,8 @@
+package helmtemplate
+
+import "testing"
+
+// TestChartRenders verifies the Helm chart renders without error.
+func TestChartRenders(t *testing.T) {
+	renderChart(t)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a Helm chart render test to the unit-tests CI, so a template that fails to render is caught on every PR without a cluster.

- New `tests/helm-template` package: runs `helm template` on the chart (default values) and fails if it errors. Stdlib only, no new dependencies.
- `Makefile` `test/helm-template` target: `helm lint --strict` + `go test ./tests/helm-template/...`.
- `unit-tests.yaml`: installs Helm by reusing the existing `helm_install` function from `tests/e2e-kubernetes/scripts/helm.sh`, then runs the target.

 it only checks that the chart renders, not specific objects or field values. 

## Testing
`make test/helm-template` passes locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
