### PR TITLE
Inherit node affinity and tolerations for the mounter daemonset

### DIFF
--- a/charts/aws-mountpoint-s3-csi-driver/templates/mounter-daemonset.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/templates/mounter-daemonset.yaml
@@ -34,13 +34,13 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       priorityClassName: system-node-critical
-      {{- with $mounter.affinity }}
+      {{- with .Values.node.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- if $mounter.tolerateAllTaints | default .Values.node.tolerateAllTaints }}
+        {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
-        {{- else if $mounter.defaultTolerations | default .Values.node.defaultTolerations }}
+        {{- else if .Values.node.defaultTolerations }}
         - key: CriticalAddonsOnly
           operator: Exists
         - key: s3.csi.aws.com/agent-not-ready
@@ -49,7 +49,7 @@ spec:
           effect: NoExecute
           tolerationSeconds: 300
         {{- end }}
-        {{- with $mounter.tolerations }}
+        {{- with .Values.node.tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with $mounter.imagePullSecrets }}

--- a/charts/aws-mountpoint-s3-csi-driver/values.yaml
+++ b/charts/aws-mountpoint-s3-csi-driver/values.yaml
@@ -168,8 +168,5 @@ daemonsetMounters:
         cpu: "500m"
     logLevel: 4
     podLabels: {}
-    tolerateAllTaints: true
-    defaultTolerations: true
-    tolerations: []
-    affinity: {}
+    # nodeSelector, affinity, and tolerations are inherited from the node DaemonSet
     imagePullSecrets: []


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*

Make the mounter DaemonSet inherit `affinity` and `tolerations` from the CSI node DaemonSet, so it always co-locates with the node pod.

The mounter must run on exactly the nodes the node pod runs on: the node pod performs the FUSE mount and hands the file descriptor to a mounter on the same node, so a node with a node pod but no mounter can't serve mounts.

This matches how `nodeSelector` already works (#945). 

### Testing

- `helm lint` passes.
- `helm template` on default values: the mounter now renders the node pod's affinity (Fargate/hybrid `NotIn` exclusion) and `tolerations: [{operator: Exists}]` (tolerate all) — previously the mounter had no affinity.
- `helm template` with custom `node.*` values (`node.nodeSelector.disktype=ssd`, `node.tolerateAllTaints=false`, a custom `node.tolerations` entry): all propagate to the mounter, and the mounter's `nodeSelector` + `affinity` + `tolerations` render byte-identical to the CSI node pod.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
