### PR TITLE
Add Squid to eks-addon image

### DIFF
--- a/tests/e2e-kubernetes/scripts/eks-addon/Dockerfile
+++ b/tests/e2e-kubernetes/scripts/eks-addon/Dockerfile
@@ -29,6 +29,12 @@ ARG KUBECTL_VERSION=1.33.3
 RUN curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     chmod +x kubectl && mv kubectl /usr/local/bin/
 
+# Install Squid to act as the forward proxy for the proxy e2e specs.
+RUN dnf install -y squid && \
+    dnf clean all && \
+    test -x /usr/sbin/squid && \
+    sed -i -E 's/^#[[:space:]]*http_access allow localnet/http_access allow localnet/' /etc/squid/squid.conf
+
 # Copy pre-compiled binaries from builder
 COPY --from=builder /e2e.test /usr/local/bin/e2e.test
 COPY --from=builder /usr/local/bin/ginkgo /usr/local/bin/ginkgo
@@ -83,5 +89,22 @@ exec ginkgo -vv -timeout 60m \
 
 EOF
 RUN chmod +x /entrypoint.sh
+
+COPY <<'EOF' /squid-entrypoint.sh
+#!/bin/sh
+set -eu
+
+# Squid writes to log files under /var/log/squid rather than stdout. Forward
+# them to this container's stdout so they are visible via `kubectl logs`.
+# --follow=name --retry tolerates the files not existing until Squid starts.
+for log in access.log error.log store.log cache.log; do
+    tail --follow=name --retry "/var/log/squid/${log}" &
+done
+
+# Create any missing cache directories, then run Squid in the foreground.
+squid -Nz
+exec squid -f /etc/squid/squid.conf -NYC
+EOF
+RUN chmod +x /squid-entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/tests/e2e-kubernetes/testsuites/proxy.go
+++ b/tests/e2e-kubernetes/testsuites/proxy.go
@@ -3,6 +3,7 @@ package custom_testsuites
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -135,11 +136,7 @@ func (t *s3CSIProxyTestSuite) DefineTests(driver storageframework.TestDriver, pa
 			},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
-					{
-						Name:  "proxy",
-						Image: "public.ecr.aws/ubuntu/squid:latest",
-						Ports: []v1.ContainerPort{{ContainerPort: proxyPort}},
-					},
+					squidProxyContainer(proxyPort),
 				},
 			},
 		}
@@ -205,4 +202,20 @@ func (t *s3CSIProxyTestSuite) DefineTests(driver storageframework.TestDriver, pa
 			"mountpointEnv.FOO": "BAR",
 		}), "environment variable not allowed")
 	})
+}
+
+func squidProxyContainer(port int32) v1.Container {
+	container := v1.Container{
+		Name:  "proxy",
+		Image: "public.ecr.aws/ubuntu/squid:latest",
+		Ports: []v1.ContainerPort{{ContainerPort: port}},
+	}
+
+	// If we're running with a test image override, use it instead of ecr public.
+	if img := os.Getenv("TEST_POD_IMAGE"); img != "" {
+		container.Image = img
+		container.Command = []string{"/squid-entrypoint.sh"}
+	}
+
+	return container
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

**Motivation:** In isolated regions, ecr public is not available.

*Description of changes:* 

- Move squid proxy to the Dockerfile, so it can be launched in the eks addon tests.
- Migrate proxy tests to use test pod override if supplied. 

Tested eks addon image


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
