### PR TITLE
Use node.nodeSelector for the mounter daemonset

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/mounter-daemonset.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/mounter-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-        {{- with $mounter.nodeSelector }}
+        {{- with .Values.node.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       priorityClassName: system-node-critical

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -168,7 +168,6 @@ daemonsetMounters:
         cpu: "500m"
     logLevel: 4
     podLabels: {}
-    nodeSelector: {}
     tolerateAllTaints: true
     defaultTolerations: true
     tolerations: []


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*
The mounter daemonset now uses the node pod's `node.nodeSelector` instead of the per-mounter `daemonsetMounters[].nodeSelector`, so it always lands on the same nodes as `s3-csi-node`. Also drops the now-unused `daemonsetMounters[].nodeSelector` field; per-mounter (heterogeneous) selection is deferred to a later milestone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
