### PR TITLE
Version skew detection

### DIFF
--- a/cmd/aws-s3-csi-daemonset-mounter/handler.go
+++ b/cmd/aws-s3-csi-daemonset-mounter/handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"regexp"
 	"syscall"
@@ -32,6 +33,22 @@ func handleConnection(conn *net.UnixConn, mountpointPath string, pm *ProcessMana
 	if mountId == "" || !validMountId.MatchString(mountId) {
 		syscall.Close(options.Fd)
 		klog.Errorf("Received mount request with invalid mountId: %q", mountId)
+		return
+	}
+
+	// Reject a version-skewed CSI Driver Node before spawning anything: the mounter uses an OnDelete
+	// update strategy, so after a Helm upgrade a new driver may talk to this (still-old) mounter until
+	// the node is recycled. On mismatch we do NOT mount — we close the FUSE fd and surface a clear
+	// error via the .error file (which the driver's waitForMount polls), so NodePublishVolume fails
+	// fast instead of producing a silent/partial mount.
+	if options.ProtocolVersion != mountoptions.ProtocolVersion {
+		syscall.Close(options.Fd)
+		msg := fmt.Sprintf("protocol version mismatch: mounter=%q driver=%q. "+
+			"The s3-csi-daemonset-mounter pod is running a version incompatible with the CSI Driver Node; "+
+			"recycle the node or delete the mounter pod so it is recreated at the matching version.",
+			mountoptions.ProtocolVersion, options.ProtocolVersion)
+		klog.Error(msg)
+		pm.WriteErrorFile(mountId, []byte(msg))
 		return
 	}
 

--- a/cmd/aws-s3-csi-daemonset-mounter/process_manager.go
+++ b/cmd/aws-s3-csi-daemonset-mounter/process_manager.go
@@ -97,11 +97,7 @@ func (pm *ProcessManager) Launch(mountId string, mountpointPath string, options 
 		pm.mu.Unlock()
 
 		if exitCode != 0 {
-			errPath := filepath.Join(pm.commDir, mountId+errorFileExt)
-			// TODO(vlaad): write error file atomically (open,write,rename)
-			if writeErr := os.WriteFile(errPath, stderr, errorFilePerm); writeErr != nil {
-				klog.Errorf("Failed to write error file for mount %s: %v", mountId, writeErr)
-			}
+			pm.WriteErrorFile(mountId, stderr)
 			klog.Errorf("Mountpoint for mount %s exited with code %d", mountId, exitCode)
 		} else {
 			klog.Infof("Mountpoint for mount %s exited cleanly", mountId)
@@ -109,6 +105,17 @@ func (pm *ProcessManager) Launch(mountId string, mountpointPath string, options 
 	}()
 
 	return nil
+}
+
+// WriteErrorFile writes `content` to <comm-dir>/<mountId>.error, the file the CSI Driver Node polls
+// (via waitForMount) to surface a mount failure. Used both when a Mountpoint process exits non-zero
+// and when a mount request is rejected before spawning (e.g. protocol version mismatch).
+func (pm *ProcessManager) WriteErrorFile(mountId string, content []byte) {
+	errPath := filepath.Join(pm.commDir, mountId+errorFileExt)
+	// TODO(vlaad): write error file atomically (open,write,rename)
+	if writeErr := os.WriteFile(errPath, content, errorFilePerm); writeErr != nil {
+		klog.Errorf("Failed to write error file for mount %s: %v", mountId, writeErr)
+	}
 }
 
 // Shutdown sends SIGTERM to all processes and waits for them to exit.

--- a/cmd/aws-s3-csi-daemonset-mounter/process_manager_test.go
+++ b/cmd/aws-s3-csi-daemonset-mounter/process_manager_test.go
@@ -138,7 +138,11 @@ func TestHandleConnection_RejectsProtocolVersionMismatch(t *testing.T) {
 	dev := mountertest.OpenDevNull(t)
 	const mountId = "pod123-vol456"
 
+	// Wait for the Send goroutine to finish before returning so its dev.Fd() read
+	// doesn't race with OpenDevNull's t.Cleanup closing the file.
+	sendDone := make(chan struct{})
 	go func() {
+		defer close(sendDone)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		mountoptions.Send(ctx, sockPath, mountoptions.Options{
@@ -153,6 +157,7 @@ func TestHandleConnection_RejectsProtocolVersionMismatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	handleConnection(conn.(*net.UnixConn), "/opt/mount-s3", pm, 5*time.Second)
+	<-sendDone
 
 	// No Mountpoint process should have been spawned.
 	fr.mu.Lock()
@@ -356,9 +361,10 @@ func TestHandleConnection_NoFdLeak(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			mountoptions.Send(ctx, sockPath, mountoptions.Options{
-				Fd:         int(dev.Fd()),
-				BucketName: "bucket",
-				VolumeId:   volumeId,
+				Fd:              int(dev.Fd()),
+				ProtocolVersion: mountoptions.ProtocolVersion,
+				BucketName:      "bucket",
+				VolumeId:        volumeId,
 			})
 			dev.Close()
 			close(sendDone)
@@ -424,9 +430,10 @@ func TestHandleConnection_MountIdValidation(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			mountoptions.Send(ctx, sockPath, mountoptions.Options{
-				Fd:         int(dev.Fd()),
-				BucketName: "bucket",
-				VolumeId:   id,
+				Fd:              int(dev.Fd()),
+				ProtocolVersion: mountoptions.ProtocolVersion,
+				BucketName:      "bucket",
+				VolumeId:        id,
 			})
 			close(sendDone)
 		}()

--- a/cmd/aws-s3-csi-daemonset-mounter/process_manager_test.go
+++ b/cmd/aws-s3-csi-daemonset-mounter/process_manager_test.go
@@ -92,11 +92,12 @@ func TestHandleConnection_PropagatesOptionsToRunner(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		mountoptions.Send(ctx, sockPath, mountoptions.Options{
-			Fd:         int(dev.Fd()),
-			BucketName: "test-bucket",
-			Args:       []string{"--region", "us-west-2"},
-			Env:        []string{"AWS_REGION=us-west-2"},
-			VolumeId:   "pod123-vol456",
+			Fd:              int(dev.Fd()),
+			ProtocolVersion: mountoptions.ProtocolVersion,
+			BucketName:      "test-bucket",
+			Args:            []string{"--region", "us-west-2"},
+			Env:             []string{"AWS_REGION=us-west-2"},
+			VolumeId:        "pod123-vol456",
 		})
 	}()
 
@@ -119,6 +120,51 @@ func TestHandleConnection_PropagatesOptionsToRunner(t *testing.T) {
 	// Cleanup
 	fr.handles[0].Exit(0, "")
 	pm.Shutdown()
+}
+
+// TestHandleConnection_RejectsProtocolVersionMismatch verifies that a mount request from a
+// version-skewed CSI Driver Node is rejected before any Mountpoint process is spawned, and that a
+// clear error is written to <mountId>.error for the driver to surface.
+func TestHandleConnection_RejectsProtocolVersionMismatch(t *testing.T) {
+	commDir := t.TempDir()
+	fr := &fakeProcessRunner{}
+	pm := NewProcessManager(commDir, fr)
+
+	sockPath := filepath.Join(commDir, "test.sock")
+	listener, err := net.Listen("unix", sockPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	dev := mountertest.OpenDevNull(t)
+	const mountId = "pod123-vol456"
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		mountoptions.Send(ctx, sockPath, mountoptions.Options{
+			Fd:              int(dev.Fd()),
+			ProtocolVersion: mountoptions.ProtocolVersion + "-incompatible",
+			BucketName:      "test-bucket",
+			VolumeId:        mountId,
+		})
+	}()
+
+	conn, err := listener.Accept()
+	assert.NoError(t, err)
+
+	handleConnection(conn.(*net.UnixConn), "/opt/mount-s3", pm, 5*time.Second)
+
+	// No Mountpoint process should have been spawned.
+	fr.mu.Lock()
+	assert.Equals(t, 0, len(fr.handles))
+	fr.mu.Unlock()
+
+	// A clear error must be written to the mount's .error file for the driver to surface.
+	content, err := os.ReadFile(filepath.Join(commDir, mountId+errorFileExt))
+	assert.NoError(t, err)
+	if len(content) == 0 {
+		t.Fatal("expected a non-empty error file on protocol version mismatch")
+	}
 }
 
 func TestProcessManager_Launch_HappyPath(t *testing.T) {

--- a/pkg/driver/node/mounter/daemonset_mounter.go
+++ b/pkg/driver/node/mounter/daemonset_mounter.go
@@ -391,11 +391,12 @@ func (dm *DaemonsetMounter) fuseMount(ctx context.Context, bucketName string, mo
 	defer sendCancel()
 
 	err = mountoptions.Send(sendCtx, sockPath, mountoptions.Options{
-		Fd:         fd,
-		BucketName: bucketName,
-		Args:       args.SortedList(),
-		Env:        env.List(),
-		VolumeId:   volumeID,
+		Fd:              fd,
+		ProtocolVersion: mountoptions.ProtocolVersion,
+		BucketName:      bucketName,
+		Args:            args.SortedList(),
+		Env:             env.List(),
+		VolumeId:        volumeID,
 	})
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) || os.IsPermission(err) || errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/driver/node/mounter/daemonset_mounter_test.go
+++ b/pkg/driver/node/mounter/daemonset_mounter_test.go
@@ -200,10 +200,11 @@ func TestDaemonsetMounter(t *testing.T) {
 			// The mount must carry the user-agent, built from the same inputs setupDM used.
 			expectedUserAgent := "--user-agent-prefix=" + mounter.UserAgent(credentialprovider.AuthenticationSourceDriver, testK8sVersion, cluster.DefaultKubernetes)
 			assert.Equals(t, mountoptions.Options{
-				BucketName: testCtx.bucketName,
-				Args:       []string{"--prefix=data/", expectedUserAgent},
-				Env:        env.List(),
-				VolumeId:   testCtx.volumeID,
+				ProtocolVersion: mountoptions.ProtocolVersion,
+				BucketName:      testCtx.bucketName,
+				Args:            []string{"--prefix=data/", expectedUserAgent},
+				Env:             env.List(),
+				VolumeId:        testCtx.volumeID,
 			}, got)
 		})
 

--- a/pkg/mountpoint/mountoptions/mount_options.go
+++ b/pkg/mountpoint/mountoptions/mount_options.go
@@ -18,13 +18,25 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// ProtocolVersion is the version of the driver<->mounter communication protocol (the Options/Env/Args
+// contract and FUSE-fd passing). The CSI Driver Node stamps it on every mount request and the mounter
+// rejects requests whose version does not match its own.
+//
+// Because the mounter DaemonSet uses an OnDelete update strategy, after a Helm upgrade the (new)
+// CSI Driver Node can talk to a (still-old) mounter pod until the node is recycled. Bumping this
+// constant on any breaking protocol change turns that skew into a clear, fail-fast error instead of a
+// silent wrong/partial mount.
+const ProtocolVersion = "1"
+
 // An Options struct represents mount options to use while invoking Mountpoint.
 type Options struct {
 	// Fd will be passed over Unix socket using `SCM_RIGHTS`, not as part of the serialized JSON.
-	Fd         int      `json:"-"`
-	BucketName string   `json:"bucketName"`
-	Args       []string `json:"args"`
-	Env        []string `json:"env"`
+	Fd int `json:"-"`
+	// ProtocolVersion is the driver<->mounter protocol version; see [ProtocolVersion].
+	ProtocolVersion string   `json:"protocolVersion"`
+	BucketName      string   `json:"bucketName"`
+	Args            []string `json:"args"`
+	Env             []string `json:"env"`
 	// VolumeId is a unique mount identifier used by the daemonset mounter for child process
 	// tracking and error file naming. In daemonset mode this is "<podUID>-<volumeId>".
 	// With pod sharing it'll be "volumeID" (PersistentVolume: metadata.name).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reject a version-skewed CSI Driver Node before spawning anything: the mounter uses an OnDelete update strategy, so after a Helm upgrade a new driver may talk to this (still-old) mounter until the node is recycled. On mismatch we do NOT mount — we close the FUSE fd and surface a clear error via the .error file (which the driver's waitForMount polls), so NodePublishVolume fails fast instead of producing a silent/partial mount.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
